### PR TITLE
fix(proto): make generate.sh --remote mode actually work

### DIFF
--- a/Packages/ArcBoxClient/generate.sh
+++ b/Packages/ArcBoxClient/generate.sh
@@ -18,8 +18,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 OUT_DIR="${SCRIPT_DIR}/Sources/ArcBoxClient/Generated"
 PROTO_TMPDIR=""
 
-GITHUB_REPO="arcbox-labs/arcbox"
-GITHUB_BRANCH="main"
+GITHUB_REPO="arcboxlabs/arcbox"
+GITHUB_BRANCH="master"
 GITHUB_PROTO_PATH="rpc/arcbox-protocol/proto"
 
 PROTOS=(
@@ -56,16 +56,17 @@ find_local_proto() {
     return 1
 }
 
-# Download proto files from GitHub
+# Download proto files from GitHub. Progress messages go to stderr so the
+# function's stdout is just the tmp directory path captured by callers.
 fetch_from_github() {
     PROTO_TMPDIR="$(mktemp -d)"
-    echo "Fetching proto files from GitHub (${GITHUB_REPO}@${GITHUB_BRANCH})..."
+    echo "Fetching proto files from GitHub (${GITHUB_REPO}@${GITHUB_BRANCH})..." >&2
 
     for proto in "${PROTOS[@]}"; do
         local url="https://raw.githubusercontent.com/${GITHUB_REPO}/${GITHUB_BRANCH}/${GITHUB_PROTO_PATH}/${proto}"
-        echo "  Downloading ${proto}"
+        echo "  Downloading ${proto}" >&2
         if ! curl -fsSL -o "${PROTO_TMPDIR}/${proto}" "$url"; then
-            echo "Error: failed to download ${proto} from ${url}"
+            echo "Error: failed to download ${proto} from ${url}" >&2
             exit 1
         fi
     done


### PR DESCRIPTION
## Summary

`Packages/ArcBoxClient/generate.sh --remote` has been broken on two fronts:

- **Stale constants** — `GITHUB_REPO=\"arcbox-labs/arcbox\"` predates the org rename to `arcboxlabs`, and `GITHUB_BRANCH=\"main\"` doesn't match the actual default branch (`master`). The first 404s; even with the redirect, the second always 404s the proto.
- **stdout contamination** — `fetch_from_github` echoes progress messages to stdout, which the caller captures via `PROTO_DIR=\"\$(fetch_from_github)\"`. `PROTO_DIR` ends up being a multi-line blob that includes \"Fetching proto files from GitHub...\", not the temp directory. Even with the URL fixed, `protoc` then can't find the protos.

After this PR, `./generate.sh --remote` fetches `arcboxlabs/arcbox@master` and generates Swift code successfully without a sibling arcbox checkout.

`--local` mode is unaffected. CI uses `--local` so it isn't impacted either way.

## Test plan

- [x] `cd Packages/ArcBoxClient && ./generate.sh --remote` exits 0 and generates the expected files
- [x] Output matches what `--local` produces against `arcboxlabs/arcbox@master`
- [x] Generated `agent.grpc.swift` size matches what CI produces (124950 bytes)