### PR TITLE
chore(devenv): add devenv-based reproducible dev shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+eval "$(devenv direnvrc)"
+
+use devenv

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,11 @@ Local.xcconfig
 *.cer
 .env
 .env.*
+
+# Devenv
+.devenv*
+devenv.local.nix
+devenv.local.yaml
+
+# direnv
+.direnv

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1779749056,
+        "narHash": "sha256-AtocdrunzuxTvSDn+82RntEhrs6TicM6Z4/zNQS9KKg=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "099ac65fcef79e88127bdc06adbd1ea94255274a",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1778507786,
+        "narHash": "sha256-HzSQCKMsMr8r55LwM1JuzIOB+8bzk0FEv6sItKvsfoY=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "8f24a228a782e24576b155d1e39f0d914b380691",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+
+{
+  # Xcode (xcodebuild, swift, codesign, security) comes from the system
+  # Xcode install — it is not available in nixpkgs on darwin. devenv
+  # provides auxiliary tooling: lint/format for pre-commit hooks and
+  # protoc for Packages/ArcBoxClient/generate.sh.
+  packages = with pkgs; [
+    swift-format
+    swiftlint
+    pre-commit
+    protobuf
+  ];
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling


### PR DESCRIPTION
## Summary

Adds a Nix-backed devenv shell so contributors get the auxiliary tooling Xcode does not ship:

- `swift-format` and `swiftlint` for the existing pre-commit hooks
- `pre-commit` itself
- `protobuf` (i.e. `protoc`) for `Packages/ArcBoxClient/generate.sh`

Xcode-provided binaries (`xcodebuild`, `swift`, `codesign`, `security`) stay on the system toolchain — they are not in nixpkgs on darwin, and mixing the Nix macOS SDK with Xcode's Swift compiler breaks `swift build`. The `devenv.nix` comment spells this out.

Files added:
- `.envrc` — direnv hook that activates the shell on `cd`
- `devenv.yaml`, `devenv.nix`, `devenv.lock` — devenv config + pinned inputs
- `.gitignore` — ignore `.devenv*`, `.direnv`, and `devenv.local.{nix,yaml}`

## Test plan

- [x] `devenv shell -- which protoc` returns a Nix store path
- [x] `devenv shell -- swift-format --version` and `swiftlint version` resolve
- [x] direnv users get the shell on entering the repo directory (`.envrc` calls `use devenv`)