### PR TITLE
feat(sparkle): integrate Sparkle auto-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,12 +272,15 @@ jobs:
         run: ln -s "$GITHUB_WORKSPACE/arcbox" ../arcbox
 
       - name: Create Local.xcconfig
+        env:
+          SPARKLE_PUBLIC_KEY: ${{ vars.SPARKLE_PUBLIC_KEY }}
         run: |
-          CHANNEL="${{ steps.version.outputs.channel }}"
-          cat > Local.xcconfig <<EOF
-          INFOPLIST_KEY_SUFeedURL = https://release.arcboxcdn.com/desktop/appcast/${CHANNEL}.xml
-          INFOPLIST_KEY_SUPublicEDKey = ${{ secrets.SPARKLE_PUBLIC_KEY }}
-          EOF
+          cat > Local.xcconfig <<XCEOF
+          #include "Version.xcconfig"
+          INFOPLIST_KEY_SUPublicEDKey = ${SPARKLE_PUBLIC_KEY}
+          XCEOF
+          echo "Local.xcconfig:"
+          cat Local.xcconfig
 
       - name: Trust SwiftPM plugins
         run: defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES
@@ -288,6 +291,7 @@ jobs:
           DESKTOP_REPO: ${{ github.workspace }}
           BUNDLE_ID: ${{ secrets.BUNDLE_ID }}
           TEAM_ID: ${{ secrets.TEAM_ID }}
+          SPARKLE_FEED_URL: "https://release.arcboxcdn.com/desktop/appcast/${{ steps.version.outputs.channel }}.xml"
         run: |
           scripts/package-dmg.sh \
             --sign "${{ secrets.APPLE_SIGNING_IDENTITY }}" \
@@ -307,6 +311,7 @@ jobs:
         id: sparkle_sign
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        shell: bash
         run: |
           set -euo pipefail
 
@@ -342,16 +347,15 @@ jobs:
 
           # Parse sparkle:edSignature="..." length="..."
           ED_SIGNATURE=$(echo "$SIGN_OUTPUT" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p')
-          DMG_LENGTH=$(echo "$SIGN_OUTPUT" | sed -n 's/.*length="\([^"]*\)".*/\1/p')
+          if [ -z "$ED_SIGNATURE" ]; then
+            echo "::error::Failed to extract EdDSA signature from sign_update output"
+            exit 1
+          fi
 
+          DMG_LENGTH=$(echo "$SIGN_OUTPUT" | sed -n 's/.*length="\([^"]*\)".*/\1/p')
           # Fallback: get length from stat if not in output
           if [ -z "$DMG_LENGTH" ]; then
             DMG_LENGTH=$(stat -f%z "$DMG_PATH")
-          fi
-
-          if [ -z "$ED_SIGNATURE" ]; then
-            echo "::error::Failed to extract EdDSA signature from: $SIGN_OUTPUT"
-            exit 1
           fi
 
           echo "ed_signature=$ED_SIGNATURE" >> "$GITHUB_OUTPUT"

--- a/ArcBox/ViewModels/UpdaterDelegate.swift
+++ b/ArcBox/ViewModels/UpdaterDelegate.swift
@@ -1,4 +1,8 @@
 import Foundation
 import Sparkle
 
-final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {}
+final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
+    @objc func feedURLString(for updater: SPUUpdater) -> String? {
+        Bundle.main.infoDictionary?["SUFeedURL"] as? String
+    }
+}

--- a/scripts/package-dmg.sh
+++ b/scripts/package-dmg.sh
@@ -101,6 +101,11 @@ if [ -n "$SIGN_IDENTITY" ]; then
     )
 fi
 
+# Pass Sparkle feed URL as command-line build setting (xcconfig can't handle // in URLs)
+if [ -n "${SPARKLE_FEED_URL:-}" ]; then
+    XCODE_FLAGS+=("INFOPLIST_KEY_SUFeedURL=$SPARKLE_FEED_URL")
+fi
+
 xcodebuild build "${XCODE_FLAGS[@]}" | tail -20
 
 # Locate the built .app


### PR DESCRIPTION
## Summary
- Integrate Sparkle 2.9.0 for automatic update checking via the app menu
- Pass appcast feed URL via xcodebuild command-line build setting instead of xcconfig (`//` in URLs is treated as xcconfig comment)
- Implement `SPUUpdaterDelegate.feedURLString(for:)` to read feed URL from Info.plist
- CI generates appcast XML per channel (stable/beta) and signs DMG with EdDSA

## Test plan
- [ ] Local build: "Check for Updates" opens Sparkle UI without configuration errors
- [ ] CI release build: verify `SUFeedURL` is present in the built app's Info.plist
- [ ] End-to-end: after appcast is published to CDN, verify update check finds the latest version