### PR TITLE
fix(menubar): optimize quick actions

### DIFF
--- a/ArcBox/ArcBoxApp.swift
+++ b/ArcBox/ArcBoxApp.swift
@@ -169,7 +169,7 @@ struct ArcBoxDesktopApp: App {
     }
 
     var body: some Scene {
-        WindowGroup {
+        Window("ArcBox", id: "main") {
             ContentView()
                 .environment(appVM)
                 .environment(daemonManager)
@@ -249,6 +249,8 @@ struct ArcBoxDesktopApp: App {
         }
         .defaultSize(width: 1200, height: 800)
         .commands {
+            CommandGroup(replacing: .newItem) {}
+
             CommandGroup(replacing: .appInfo) {
                 Button("About ArcBox") {
                     showAboutWindow()

--- a/ArcBox/Views/MenuBar/MenuBarView.swift
+++ b/ArcBox/Views/MenuBar/MenuBarView.swift
@@ -376,10 +376,11 @@ struct MenuBarView: View {
     }
 
     private func showSettingsWindow() {
-        openWindow(id: "settings")
-        if !bringWindowToFront(matching: { $0.title == "Settings" }) {
-            bringWindowToFrontAfterOpening(matching: { $0.title == "Settings" })
+        if bringWindowToFront(matching: { $0.title == "Settings" }) {
+            return
         }
+
+        openWindow(id: "settings")
     }
 
     private func showArcBoxWindow() {
@@ -388,17 +389,16 @@ struct MenuBarView: View {
         }
 
         openWindow(id: "main")
-        bringWindowToFrontAfterOpening(matching: isMainArcBoxWindow)
     }
 
     @discardableResult
     private func bringWindowToFront(matching predicate: (NSWindow) -> Bool) -> Bool {
-        NSApp.unhide(nil)
-        NSApp.activate(ignoringOtherApps: true)
-
         guard let window = NSApp.windows.first(where: predicate) else {
             return false
         }
+
+        NSApp.unhide(nil)
+        NSApp.activate(ignoringOtherApps: true)
 
         if window.isMiniaturized {
             window.deminiaturize(nil)
@@ -407,19 +407,12 @@ struct MenuBarView: View {
         return true
     }
 
-    private func bringWindowToFrontAfterOpening(matching predicate: @escaping (NSWindow) -> Bool) {
-        Task { @MainActor in
-            await Task.yield()
-            _ = bringWindowToFront(matching: predicate)
-        }
-    }
-
     private func isMainArcBoxWindow(_ window: NSWindow) -> Bool {
         guard window.styleMask.contains(.titled), !(window is NSPanel) else {
             return false
         }
 
-        return window.title == "ArcBox" || window.title.isEmpty
+        return window.title == "ArcBox"
     }
 }
 

--- a/ArcBox/Views/MenuBar/MenuBarView.swift
+++ b/ArcBox/Views/MenuBar/MenuBarView.swift
@@ -37,6 +37,19 @@ struct MenuBarView: View {
             .onReceive(NotificationCenter.default.publisher(for: .dockerDataChanged)) { _ in
                 Task { await loadAll() }
             }
+            .onAppear {
+                containersExpanded = hasContainers
+            }
+            .onChange(of: containersVM.runningCount) { _, newValue in
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    containersExpanded = newValue > 0 || hasStoppedContainers
+                }
+            }
+            .onChange(of: containersVM.containers.isEmpty) { _, isEmpty in
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    containersExpanded = !isEmpty
+                }
+            }
     }
 
     // MARK: - Data
@@ -161,15 +174,26 @@ struct MenuBarView: View {
         VStack(alignment: .leading, spacing: 2) {
             containersHeader
 
-            if containersExpanded, !sortedContainers.isEmpty {
-                containerList
-                    .transition(.opacity.combined(with: .move(edge: .top)))
+            if hasContainers {
+                containerListViewport
             }
         }
     }
 
+    private var containerListViewport: some View {
+        ZStack(alignment: .topLeading) {
+            if containersExpanded {
+                containerList
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .frame(height: containersExpanded ? containerListHeight : 0, alignment: .top)
+        .clipped()
+    }
+
     private var containersHeader: some View {
         Button {
+            guard hasContainers else { return }
             withAnimation(.easeInOut(duration: 0.2)) {
                 containersExpanded.toggle()
             }
@@ -192,7 +216,8 @@ struct MenuBarView: View {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundStyle(.tertiary)
-                    .rotationEffect(.degrees(containersExpanded ? 90 : 0))
+                    .opacity(hasContainers ? 1 : 0.35)
+                    .rotationEffect(.degrees(containersExpanded && hasContainers ? 90 : 0))
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 5)
@@ -200,26 +225,27 @@ struct MenuBarView: View {
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .fill(
-                        containersExpanded
+                        containersExpanded && hasContainers
                             ? AnyShapeStyle(.quaternary.opacity(0.30))
                             : AnyShapeStyle(.clear))
             )
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .disabled(!hasContainers)
     }
 
     private var containerList: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 2) {
-                ForEach(sortedContainers) { container in
+            VStack(alignment: .leading, spacing: containerRowSpacing) {
+                ForEach(displayedContainers) { container in
                     containerRow(container)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .frame(maxHeight: 200)
-        .padding(.leading, 26)
+        .frame(height: containerListHeight)
+        .padding(.leading, 12)
     }
 
     private func containerRow(_ container: ContainerViewModel) -> some View {
@@ -245,6 +271,7 @@ struct MenuBarView: View {
             }
             .padding(.horizontal, 6)
             .padding(.vertical, 5)
+            .frame(height: containerRowHeight)
         }
     }
 
@@ -263,7 +290,7 @@ struct MenuBarView: View {
             MenuBarHoverButton {
                 // TODO: open settings when settings UI is implemented
             } label: {
-                Label("Settings", systemImage: "gearshape")
+                Label("Settings", systemImage: "gear")
                     .padding(.horizontal, 6)
                     .padding(.vertical, 5)
             }
@@ -286,14 +313,35 @@ struct MenuBarView: View {
 
     // MARK: - Helpers
 
-    private var sortedContainers: [ContainerViewModel] {
+    private var hasContainers: Bool {
+        !displayedContainers.isEmpty
+    }
+
+    private var hasStoppedContainers: Bool {
+        containersVM.containers.contains { !$0.isRunning }
+    }
+
+    private var displayedContainers: [ContainerViewModel] {
         containersVM.containers.sorted { lhs, rhs in
             if lhs.isRunning != rhs.isRunning {
-                return lhs.isRunning && !rhs.isRunning
+                return lhs.isRunning
             }
             return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
         }
     }
+
+    private var containerListHeight: CGFloat {
+        let rowCount = min(displayedContainers.count, maxVisibleContainerRows)
+        let rowsHeight = CGFloat(rowCount) * containerRowHeight
+        let spacingHeight = CGFloat(max(rowCount - 1, 0)) * containerRowSpacing
+        return rowsHeight + spacingHeight
+    }
+
+    private var maxVisibleContainerRows: Int { 8 }
+
+    private var containerRowHeight: CGFloat { 24 }
+
+    private var containerRowSpacing: CGFloat { 2 }
 
     private var daemonStateDisplay: String {
         switch daemonManager.state {

--- a/ArcBox/Views/MenuBar/MenuBarView.swift
+++ b/ArcBox/Views/MenuBar/MenuBarView.swift
@@ -1,6 +1,8 @@
+import AppKit
+import SwiftUI
+
 import ArcBoxClient
 import DockerClient
-import SwiftUI
 
 struct MenuBarView: View {
     @Environment(DaemonManager.self) private var daemonManager
@@ -9,6 +11,7 @@ struct MenuBarView: View {
     @Environment(ImagesViewModel.self) private var imagesVM
     @Environment(NetworksViewModel.self) private var networksVM
     @Environment(VolumesViewModel.self) private var volumesVM
+    @Environment(\.openWindow) private var openWindow
     @Environment(\.arcboxClient) private var client
     @Environment(\.dockerClient) private var docker
 
@@ -252,7 +255,7 @@ struct MenuBarView: View {
         MenuBarHoverButton {
             containersVM.selectContainer(container.id)
             appVM.navigate(to: .containers)
-            NSApp.activate(ignoringOtherApps: true)
+            showArcBoxWindow()
         } label: {
             HStack(spacing: 8) {
                 Circle()
@@ -279,22 +282,17 @@ struct MenuBarView: View {
 
     private var actionSection: some View {
         VStack(alignment: .leading, spacing: 2) {
-            MenuBarHoverButton {
-                NSApp.activate(ignoringOtherApps: true)
-            } label: {
+            MenuBarHoverButton(action: showArcBoxWindow) {
                 Label("Show ArcBox", systemImage: "macwindow")
                     .padding(.horizontal, 6)
                     .padding(.vertical, 5)
             }
 
-            MenuBarHoverButton {
-                // TODO: open settings when settings UI is implemented
-            } label: {
+            MenuBarHoverButton(action: showSettingsWindow) {
                 Label("Settings", systemImage: "gear")
                     .padding(.horizontal, 6)
                     .padding(.vertical, 5)
             }
-            .disabled(true)
 
             Divider()
                 .padding(.vertical, 4)
@@ -374,7 +372,54 @@ struct MenuBarView: View {
 
     private func navigateToPage(_ item: NavItem) {
         appVM.navigate(to: item)
+        showArcBoxWindow()
+    }
+
+    private func showSettingsWindow() {
+        openWindow(id: "settings")
+        if !bringWindowToFront(matching: { $0.title == "Settings" }) {
+            bringWindowToFrontAfterOpening(matching: { $0.title == "Settings" })
+        }
+    }
+
+    private func showArcBoxWindow() {
+        if bringWindowToFront(matching: isMainArcBoxWindow) {
+            return
+        }
+
+        openWindow(id: "main")
+        bringWindowToFrontAfterOpening(matching: isMainArcBoxWindow)
+    }
+
+    @discardableResult
+    private func bringWindowToFront(matching predicate: (NSWindow) -> Bool) -> Bool {
+        NSApp.unhide(nil)
         NSApp.activate(ignoringOtherApps: true)
+
+        guard let window = NSApp.windows.first(where: predicate) else {
+            return false
+        }
+
+        if window.isMiniaturized {
+            window.deminiaturize(nil)
+        }
+        window.makeKeyAndOrderFront(nil)
+        return true
+    }
+
+    private func bringWindowToFrontAfterOpening(matching predicate: @escaping (NSWindow) -> Bool) {
+        Task { @MainActor in
+            await Task.yield()
+            _ = bringWindowToFront(matching: predicate)
+        }
+    }
+
+    private func isMainArcBoxWindow(_ window: NSWindow) -> Bool {
+        guard window.styleMask.contains(.titled), !(window is NSPanel) else {
+            return false
+        }
+
+        return window.title == "ArcBox" || window.title.isEmpty
     }
 }
 


### PR DESCRIPTION
Summary:
- Enable the menu bar Settings action and focus the settings window when opened.
- Make Show ArcBox reuse the single main window instead of creating duplicate main windows.
- Polish the container quick-action list with running-first sorting, compact spacing, clipping, and an eight-row scroll limit.

Testing:
- xcodebuild build -project ArcBox.xcodeproj -scheme ArcBox -configuration Debug SKIP_RUST_BUILD=1 CODE_SIGN_IDENTITY=-