### PR TITLE
fix(ci): skip SwiftPM plugin validation for OpenAPIGenerator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,12 @@ jobs:
           codesign --force -s - target/release/arcbox
           target/release/arcbox boot prefetch
 
+      - name: Trust SwiftPM plugins
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -scheme arcbox-desktop-swift \
+            -skipPackagePluginValidation
+
       - name: Build DMG
         id: dmg
         env:


### PR DESCRIPTION
## Summary
- CI build fails at "Validate plug-in 'OpenAPIGenerator'" (exit code 65) because `xcodebuild` cannot interactively trust the plugin on headless runners
- Add a `Trust SwiftPM plugins` step before the DMG build that resolves dependencies with `-skipPackagePluginValidation`

## Test plan
- [ ] Trigger the release workflow via `workflow_dispatch` and verify it passes the plugin validation step