### PR TITLE
fix(settings): polish settings sidebar window

### DIFF
--- a/ArcBox/ArcBoxApp.swift
+++ b/ArcBox/ArcBoxApp.swift
@@ -51,6 +51,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 @main
 struct ArcBoxDesktopApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @Environment(\.openWindow) private var openWindow
     // Lightweight init — no network calls until view appears
     @State private var appVM = AppViewModel()
     // Lightweight init — no network calls until view appears
@@ -254,15 +255,25 @@ struct ArcBoxDesktopApp: App {
                 }
                 CheckForUpdatesView(updater: updaterController.updater)
             }
+            CommandGroup(replacing: .appSettings) {
+                Button {
+                    openWindow(id: "settings")
+                } label: {
+                    Label("Settings...", systemImage: "gear")
+                }
+                .keyboardShortcut(",", modifiers: .command)
+            }
         }
 
-        Settings {
+        Window("Settings", id: "settings") {
             SettingsView()
                 .environment(daemonManager)
                 .environment(containersVM)
                 .environment(imagesVM)
                 .environment(\.dockerClient, dockerClient)
         }
+        .defaultSize(width: 700, height: 580)
+        .windowResizability(.contentSize)
 
         MenuBarExtra("ArcBox", systemImage: "shippingbox", isInserted: $showInMenuBar) {
             MenuBarView()

--- a/ArcBox/Views/Settings/SettingsView.swift
+++ b/ArcBox/Views/Settings/SettingsView.swift
@@ -35,18 +35,31 @@ struct SettingsView: View {
 
     var body: some View {
         NavigationSplitView {
+            sidebar
+        } detail: {
+            settingsContent
+                .navigationTitle(selectedTab?.rawValue ?? "")
+                .background(AppColors.background)
+        }
+        .frame(minWidth: 700, minHeight: 580)
+        .background(AppColors.background)
+    }
+
+    private var sidebar: some View {
+        ZStack {
+            AppColors.sidebar
+                .ignoresSafeArea(.container, edges: [.top, .bottom, .leading])
+
             List(SettingsTab.allCases, selection: $selectedTab) { tab in
                 Label(tab.rawValue, systemImage: tab.sfSymbol)
                     .tag(tab)
             }
             .listStyle(.sidebar)
-            .navigationSplitViewColumnWidth(min: 150, ideal: 180, max: 220)
-        } detail: {
-            settingsContent
-                .navigationTitle(selectedTab?.rawValue ?? "")
+            .scrollContentBackground(.hidden)
+            .background(Color.clear)
         }
-        .toolbar(removing: .sidebarToggle)
-        .frame(width: 700, height: 580)
+        .background(AppColors.sidebar)
+        .navigationSplitViewColumnWidth(180)
     }
 
     @ViewBuilder


### PR DESCRIPTION
Replace the native Settings scene with a dedicated Settings window opened from the app settings command so the window keeps a stable size and consistent resizing behavior.

Extract the settings sidebar layout and apply the sidebar background across the full column, while keeping the detail pane on the app background for cleaner navigation.