### PR TITLE
feat(ci): update Dub download short links after stable release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -558,6 +558,7 @@ jobs:
           AWS_REGION: ${{ secrets.RELEASE_B2_REGION }}
 
       - name: Verify CDN URLs
+        id: cdn_verify
         run: |
           VERSION="${{ steps.channel.outputs.version }}"
           CHANNEL="${{ steps.channel.outputs.channel }}"
@@ -578,33 +579,32 @@ jobs:
           if [ "$FAILED" -eq 1 ]; then
             echo "::warning::Some CDN URLs did not return HTTP 200"
           fi
+          echo "ok=$([ $FAILED -eq 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
-      - name: Update Dub download short links
-        if: needs.build-dmg.outputs.channel == 'stable'
+      - name: Update Dub download short link
+        if: needs.build-dmg.outputs.channel == 'stable' && steps.cdn_verify.outputs.ok == 'true'
         env:
           DUB_API_KEY: ${{ secrets.DUB_API_KEY }}
         run: |
+          if [ -z "$DUB_API_KEY" ]; then
+            echo "::warning::DUB_API_KEY is not set, skipping Dub link update"
+            exit 0
+          fi
+
           VERSION="${{ steps.channel.outputs.version }}"
           DMG_NAME="${{ needs.build-dmg.outputs.dmg }}"
           CDN_URL="https://release.arcboxcdn.com/desktop/${VERSION}/${DMG_NAME}"
+          LINK_ID="${{ secrets.DUB_LINKID_DOWNLOAD_DESKTOP_ARM64 }}"
 
-          update_dub_link() {
-            local LINK_ID="$1"
-            local URL="$2"
-            if [ -z "$LINK_ID" ]; then
-              echo "Skipping: no link ID provided"
-              return 0
-            fi
-            RESPONSE=$(curl -fsSL -X PATCH \
-              "https://api.dub.co/links/${LINK_ID}" \
-              -H "Authorization: Bearer $DUB_API_KEY" \
-              -H "Content-Type: application/json" \
-              -d "{\"url\": \"${URL}\"}")
-            echo "$RESPONSE" | jq '{shortLink, url}'
-          }
+          if [ -z "$LINK_ID" ]; then
+            echo "::warning::DUB_LINKID_DOWNLOAD_DESKTOP_ARM64 is not set, skipping"
+            exit 0
+          fi
 
-          echo "=== Updating ARM64 download link ==="
-          update_dub_link "${{ secrets.DUB_LINKID_DOWNLOAD_DESKTOP_ARM64 }}" "$CDN_URL"
-
-          echo "=== Updating x64 download link ==="
-          update_dub_link "${{ secrets.DUB_LINKID_DOWNLOAD_DESKTOP_X64 }}" "$CDN_URL"
+          RESPONSE=$(curl -fsSL -X PATCH \
+            "https://api.dub.co/links/${LINK_ID}" \
+            -H "Authorization: Bearer $DUB_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"url\": \"${CDN_URL}\"}")
+          echo "$RESPONSE" | jq '{shortLink, url}'
+          echo "Updated ARM64 download link -> $CDN_URL"


### PR DESCRIPTION
## Summary
- Automatically update `arcbox.link` download short links via Dub API after a stable release, pointing to the latest CDN DMG URL
- Link IDs are managed via secrets (`DUB_LINKID_DOWNLOAD_DESKTOP_ARM64` / `..._X64`); x64 is skipped when left empty
- Only triggered on `stable` channel — alpha/beta/rc releases are unaffected