### PR TITLE
fix: remove traffic lights and keep coming soon panel floating

### DIFF
--- a/ArcBox/Views/ComingSoonPanel.swift
+++ b/ArcBox/Views/ComingSoonPanel.swift
@@ -17,7 +17,7 @@ func showComingSoonPanel() {
 
     let panel = ComingSoonPanel(
         contentRect: NSRect(x: 0, y: 0, width: 280, height: 260),
-        styleMask: [.titled, .fullSizeContentView, .nonactivatingPanel],
+        styleMask: [.titled, .fullSizeContentView],
         backing: .buffered,
         defer: false
     )
@@ -28,6 +28,7 @@ func showComingSoonPanel() {
     panel.backgroundColor = .clear
     panel.hasShadow = true
     panel.level = .floating
+    panel.hidesOnDeactivate = true
     panel.center()
 
     let hostingView = NSHostingView(


### PR DESCRIPTION
## Summary

- Remove `.closable` from panel styleMask to hide traffic light buttons (close via Esc or OK button)
- Set `panel.level = .floating` to keep the panel above the app window at all times

## Test plan

- [x] Click a "coming soon" nav item → panel appears without red/yellow/green buttons
- [x] Click elsewhere in the app → panel stays on top
- [x] Press Esc or click OK → panel dismisses