### PR TITLE
fix(daemon): run launchd agent at Standard QoS, not Background

### DIFF
--- a/LaunchDaemons/com.arcboxlabs.desktop.daemon.plist
+++ b/LaunchDaemons/com.arcboxlabs.desktop.daemon.plist
@@ -27,8 +27,12 @@
     <key>ThrottleInterval</key>
     <integer>5</integer>
 
+    <!-- Must NOT be Background: that QoS class throttles CPU/I/O, which slows
+         the guest VM cold boot past the daemon's agent-wait timeout
+         (DEFAULT_STARTUP_TIMEOUT_SECS), causing "timeout waiting for agent"
+         crash loops. The daemon boots a latency-sensitive VM, so use Standard. -->
     <key>ProcessType</key>
-    <string>Background</string>
+    <string>Standard</string>
 
     <!-- Kept for backward compatibility: the current bundled daemon
          (< 0.4) still writes to stdout/stderr. Once it switches to


### PR DESCRIPTION
## Problem
On launch the bundled daemon crash-loops on `VM error: timeout waiting for agent`, leaving the app stuck at "Starting Docker engine…".

Root cause: the launchd agent runs with `ProcessType=Background`, whose QoS class throttles CPU/I/O. The guest VM cold boot to agent-ready takes ~28s — already close to the daemon's 30s `DEFAULT_STARTUP_TIMEOUT_SECS`. Under Background throttling it exceeds 30s, `wait_for_agent` times out, the daemon exits non-zero, and `KeepAlive` restarts it: a crash loop. `docker.sock` is never (re)served.

## Fix
Set `ProcessType=Standard`. The daemon boots a latency-sensitive VM and must not be throttled during startup.

## Verification
- `taskpolicy -b <daemon> --docker-integration` (forces Background QoS) reproduces `timeout waiting for agent`, exiting ~+41s.
- The same daemon run at normal QoS reaches agent-ready in ~28s; `EnsureRuntime` succeeds and dockerd/`docker.sock` come up.

## Notes
This change alone resolves the stuck startup. Companion robustness change raising the 30s budget to 90s: arcboxlabs/arcbox#304.