### PR TITLE
feat: show GitHub release notes in Sparkle update dialog

### DIFF
--- a/scripts/generate-appcast.py
+++ b/scripts/generate-appcast.py
@@ -46,9 +46,12 @@ def build_item(
     if channel != "stable":
         channel_element = f"\n        <sparkle:channel>{channel}</sparkle:channel>"
 
+    release_notes_url = f"https://github.com/arcboxlabs/arcbox-desktop/releases/tag/v{display_version}"
+
     return (
         f"      <item>\n"
         f"        <title>ArcBox {display_version}</title>\n"
+        f"        <sparkle:releaseNotesLink>{release_notes_url}</sparkle:releaseNotesLink>\n"
         f"        <pubDate>{pub_date}</pubDate>\n"
         f"        <sparkle:version>{build_number}</sparkle:version>\n"
         f"        <sparkle:shortVersionString>{display_version}</sparkle:shortVersionString>"


### PR DESCRIPTION
## Summary
- Add `<sparkle:releaseNotesLink>` to appcast items in `generate-appcast.py`
- Points to `https://github.com/arcboxlabs/arcbox-desktop/releases/tag/v{version}`
- Sparkle renders the release notes in its update window via embedded WebView

## Test plan
- [ ] Run `scripts/generate-appcast.py` with test args and verify the output XML contains the `<sparkle:releaseNotesLink>` element
- [ ] Trigger a Sparkle update check and confirm the release notes appear in the update dialog