### PR TITLE
fix(updater): embed release notes in appcast instead of linking GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -488,7 +488,7 @@ jobs:
         run: |
           VERSION="${{ needs.build-dmg.outputs.version }}"
           gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-            -f tag_name="$VERSION" --jq .body > notes.md
+            -f tag_name="$VERSION" --jq '.body // empty' > notes.md
           # GitHub-flavored HTML, with PR/compare URLs collapsed to short links
           gh api markdown -f mode=gfm -f context="$GITHUB_REPOSITORY" \
             -F text=@notes.md > notes.html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -455,6 +455,9 @@ jobs:
     name: Upload to CDN
     needs: [build-dmg]
     runs-on: ubuntu-latest
+    permissions:
+      # The releases/generate-notes API requires contents: write.
+      contents: write
 
     steps:
       - name: Checkout code
@@ -474,6 +477,23 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
           echo "Channel: $CHANNEL, Version: $VERSION"
+
+      # Sparkle renders these inline in the update dialog. Linking the GitHub
+      # release page instead would load the whole GitHub website in the dialog.
+      - name: Generate release notes HTML
+        id: release_notes
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ needs.build-dmg.outputs.version }}"
+          gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="$VERSION" --jq .body > notes.md
+          # GitHub-flavored HTML, with PR/compare URLs collapsed to short links
+          gh api markdown -f mode=gfm -f context="$GITHUB_REPOSITORY" \
+            -F text=@notes.md > notes.html
+          [ -s notes.html ]
+          echo "found=true" >> "$GITHUB_OUTPUT"
 
       - name: Download existing appcast from CDN
         id: existing_appcast
@@ -517,6 +537,10 @@ jobs:
 
           if [ "${{ steps.existing_appcast.outputs.found }}" = "true" ]; then
             APPCAST_ARGS+=(--existing existing/appcast.xml)
+          fi
+
+          if [ "${{ steps.release_notes.outputs.found }}" = "true" ]; then
+            APPCAST_ARGS+=(--release-notes-html notes.html)
           fi
 
           mkdir -p cdn-staging/desktop/appcast

--- a/scripts/generate-appcast.py
+++ b/scripts/generate-appcast.py
@@ -31,6 +31,11 @@ def rfc2822_now() -> str:
     return formatdate(timeval=datetime.now(timezone.utc).timestamp(), usegmt=True)
 
 
+def cdata(text: str) -> str:
+    """Wrap text in a CDATA section, splitting any ']]>' terminators."""
+    return "<![CDATA[" + text.replace("]]>", "]]]]><![CDATA[>") + "]]>"
+
+
 def build_item(
     display_version: str,
     build_number: str,
@@ -40,18 +45,25 @@ def build_item(
     channel: str,
     min_macos: str,
     pub_date: str,
+    release_notes_html: str | None,
 ) -> str:
     """Build a single <item> XML fragment."""
     channel_element = ""
     if channel != "stable":
         channel_element = f"\n        <sparkle:channel>{channel}</sparkle:channel>"
 
-    release_notes_url = f"https://github.com/arcboxlabs/arcbox-desktop/releases/tag/v{display_version}"
+    # Embedded HTML renders inside Sparkle's update dialog. A releaseNotesLink
+    # would be loaded as a full web page there, so it is only a fallback.
+    if release_notes_html:
+        notes_element = f"        <description>{cdata(release_notes_html)}</description>"
+    else:
+        release_notes_url = f"https://github.com/arcboxlabs/arcbox-desktop/releases/tag/v{display_version}"
+        notes_element = f"        <sparkle:releaseNotesLink>{release_notes_url}</sparkle:releaseNotesLink>"
 
     return (
         f"      <item>\n"
         f"        <title>ArcBox {display_version}</title>\n"
-        f"        <sparkle:releaseNotesLink>{release_notes_url}</sparkle:releaseNotesLink>\n"
+        f"{notes_element}\n"
         f"        <pubDate>{pub_date}</pubDate>\n"
         f"        <sparkle:version>{build_number}</sparkle:version>\n"
         f"        <sparkle:shortVersionString>{display_version}</sparkle:shortVersionString>"
@@ -89,17 +101,16 @@ def merge_appcast(existing_path: Path, item: str, display_version: str) -> str:
 
     # Remove any existing items that match this version by shortVersionString
     # or sparkle:version (build number is the display_version for dedup).
-    for tag in ("sparkle:shortVersionString", "sparkle:version"):
-        pattern = (
-            r"\s*<item>.*?<"
-            + tag
-            + r">"
-            + re.escape(display_version)
-            + r"</"
-            + tag
-            + r">.*?</item>"
-        )
-        content = re.sub(pattern, "", content, flags=re.DOTALL)
+    # Each <item> is matched individually: a single lazy cross-item pattern
+    # would also swallow every item preceding the duplicate.
+    def keep_or_drop(match: re.Match) -> str:
+        item_xml = match.group(0)
+        for tag in ("sparkle:shortVersionString", "sparkle:version"):
+            if f"<{tag}>{display_version}</{tag}>" in item_xml:
+                return ""
+        return item_xml
+
+    content = re.sub(r"\s*<item>.*?</item>", keep_or_drop, content, flags=re.DOTALL)
 
     # Strip legacy <sparkle:channel>stable</sparkle:channel> tags.
     content = re.sub(r"\n\s*<sparkle:channel>stable</sparkle:channel>", "", content)
@@ -123,11 +134,22 @@ def main() -> None:
     parser.add_argument("--min-macos", default="15.0", help="Minimum macOS version (default: 15.0)")
     parser.add_argument("--output", required=True, type=Path, help="Output appcast XML path")
     parser.add_argument("--existing", default=None, type=Path, help="Existing appcast to merge into")
+    parser.add_argument(
+        "--release-notes-html",
+        default=None,
+        type=Path,
+        help="HTML file embedded as the item description; "
+        "falls back to linking the GitHub release page",
+    )
 
     args = parser.parse_args()
 
     display_version = args.version.lstrip("v")
     pub_date = rfc2822_now()
+
+    release_notes_html = None
+    if args.release_notes_html and args.release_notes_html.is_file():
+        release_notes_html = args.release_notes_html.read_text().strip() or None
 
     item = build_item(
         display_version=display_version,
@@ -138,6 +160,7 @@ def main() -> None:
         channel=args.channel,
         min_macos=args.min_macos,
         pub_date=pub_date,
+        release_notes_html=release_notes_html,
     )
 
     if args.existing and args.existing.is_file():


### PR DESCRIPTION
## Problem

The "Check for Updates" dialog rendered the entire GitHub website (header, Sign in button, repo tabs) inside the release notes pane.

Each appcast item set `<sparkle:releaseNotesLink>` to the GitHub release page, and Sparkle loads that URL as a full web page in the dialog's WebView.

## Fix

- The `upload-cdn` job now generates the changelog with the `releases/generate-notes` API and renders it to GitHub-flavored HTML via the `/markdown` API (PR URLs collapse to `#231`-style links, compare URLs to `v1.22.6...v1.22.7`).
- `generate-appcast.py` embeds that HTML as the item's `<description>` CDATA, which Sparkle renders inline with its own dark-mode stylesheet (`SUUpdateAlert.m` falls back to `itemDescription` when `releaseNotesURL` is nil).
- If notes generation ever fails, the step is `continue-on-error` and the appcast falls back to the old GitHub link.
- Side benefit: notes ship inside the appcast from the CDN, so the dialog no longer depends on github.com being reachable.

Also fixes a latent bug in `merge_appcast`: the dedup regex matched lazily **across** item boundaries, so re-publishing the newest version deleted every older item from the feed (reproduced: feed left with 0 items). Items are now matched individually.

## Verification

- Generated an appcast locally using GitHub's real API output for v1.22.7: new item gets embedded CDATA notes, old items keep their link, `xmllint` passes.
- Re-publishing an existing version replaces only that item; `]]>` in notes round-trips via CDATA splitting.
- `actionlint` reports only the 3 pre-existing warnings.

## Note

The published appcast still links GitHub for the existing 1.22.7 item; the fix becomes visible with the next release. Re-running the release workflow for `v1.22.7` via `workflow_dispatch` would regenerate that item in place.