### PR TITLE
fix(startup): defer DockerClient creation until daemon is running

### DIFF
--- a/ArcBox/ArcBoxApp.swift
+++ b/ArcBox/ArcBoxApp.swift
@@ -136,9 +136,12 @@ struct ArcBoxDesktopApp: App {
                     appDelegate.startupOrchestrator = orchestrator
                     await orchestrator.start()
                 }
-                // When daemon transitions to running, start event monitor.
+                // When daemon transitions to running, create DockerClient and start event monitor.
                 .onChange(of: daemonManager.state) { _, newState in
                     if newState.isRunning {
+                        if dockerClient == nil {
+                            dockerClient = DockerClient()
+                        }
                         if let dockerClient {
                             eventMonitor.start(docker: dockerClient)
                         }
@@ -169,12 +172,10 @@ struct ArcBoxDesktopApp: App {
         .menuBarExtraStyle(.window)
     }
 
-    /// Create clients and return the ArcBoxClient for the orchestrator.
+    /// Create gRPC client and return it for the orchestrator.
+    /// DockerClient is created later in onChange(of: daemonManager.state)
+    /// when the daemon is confirmed running.
     private func initClientsAndReturn() throws -> ArcBoxClient {
-        if dockerClient == nil {
-            dockerClient = DockerClient()
-        }
-
         if let existing = arcboxClient {
             Log.startup.info("Reusing existing ArcBoxClient")
             return existing


### PR DESCRIPTION
## Summary

- Container list stayed empty on app launch until a Docker event or user interaction triggered a reload
- All containers appeared as "Stopped" even when running, because the initial load fired before the Docker-compat layer was ready

## Root Cause

`DockerClient` was created inside `initClientsAndReturn()` during `StartupOrchestrator` Step 3 — **before** the daemon poll loop confirmed the daemon was running. This caused `.task(id: docker != nil)` in all four ListViews (Containers, Images, Networks, Volumes) to fire prematurely when the Docker socket wasn't accepting connections yet.

## Fix

Move `DockerClient()` creation from `initClientsAndReturn()` to `onChange(of: daemonManager.state)` — the client is now created only after the daemon is confirmed `.running`. The `docker` environment variable transitions `nil → non-nil` at the correct time, so all downstream `.task(id: docker != nil)` modifiers fire naturally without per-view changes.

## Test plan

- [x] `xcodebuild build` passes
- [ ] Launch app from cold start → container list should load immediately after startup progress completes
- [ ] All containers should show correct state (Running vs Stopped)
- [ ] Kill daemon manually → reconnect should re-create DockerClient and reload lists

Closes ABXD-76