### PR TITLE
fix: inject SUFeedURL via PlistBuddy instead of xcodebuild build setting

### DIFF
--- a/scripts/package-dmg.sh
+++ b/scripts/package-dmg.sh
@@ -138,14 +138,11 @@ cp -R "$BUILT_APP" "$APP_BUNDLE"
 
 echo "  App bundle: $APP_BUNDLE"
 
-# Inject Sparkle feed URL directly into Info.plist via PlistBuddy.
+# Inject Sparkle feed URL directly into Info.plist via plutil.
 # xcodebuild build settings (both xcconfig and command-line) treat "//" as a
-# comment delimiter, which silently truncates URLs.  PlistBuddy has no such
-# limitation.
+# comment delimiter, which silently truncates URLs.
 if [ -n "${SPARKLE_FEED_URL:-}" ]; then
-    /usr/libexec/PlistBuddy -c "Add :SUFeedURL string $SPARKLE_FEED_URL" \
-        "$APP_BUNDLE/Contents/Info.plist" 2>/dev/null || \
-    /usr/libexec/PlistBuddy -c "Set :SUFeedURL $SPARKLE_FEED_URL" \
+    plutil -replace SUFeedURL -string "$SPARKLE_FEED_URL" \
         "$APP_BUNDLE/Contents/Info.plist"
     echo "  SUFeedURL: $SPARKLE_FEED_URL"
 fi


### PR DESCRIPTION
## Summary

- xcodebuild treats `//` as a comment delimiter in both xcconfig files and command-line build settings, silently truncating URLs like `https://...`
- CI-built DMGs were missing `SUFeedURL` in Info.plist, causing Sparkle to show "Update Error!" on launch
- Switch to PlistBuddy post-build injection which handles URLs correctly

## Test plan

- [ ] Trigger a CI release build and verify the DMG's `Info.plist` contains a valid `SUFeedURL`
- [ ] Launch the built app and confirm no Sparkle "Update Error!" dialog appears