### PR TITLE
ci(release): auto-update Homebrew tap on stable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -617,6 +617,7 @@ jobs:
     needs: [build-dmg, upload-cdn]
     if: needs.build-dmg.outputs.channel == 'stable'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -638,7 +639,12 @@ jobs:
           VERSION: ${{ needs.build-dmg.outputs.version }}
         run: |
           CASK_VERSION="${VERSION#v}"
-          SHA256=$(sha256sum artifacts/ArcBox-*.dmg | awk '{print $1}')
+          DMG_PATH="$(find artifacts/ -type f -name '*.dmg' -print -quit)"
+          if [ -z "$DMG_PATH" ]; then
+            echo "Error: No DMG file found under artifacts/"
+            exit 1
+          fi
+          SHA256=$(sha256sum "$DMG_PATH" | awk '{print $1}')
 
           git clone --depth 1 \
             "https://x-access-token:${GH_TOKEN}@github.com/arcboxlabs/homebrew-tap.git" \


### PR DESCRIPTION
## Summary

- Add `update-homebrew-tap` job to `release.yml` that runs after CDN upload on stable releases
- Clones `arcboxlabs/homebrew-tap`, updates `Casks/arcbox.rb` with new version and SHA256, pushes
- Uses the same bot token pattern as the existing `update-desktop` job in arcbox's release-please workflow

## Test plan

- [ ] Next stable release triggers the `update-homebrew-tap` job
- [ ] `Casks/arcbox.rb` in homebrew-tap is updated with correct version and SHA256
- [ ] `brew upgrade --cask arcbox` picks up the new version