### PR TITLE
feat: integrate IconService for container/image icon display

### DIFF
--- a/ArcBox/Components/RemoteIconView.swift
+++ b/ArcBox/Components/RemoteIconView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+/// Displays a remote icon image with a fallback SF Symbol.
+///
+/// When `iconURL` is non-nil, loads the image asynchronously and displays it
+/// inside a rounded rectangle. Falls back to the given SF Symbol when the URL
+/// is nil, during loading, or on failure.
+struct RemoteIconView: View {
+    let iconURL: String?
+    let fallbackSymbol: String
+    let size: CGFloat
+    let cornerRadius: CGFloat
+    let symbolFontSize: CGFloat
+    let foregroundColor: Color
+    let backgroundColor: Color
+
+    init(
+        iconURL: String?,
+        fallbackSymbol: String = "shippingbox",
+        size: CGFloat = 32,
+        cornerRadius: CGFloat = 6,
+        symbolFontSize: CGFloat = 16,
+        foregroundColor: Color,
+        backgroundColor: Color
+    ) {
+        self.iconURL = iconURL
+        self.fallbackSymbol = fallbackSymbol
+        self.size = size
+        self.cornerRadius = cornerRadius
+        self.symbolFontSize = symbolFontSize
+        self.foregroundColor = foregroundColor
+        self.backgroundColor = backgroundColor
+    }
+
+    var body: some View {
+        if let iconURL, let url = URL(string: iconURL) {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: size - 4, height: size - 4)
+                default:
+                    fallbackIcon
+                }
+            }
+            .frame(width: size, height: size)
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .fill(backgroundColor)
+            )
+        } else {
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .fill(backgroundColor)
+                .frame(width: size, height: size)
+                .overlay {
+                    fallbackIcon
+                }
+        }
+    }
+
+    private var fallbackIcon: some View {
+        Image(systemName: fallbackSymbol)
+            .font(.system(size: symbolFontSize))
+            .foregroundStyle(foregroundColor)
+    }
+}

--- a/ArcBox/Models/ContainerModel.swift
+++ b/ArcBox/Models/ContainerModel.swift
@@ -60,6 +60,7 @@ struct ContainerViewModel: Identifiable, Hashable {
     var ipAddress: String?
     var mounts: [ContainerMount] = []
     var rootfsMountPath: String?
+    var iconURL: String?
 
     var isRunning: Bool { state.isRunning }
 

--- a/ArcBox/Models/ImageModel.swift
+++ b/ArcBox/Models/ImageModel.swift
@@ -10,6 +10,7 @@ struct ImageViewModel: Identifiable, Hashable {
     let inUse: Bool
     let os: String
     let architecture: String
+    var iconURL: String?
 
     var fullName: String {
         if repository == "<none>" {

--- a/ArcBox/ViewModels/ContainersViewModel.swift
+++ b/ArcBox/ViewModels/ContainersViewModel.swift
@@ -65,6 +65,7 @@ class ContainersViewModel {
     }
 
     private var detailsByID: [String: ContainerDetailSnapshot] = [:]
+    private var iconsByImage: [String: String] = [:]
 
     private func sortedContainers(_ list: [ContainerViewModel]) -> [ContainerViewModel] {
         list.sorted { a, b in
@@ -235,6 +236,45 @@ class ContainersViewModel {
         }
     }
 
+    private func applyCachedIcons(to viewModels: inout [ContainerViewModel]) {
+        for i in viewModels.indices {
+            viewModels[i].iconURL = iconsByImage[viewModels[i].image]
+        }
+    }
+
+    /// Fetch icon URLs for all unique image references that are not already cached.
+    func fetchIcons(client: ArcBoxClient?) async {
+        guard let client else { return }
+        let uncached = Set(containers.map(\.image)).subtracting(iconsByImage.keys)
+        guard !uncached.isEmpty else { return }
+
+        await withTaskGroup(of: (String, String?).self) { group in
+            for image in uncached {
+                group.addTask {
+                    do {
+                        var request = Arcbox_V1_GetImageIconRequest()
+                        request.fqin = image
+                        let response = try await client.icons.getImageIcon(request)
+                        let url = response.url.isEmpty ? nil : response.url
+                        return (image, url)
+                    } catch {
+                        Log.container.debug("Icon fetch failed for \(image, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                        return (image, nil)
+                    }
+                }
+            }
+            for await (image, url) in group {
+                if let url {
+                    iconsByImage[image] = url
+                }
+            }
+        }
+
+        var snapshot = containers
+        applyCachedIcons(to: &snapshot)
+        containers = snapshot
+    }
+
     // MARK: - gRPC Operations
 
     /// Load containers from daemon via gRPC.
@@ -254,11 +294,13 @@ class ContainersViewModel {
                 ContainerViewModel(from: summary)
             }
             applyCachedDetails(cachedDetails, to: &viewModels)
+            applyCachedIcons(to: &viewModels)
             for i in viewModels.indices where currentTransitioning.contains(viewModels[i].id) {
                 viewModels[i].isTransitioning = true
             }
             containers = viewModels
             applyExpandedGroups(from: containers)
+            await fetchIcons(client: client)
             if let selectedID, containers.contains(where: { $0.id == selectedID }) {
                 await loadContainerDetails(selectedID, client: client)
             }
@@ -343,7 +385,7 @@ class ContainersViewModel {
     // MARK: - Docker API Operations
 
     /// Load containers from Docker Engine API.
-    func loadContainersFromDocker(docker: DockerClient?) async {
+    func loadContainersFromDocker(docker: DockerClient?, iconClient: ArcBoxClient? = nil) async {
         guard let docker else {
             Log.container.debug("No docker client available")
             return
@@ -356,6 +398,7 @@ class ContainersViewModel {
             let containerList = try response.ok.body.json
             var viewModels = containerList.map { ContainerViewModel(fromDocker: $0) }
             applyCachedDetails(cachedDetails, to: &viewModels)
+            applyCachedIcons(to: &viewModels)
             // Preserve transitioning state across reload
             for i in viewModels.indices where currentTransitioning.contains(viewModels[i].id) {
                 viewModels[i].isTransitioning = true
@@ -363,6 +406,7 @@ class ContainersViewModel {
             containers = viewModels
             Log.container.info("Loaded \(self.containers.count, privacy: .public) containers")
             applyExpandedGroups(from: containers)
+            await fetchIcons(client: iconClient)
             if let selectedID, containers.contains(where: { $0.id == selectedID }) {
                 await loadContainerDetailsFromDocker(selectedID, docker: docker)
             }

--- a/ArcBox/ViewModels/ImagesViewModel.swift
+++ b/ArcBox/ViewModels/ImagesViewModel.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import ArcBoxClient
 import DockerClient
 import OSLog
 
@@ -30,6 +31,7 @@ class ImagesViewModel {
     var isSearching: Bool = false
     var sortBy: ImageSortField = .name
     var sortAscending: Bool = true
+    private var iconsByImage: [String: String] = [:]
 
     var totalSize: String {
         let bytes: UInt64 = images.map(\.sizeBytes).reduce(0, +)
@@ -75,10 +77,51 @@ class ImagesViewModel {
         selectedID = id
     }
 
+    private func applyCachedIcons(to viewModels: inout [ImageViewModel]) {
+        for i in viewModels.indices {
+            viewModels[i].iconURL = iconsByImage[viewModels[i].repository]
+        }
+    }
+
+    /// Fetch icon URLs for all unique image repositories that are not already cached.
+    func fetchIcons(client: ArcBoxClient?) async {
+        guard let client else { return }
+        let uncached = Set(images.map(\.repository))
+            .filter { $0 != "<none>" }
+            .subtracting(iconsByImage.keys)
+        guard !uncached.isEmpty else { return }
+
+        await withTaskGroup(of: (String, String?).self) { group in
+            for repo in uncached {
+                group.addTask {
+                    do {
+                        var request = Arcbox_V1_GetImageIconRequest()
+                        request.fqin = repo
+                        let response = try await client.icons.getImageIcon(request)
+                        let url = response.url.isEmpty ? nil : response.url
+                        return (repo, url)
+                    } catch {
+                        Log.image.debug("Icon fetch failed for \(repo, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                        return (repo, nil)
+                    }
+                }
+            }
+            for await (repo, url) in group {
+                if let url {
+                    iconsByImage[repo] = url
+                }
+            }
+        }
+
+        var snapshot = images
+        applyCachedIcons(to: &snapshot)
+        images = snapshot
+    }
+
     // MARK: - Docker API Operations
 
     /// Load images from Docker Engine API.
-    func loadImages(docker: DockerClient?) async {
+    func loadImages(docker: DockerClient?, iconClient: ArcBoxClient? = nil) async {
         guard let docker else {
             Log.image.debug("No docker client available")
             return
@@ -87,8 +130,11 @@ class ImagesViewModel {
         do {
             let response = try await docker.api.ImageList(.init())
             let imageList = try response.ok.body.json
-            images = imageList.flatMap { ImageViewModel.fromDocker($0) }
+            var viewModels = imageList.flatMap { ImageViewModel.fromDocker($0) }
+            applyCachedIcons(to: &viewModels)
+            images = viewModels
             Log.image.info("Loaded \(self.images.count, privacy: .public) images")
+            await fetchIcons(client: iconClient)
         } catch {
             Log.image.error("Error loading images: \(error.localizedDescription, privacy: .public)")
         }

--- a/ArcBox/Views/Containers/ContainerRowView.swift
+++ b/ArcBox/Views/Containers/ContainerRowView.swift
@@ -35,23 +35,16 @@ struct ContainerRowView: View {
         HStack(spacing: 8) {
             // Container icon with status dot
             ZStack(alignment: .bottomTrailing) {
-                // Container icon (colored box fallback)
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(
-                        isSelected
-                            ? Color.white.opacity(0.12)
-                            : AppColors.surfaceElevated
-                    )
-                    .frame(width: 32, height: 32)
-                    .overlay {
-                        Image(systemName: "shippingbox")
-                            .font(.system(size: 16))
-                            .foregroundStyle(
-                                isSelected
-                                    ? AppColors.onAccent
-                                    : (isStopped ? AppColors.textMuted : containerColor)
-                            )
-                    }
+                RemoteIconView(
+                    iconURL: container.iconURL,
+                    size: 32,
+                    foregroundColor: isSelected
+                        ? AppColors.onAccent
+                        : (isStopped ? AppColors.textMuted : containerColor),
+                    backgroundColor: isSelected
+                        ? Color.white.opacity(0.12)
+                        : AppColors.surfaceElevated
+                )
 
                 // Status dot
                 if container.isTransitioning {

--- a/ArcBox/Views/Containers/ContainersListView.swift
+++ b/ArcBox/Views/Containers/ContainersListView.swift
@@ -79,10 +79,10 @@ struct ContainersListView: View {
             }
         }
         .task(id: docker != nil) {
-            await vm.loadContainersFromDocker(docker: docker)
+            await vm.loadContainersFromDocker(docker: docker, iconClient: client)
         }
         .onReceive(NotificationCenter.default.publisher(for: .dockerContainerChanged)) { _ in
-            Task { await vm.loadContainersFromDocker(docker: docker) }
+            Task { await vm.loadContainersFromDocker(docker: docker, iconClient: client) }
         }
         .sheet(isPresented: Bindable(vm).showNewContainerSheet) {
             NewContainerSheet()

--- a/ArcBox/Views/Images/ImageRowView.swift
+++ b/ArcBox/Views/Images/ImageRowView.swift
@@ -24,16 +24,13 @@ struct ImageRowView: View {
     var body: some View {
         HStack(spacing: 12) {
             // Image icon
-            RoundedRectangle(cornerRadius: 6)
-                .fill(isSelected ? Color.white.opacity(0.18) : AppColors.surfaceElevated)
-                .frame(width: 32, height: 32)
-                .overlay {
-                    Image(systemName: "shippingbox")
-                        .font(.system(size: 14))
-                        .foregroundStyle(
-                            isSelected ? AppColors.onAccent : imageColor
-                        )
-                }
+            RemoteIconView(
+                iconURL: image.iconURL,
+                size: 32,
+                symbolFontSize: 14,
+                foregroundColor: isSelected ? AppColors.onAccent : imageColor,
+                backgroundColor: isSelected ? Color.white.opacity(0.18) : AppColors.surfaceElevated
+            )
 
             // Name, size, and age
             VStack(alignment: .leading, spacing: 2) {

--- a/ArcBox/Views/Images/ImagesListView.swift
+++ b/ArcBox/Views/Images/ImagesListView.swift
@@ -7,6 +7,7 @@ struct ImagesListView: View {
     @Environment(ImagesViewModel.self) private var vm
     @Environment(DaemonManager.self) private var daemonManager
     @Environment(\.startupOrchestrator) private var orchestrator
+    @Environment(\.arcboxClient) private var client
     @Environment(\.dockerClient) private var docker
 
     var body: some View {
@@ -63,12 +64,12 @@ struct ImagesListView: View {
         .sheet(isPresented: Bindable(vm).showPullImageSheet) {
             PullImageSheet()
         }
-        .task(id: docker != nil) { await vm.loadImages(docker: docker) }
+        .task(id: docker != nil) { await vm.loadImages(docker: docker, iconClient: client) }
         .onReceive(NotificationCenter.default.publisher(for: .dockerImageChanged)) { _ in
-            Task { await vm.loadImages(docker: docker) }
+            Task { await vm.loadImages(docker: docker, iconClient: client) }
         }
         .onReceive(NotificationCenter.default.publisher(for: .dockerDataChanged)) { _ in
-            Task { await vm.loadImages(docker: docker) }
+            Task { await vm.loadImages(docker: docker, iconClient: client) }
         }
     }
 }

--- a/ArcBox/Views/MenuBar/MenuBarView.swift
+++ b/ArcBox/Views/MenuBar/MenuBarView.swift
@@ -9,6 +9,7 @@ struct MenuBarView: View {
     @Environment(ImagesViewModel.self) private var imagesVM
     @Environment(NetworksViewModel.self) private var networksVM
     @Environment(VolumesViewModel.self) private var volumesVM
+    @Environment(\.arcboxClient) private var client
     @Environment(\.dockerClient) private var docker
 
     @State private var containersExpanded = true
@@ -39,10 +40,10 @@ struct MenuBarView: View {
             await loadAll()
         }
         .onReceive(NotificationCenter.default.publisher(for: .dockerContainerChanged)) { _ in
-            Task { await containersVM.loadContainersFromDocker(docker: docker) }
+            Task { await containersVM.loadContainersFromDocker(docker: docker, iconClient: client) }
         }
         .onReceive(NotificationCenter.default.publisher(for: .dockerImageChanged)) { _ in
-            Task { await imagesVM.loadImages(docker: docker) }
+            Task { await imagesVM.loadImages(docker: docker, iconClient: client) }
         }
         .onReceive(NotificationCenter.default.publisher(for: .dockerNetworkChanged)) { _ in
             Task { await networksVM.loadNetworks(docker: docker) }
@@ -58,8 +59,8 @@ struct MenuBarView: View {
     // MARK: - Data
 
     private func loadAll() async {
-        async let c: () = containersVM.loadContainersFromDocker(docker: docker)
-        async let i: () = imagesVM.loadImages(docker: docker)
+        async let c: () = containersVM.loadContainersFromDocker(docker: docker, iconClient: client)
+        async let i: () = imagesVM.loadImages(docker: docker, iconClient: client)
         async let n: () = networksVM.loadNetworks(docker: docker)
         async let v: () = volumesVM.loadVolumes(docker: docker)
         _ = await (c, i, n, v)

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/ArcBoxClient.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/ArcBoxClient.swift
@@ -76,4 +76,9 @@ public final class ArcBoxClient: Sendable {
     public var machines: Arcbox_V1_MachineService.Client<HTTP2ClientTransport.TransportServices> {
         .init(wrapping: grpcClient)
     }
+
+    /// Container image icon lookups.
+    public var icons: Arcbox_V1_IconService.Client<HTTP2ClientTransport.TransportServices> {
+        .init(wrapping: grpcClient)
+    }
 }

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/Generated/api.grpc.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/Generated/api.grpc.swift
@@ -2713,6 +2713,352 @@ extension Arcbox_V1_SystemService.ClientProtocol {
     }
 }
 
+// MARK: - arcbox.v1.IconService
+
+/// Namespace containing generated types for the "arcbox.v1.IconService" service.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+public enum Arcbox_V1_IconService {
+    /// Service descriptor for the "arcbox.v1.IconService" service.
+    public static let descriptor = GRPCCore.ServiceDescriptor(fullyQualifiedService: "arcbox.v1.IconService")
+    /// Namespace for method metadata.
+    public enum Method {
+        /// Namespace for "GetImageIcon" metadata.
+        public enum GetImageIcon {
+            /// Request type for "GetImageIcon".
+            public typealias Input = Arcbox_V1_GetImageIconRequest
+            /// Response type for "GetImageIcon".
+            public typealias Output = Arcbox_V1_GetImageIconResponse
+            /// Descriptor for "GetImageIcon".
+            public static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "arcbox.v1.IconService"),
+                method: "GetImageIcon"
+            )
+        }
+        /// Descriptors for all methods in the "arcbox.v1.IconService" service.
+        public static let descriptors: [GRPCCore.MethodDescriptor] = [
+            GetImageIcon.descriptor
+        ]
+    }
+}
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension GRPCCore.ServiceDescriptor {
+    /// Service descriptor for the "arcbox.v1.IconService" service.
+    public static let arcbox_v1_IconService = GRPCCore.ServiceDescriptor(fullyQualifiedService: "arcbox.v1.IconService")
+}
+
+// MARK: arcbox.v1.IconService (server)
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension Arcbox_V1_IconService {
+    /// Streaming variant of the service protocol for the "arcbox.v1.IconService" service.
+    ///
+    /// This protocol is the lowest-level of the service protocols generated for this service
+    /// giving you the most flexibility over the implementation of your service. This comes at
+    /// the cost of more verbose and less strict APIs. Each RPC requires you to implement it in
+    /// terms of a request stream and response stream. Where only a single request or response
+    /// message is expected, you are responsible for enforcing this invariant is maintained.
+    ///
+    /// Where possible, prefer using the stricter, less-verbose ``ServiceProtocol``
+    /// or ``SimpleServiceProtocol`` instead.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > IconService provides container image icon lookups.
+    public protocol StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+        /// Handle the "GetImageIcon" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Gets the icon URL for a container image reference.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request of `Arcbox_V1_GetImageIconRequest` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A streaming response of `Arcbox_V1_GetImageIconResponse` messages.
+        func getImageIcon(
+            request: GRPCCore.StreamingServerRequest<Arcbox_V1_GetImageIconRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.StreamingServerResponse<Arcbox_V1_GetImageIconResponse>
+    }
+
+    /// Service protocol for the "arcbox.v1.IconService" service.
+    ///
+    /// This protocol is higher level than ``StreamingServiceProtocol`` but lower level than
+    /// the ``SimpleServiceProtocol``, it provides access to request and response metadata and
+    /// trailing response metadata. If you don't need these then consider using
+    /// the ``SimpleServiceProtocol``. If you need fine grained control over your RPCs then
+    /// use ``StreamingServiceProtocol``.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > IconService provides container image icon lookups.
+    public protocol ServiceProtocol: Arcbox_V1_IconService.StreamingServiceProtocol {
+        /// Handle the "GetImageIcon" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Gets the icon URL for a container image reference.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Arcbox_V1_GetImageIconRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A response containing a single `Arcbox_V1_GetImageIconResponse` message.
+        func getImageIcon(
+            request: GRPCCore.ServerRequest<Arcbox_V1_GetImageIconRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.ServerResponse<Arcbox_V1_GetImageIconResponse>
+    }
+
+    /// Simple service protocol for the "arcbox.v1.IconService" service.
+    ///
+    /// This is the highest level protocol for the service. The API is the easiest to use but
+    /// doesn't provide access to request or response metadata. If you need access to these
+    /// then use ``ServiceProtocol`` instead.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > IconService provides container image icon lookups.
+    public protocol SimpleServiceProtocol: Arcbox_V1_IconService.ServiceProtocol {
+        /// Handle the "GetImageIcon" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Gets the icon URL for a container image reference.
+        ///
+        /// - Parameters:
+        ///   - request: A `Arcbox_V1_GetImageIconRequest` message.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A `Arcbox_V1_GetImageIconResponse` to respond with.
+        func getImageIcon(
+            request: Arcbox_V1_GetImageIconRequest,
+            context: GRPCCore.ServerContext
+        ) async throws -> Arcbox_V1_GetImageIconResponse
+    }
+}
+
+// Default implementation of 'registerMethods(with:)'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension Arcbox_V1_IconService.StreamingServiceProtocol {
+    public func registerMethods<Transport>(with router: inout GRPCCore.RPCRouter<Transport>) where Transport: GRPCCore.ServerTransport {
+        router.registerHandler(
+            forMethod: Arcbox_V1_IconService.Method.GetImageIcon.descriptor,
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Arcbox_V1_GetImageIconRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Arcbox_V1_GetImageIconResponse>(),
+            handler: { request, context in
+                try await self.getImageIcon(
+                    request: request,
+                    context: context
+                )
+            }
+        )
+    }
+}
+
+// Default implementation of streaming methods from 'StreamingServiceProtocol'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension Arcbox_V1_IconService.ServiceProtocol {
+    public func getImageIcon(
+        request: GRPCCore.StreamingServerRequest<Arcbox_V1_GetImageIconRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.StreamingServerResponse<Arcbox_V1_GetImageIconResponse> {
+        let response = try await self.getImageIcon(
+            request: GRPCCore.ServerRequest(stream: request),
+            context: context
+        )
+        return GRPCCore.StreamingServerResponse(single: response)
+    }
+}
+
+// Default implementation of methods from 'ServiceProtocol'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension Arcbox_V1_IconService.SimpleServiceProtocol {
+    public func getImageIcon(
+        request: GRPCCore.ServerRequest<Arcbox_V1_GetImageIconRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.ServerResponse<Arcbox_V1_GetImageIconResponse> {
+        return GRPCCore.ServerResponse<Arcbox_V1_GetImageIconResponse>(
+            message: try await self.getImageIcon(
+                request: request.message,
+                context: context
+            ),
+            metadata: [:]
+        )
+    }
+}
+
+// MARK: arcbox.v1.IconService (client)
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension Arcbox_V1_IconService {
+    /// Generated client protocol for the "arcbox.v1.IconService" service.
+    ///
+    /// You don't need to implement this protocol directly, use the generated
+    /// implementation, ``Client``.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > IconService provides container image icon lookups.
+    public protocol ClientProtocol: Sendable {
+        /// Call the "GetImageIcon" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Gets the icon URL for a container image reference.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Arcbox_V1_GetImageIconRequest` message.
+        ///   - serializer: A serializer for `Arcbox_V1_GetImageIconRequest` messages.
+        ///   - deserializer: A deserializer for `Arcbox_V1_GetImageIconResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func getImageIcon<Result>(
+            request: GRPCCore.ClientRequest<Arcbox_V1_GetImageIconRequest>,
+            serializer: some GRPCCore.MessageSerializer<Arcbox_V1_GetImageIconRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Arcbox_V1_GetImageIconResponse>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Arcbox_V1_GetImageIconResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+    }
+
+    /// Generated client for the "arcbox.v1.IconService" service.
+    ///
+    /// The ``Client`` provides an implementation of ``ClientProtocol`` which wraps
+    /// a `GRPCCore.GRPCCClient`. The underlying `GRPCClient` provides the long-lived
+    /// means of communication with the remote peer.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > IconService provides container image icon lookups.
+    public struct Client<Transport>: ClientProtocol where Transport: GRPCCore.ClientTransport {
+        private let client: GRPCCore.GRPCClient<Transport>
+
+        /// Creates a new client wrapping the provided `GRPCCore.GRPCClient`.
+        ///
+        /// - Parameters:
+        ///   - client: A `GRPCCore.GRPCClient` providing a communication channel to the service.
+        public init(wrapping client: GRPCCore.GRPCClient<Transport>) {
+            self.client = client
+        }
+
+        /// Call the "GetImageIcon" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Gets the icon URL for a container image reference.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `Arcbox_V1_GetImageIconRequest` message.
+        ///   - serializer: A serializer for `Arcbox_V1_GetImageIconRequest` messages.
+        ///   - deserializer: A deserializer for `Arcbox_V1_GetImageIconResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        public func getImageIcon<Result>(
+            request: GRPCCore.ClientRequest<Arcbox_V1_GetImageIconRequest>,
+            serializer: some GRPCCore.MessageSerializer<Arcbox_V1_GetImageIconRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Arcbox_V1_GetImageIconResponse>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Arcbox_V1_GetImageIconResponse>) async throws -> Result = { response in
+                try response.message
+            }
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.unary(
+                request: request,
+                descriptor: Arcbox_V1_IconService.Method.GetImageIcon.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
+    }
+}
+
+// Helpers providing default arguments to 'ClientProtocol' methods.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension Arcbox_V1_IconService.ClientProtocol {
+    /// Call the "GetImageIcon" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > Gets the icon URL for a container image reference.
+    ///
+    /// - Parameters:
+    ///   - request: A request containing a single `Arcbox_V1_GetImageIconRequest` message.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func getImageIcon<Result>(
+        request: GRPCCore.ClientRequest<Arcbox_V1_GetImageIconRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Arcbox_V1_GetImageIconResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        try await self.getImageIcon(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<Arcbox_V1_GetImageIconRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Arcbox_V1_GetImageIconResponse>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+}
+
+// Helpers providing sugared APIs for 'ClientProtocol' methods.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension Arcbox_V1_IconService.ClientProtocol {
+    /// Call the "GetImageIcon" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > Gets the icon URL for a container image reference.
+    ///
+    /// - Parameters:
+    ///   - message: request message to send.
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func getImageIcon<Result>(
+        _ message: Arcbox_V1_GetImageIconRequest,
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Arcbox_V1_GetImageIconResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.ClientRequest<Arcbox_V1_GetImageIconRequest>(
+            message: message,
+            metadata: metadata
+        )
+        return try await self.getImageIcon(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+}
+
 // MARK: - arcbox.v1.VolumeService
 
 /// Namespace containing generated types for the "arcbox.v1.VolumeService" service.

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/Generated/api.pb.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/Generated/api.pb.swift
@@ -613,6 +613,37 @@ public struct Arcbox_V1_PruneResponse: Sendable {
   public init() {}
 }
 
+/// Request to get the icon URL for a container image.
+public struct Arcbox_V1_GetImageIconRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Fully qualified image name (e.g., "nginx", "localstack/localstack", "ghcr.io/astral-sh/uv").
+  public var fqin: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// Response containing the icon URL.
+public struct Arcbox_V1_GetImageIconResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Icon URL, empty if not found.
+  public var url: String = String()
+
+  /// Icon source (e.g., "docker_hub_logo", "docker_official_image", "ghcr_avatar").
+  public var source: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 /// Request to create a volume.
 public struct Arcbox_V1_CreateVolumeRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
@@ -1988,6 +2019,71 @@ extension Arcbox_V1_PruneResponse: SwiftProtobuf.Message, SwiftProtobuf._Message
     if lhs.imagesDeleted != rhs.imagesDeleted {return false}
     if lhs.networksDeleted != rhs.networksDeleted {return false}
     if lhs.volumesDeleted != rhs.volumesDeleted {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Arcbox_V1_GetImageIconRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GetImageIconRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}fqin\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.fqin) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.fqin.isEmpty {
+      try visitor.visitSingularStringField(value: self.fqin, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Arcbox_V1_GetImageIconRequest, rhs: Arcbox_V1_GetImageIconRequest) -> Bool {
+    if lhs.fqin != rhs.fqin {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Arcbox_V1_GetImageIconResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GetImageIconResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}url\0\u{1}source\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.url) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.source) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.url.isEmpty {
+      try visitor.visitSingularStringField(value: self.url, fieldNumber: 1)
+    }
+    if !self.source.isEmpty {
+      try visitor.visitSingularStringField(value: self.source, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Arcbox_V1_GetImageIconResponse, rhs: Arcbox_V1_GetImageIconResponse) -> Bool {
+    if lhs.url != rhs.url {return false}
+    if lhs.source != rhs.source {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }


### PR DESCRIPTION
## Summary

- Regenerate proto stubs to include `IconService` from arcbox PR #87
- Add `icons` service accessor to `ArcBoxClient`
- Batch-fetch icon URLs via `IconService.GetImageIcon` after loading container/image lists, with in-memory cache to avoid redundant RPCs
- New `RemoteIconView` component: `AsyncImage` with graceful fallback to the original hash-colored SF Symbol icon
- Wire icon URLs through `ContainerViewModel.iconURL` / `ImageViewModel.iconURL` into `ContainerRowView` and `ImageRowView`

Depends on [arcbox#87](https://github.com/arcboxlabs/arcbox/pull/87).

## Test plan

- [ ] Verify container list shows remote icons for known images (nginx, postgres, etc.)
- [ ] Verify image list shows remote icons
- [ ] Verify fallback SF Symbol renders when IconService is unavailable or returns empty URL
- [ ] Verify menu bar container list still works (passes `iconClient`)
- [ ] Verify no regressions in container start/stop/remove flows