### PR TITLE
feat: show container DNS domain when resolver is installed

### DIFF
--- a/ArcBox/Models/ContainerModel.swift
+++ b/ArcBox/Models/ContainerModel.swift
@@ -157,6 +157,34 @@ struct ContainerViewModel: Identifiable, Hashable {
         )
     }
 
+    // MARK: - DNS domain helpers
+
+    /// The display domain for this container given the current DNS state.
+    func hostDomain(useDNS: Bool) -> String {
+        useDNS ? "\(name).arcbox.local" : "localhost"
+    }
+
+    /// Build a URL for the container's primary port, respecting DNS mode.
+    func domainURL(useDNS: Bool) -> URL? {
+        if useDNS, let port = ports.first {
+            let suffix = port.containerPort == 80 ? "" : ":\(port.containerPort)"
+            return URL(string: "http://\(hostDomain(useDNS: true))\(suffix)")
+        } else if let hostPort = hostPorts.first {
+            return URL(string: "http://localhost:\(hostPort)")
+        }
+        return nil
+    }
+
+    /// Build a URL for a specific port mapping, respecting DNS mode.
+    func portURL(_ port: PortMapping, useDNS: Bool) -> URL? {
+        if useDNS {
+            let suffix = port.containerPort == 80 ? "" : ":\(port.containerPort)"
+            return URL(string: "http://\(hostDomain(useDNS: true))\(suffix)")
+        } else {
+            return URL(string: "http://localhost:\(port.hostPort)")
+        }
+    }
+
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
     }

--- a/ArcBox/Views/Containers/ContainerRowView.swift
+++ b/ArcBox/Views/Containers/ContainerRowView.swift
@@ -30,19 +30,10 @@ struct ContainerRowView: View {
 
     private var useDNS: Bool { daemonManager.dnsResolverInstalled && daemonManager.routeInstalled }
 
-    private var hostDomain: String {
-        useDNS ? "\(container.name).arcbox.local" : "localhost"
-    }
+    private var hostDomain: String { container.hostDomain(useDNS: useDNS) }
 
     private func openPort(_ port: PortMapping) {
-        let urlString: String
-        if useDNS {
-            let suffix = port.containerPort == 80 ? "" : ":\(port.containerPort)"
-            urlString = "http://\(hostDomain)\(suffix)"
-        } else {
-            urlString = "http://localhost:\(port.hostPort)"
-        }
-        if let url = URL(string: urlString) {
+        if let url = container.portURL(port, useDNS: useDNS) {
             NSWorkspace.shared.open(url)
         }
     }

--- a/ArcBox/Views/Containers/Tabs/ContainerInfoTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerInfoTab.swift
@@ -15,20 +15,6 @@ struct ContainerInfoTab: View {
 
     private var useDNS: Bool { daemonManager.dnsResolverInstalled && daemonManager.routeInstalled }
 
-    private var hostDomain: String {
-        useDNS ? "\(container.name).arcbox.local" : "localhost"
-    }
-
-    private func domainURL() -> URL? {
-        if useDNS, let port = container.ports.first {
-            let suffix = port.containerPort == 80 ? "" : ":\(port.containerPort)"
-            return URL(string: "http://\(hostDomain)\(suffix)")
-        } else if let hostPort = container.hostPorts.first {
-            return URL(string: "http://localhost:\(hostPort)")
-        }
-        return nil
-    }
-
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
@@ -54,8 +40,8 @@ struct ContainerInfoTab: View {
                         if useDNS || !container.hostPorts.isEmpty {
                             InfoRow(
                                 label: "Domain",
-                                value: hostDomain,
-                                link: domainURL()
+                                value: container.hostDomain(useDNS: useDNS),
+                                link: container.domainURL(useDNS: useDNS)
                             )
                         } else if let domain = container.domain {
                             InfoRow(label: "Domain", value: domain)


### PR DESCRIPTION
## Summary
- When DNS resolver **and** subnet route are both installed, container domain displays as `<name>.arcbox.local` instead of `localhost`
- URL links use container port (direct DNS access) vs host port (localhost port mapping)
- Applies to both ContainerInfoTab domain row and ContainerRowView port link buttons
- Falls back to `localhost` mode when either DNS resolver or route is not yet ready

## Test plan
- [ ] Verify domain shows `<name>.arcbox.local` when both `dnsResolverInstalled` and `routeInstalled` are true
- [ ] Verify domain falls back to `localhost` when either signal is false
- [ ] Verify clickable link uses container port in DNS mode, host port in localhost mode
- [ ] Verify port 80 is omitted from URL in DNS mode
- [ ] Verify domain row shows even when container has no exposed ports (DNS mode, link nil)