### PR TITLE
fix(terminal): improve external terminal app selection

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -458,7 +458,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				AUTOMATION_APPLE_EVENTS = NO;
+				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = ArcBox/ArcBox.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -471,6 +471,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = ArcBox;
 				INFOPLIST_KEY_CFBundleName = ArcBox;
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "ArcBox uses Automation to open your selected terminal app and run container shell commands.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 ArcBox Labs. Licensed under MIT OR Apache-2.0.";
 				INFOPLIST_KEY_PostHogAPIKey = "$(POSTHOG_API_KEY)";
 				INFOPLIST_KEY_SentryDSN = "$(SENTRY_DSN)";
@@ -503,7 +504,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				AUTOMATION_APPLE_EVENTS = NO;
+				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = ArcBox/ArcBox.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -516,6 +517,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = ArcBox;
 				INFOPLIST_KEY_CFBundleName = ArcBox;
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "ArcBox uses Automation to open your selected terminal app and run container shell commands.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 ArcBox Labs. Licensed under MIT OR Apache-2.0.";
 				INFOPLIST_KEY_PostHogAPIKey = "$(POSTHOG_API_KEY)";
 				INFOPLIST_KEY_SentryDSN = "$(SENTRY_DSN)";

--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -15,14 +15,14 @@
 		DC0A11012F4E000000000001 /* DockerClient in Frameworks */ = {isa = PBXBuildFile; productRef = DC0A11002F4E000000000001 /* DockerClient */; };
 		DC0B11012F4E000000000001 /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = DC0B11002F4E000000000001 /* SwiftTerm */; };
 		K8S100012F90000000000001 /* K8sClient in Frameworks */ = {isa = PBXBuildFile; productRef = K8S100002F90000000000001 /* K8sClient */; };
+		RES100012FA0000000000001 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = RES100002FA0000000000001 /* CHANGELOG.md */; };
+		RES200012FA0000000000001 /* arcbox.version in Resources */ = {isa = PBXBuildFile; fileRef = RES200002FA0000000000001 /* arcbox.version */; };
 		SE0300012F90000000000001 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = SE0200012F90000000000001 /* Sentry */; };
 		UT0100012FA0000000000001 /* ContainersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = UT0100002FA0000000000001 /* ContainersViewModelTests.swift */; };
 		UT0200012FA0000000000001 /* ImagesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = UT0200002FA0000000000001 /* ImagesViewModelTests.swift */; };
 		UT0300012FA0000000000001 /* K8sModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = UT0300002FA0000000000001 /* K8sModelsTests.swift */; };
 		UT0400012FA0000000000001 /* K8sClient in Frameworks */ = {isa = PBXBuildFile; productRef = UT0400002FA0000000000001 /* K8sClient */; };
 		UT0500012FA0000000000001 /* ChangelogParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = UT0500002FA0000000000001 /* ChangelogParserTests.swift */; };
-		RES100012FA0000000000001 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = RES100002FA0000000000001 /* CHANGELOG.md */; };
-		RES200012FA0000000000001 /* arcbox.version in Resources */ = {isa = PBXBuildFile; fileRef = RES200002FA0000000000001 /* arcbox.version */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -56,12 +56,12 @@
 		8AFC409B6C134B0BBFA4D294 /* ArcBoxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ArcBoxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB0D00012F60000000000001 /* com.arcboxlabs.desktop.daemon.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = com.arcboxlabs.desktop.daemon.plist; sourceTree = "<group>"; };
 		AB0F00012F80000000000001 /* Version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
+		RES100002FA0000000000001 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
+		RES200002FA0000000000001 /* arcbox.version */ = {isa = PBXFileReference; lastKnownFileType = text; path = arcbox.version; sourceTree = "<group>"; };
 		UT0100002FA0000000000001 /* ContainersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainersViewModelTests.swift; sourceTree = "<group>"; };
 		UT0200002FA0000000000001 /* ImagesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesViewModelTests.swift; sourceTree = "<group>"; };
 		UT0300002FA0000000000001 /* K8sModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K8sModelsTests.swift; sourceTree = "<group>"; };
 		UT0500002FA0000000000001 /* ChangelogParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangelogParserTests.swift; sourceTree = "<group>"; };
-		RES100002FA0000000000001 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
-		RES200002FA0000000000001 /* arcbox.version */ = {isa = PBXFileReference; lastKnownFileType = text; path = arcbox.version; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */

--- a/ArcBox/Models/DockerCLIResolver.swift
+++ b/ArcBox/Models/DockerCLIResolver.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+enum DockerCLIResolver {
+    private static let dockerSearchPaths = [
+        "/usr/local/bin/docker",
+        "/opt/homebrew/bin/docker",
+        "/usr/bin/docker",
+    ]
+
+    static func findDockerCLI() -> String? {
+        for path in dockerSearchPaths where FileManager.default.isExecutableFile(atPath: path) {
+            return path
+        }
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        proc.arguments = ["docker"]
+
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = FileHandle.nullDevice
+
+        do {
+            try proc.run()
+            proc.waitUntilExit()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let path = String(data: data, encoding: .utf8)?.trimmingCharacters(
+                in: .whitespacesAndNewlines)
+            if let path, !path.isEmpty, FileManager.default.isExecutableFile(atPath: path) {
+                return path
+            }
+        } catch {}
+
+        return nil
+    }
+}

--- a/ArcBox/Models/DockerTerminalSession.swift
+++ b/ArcBox/Models/DockerTerminalSession.swift
@@ -82,7 +82,7 @@ class DockerTerminalSession {
 
         state = .connecting
 
-        guard let dockerPath = Self.findDockerCLI() else {
+        guard let dockerPath = DockerCLIResolver.findDockerCLI() else {
             state = .error("Docker CLI not found")
             return
         }
@@ -271,35 +271,4 @@ class DockerTerminalSession {
         return FileManager.default.isExecutableFile(atPath: path) ? path : nil
     }
 
-    // MARK: - Docker CLI Discovery
-
-    nonisolated private static let dockerSearchPaths = [
-        "/usr/local/bin/docker",
-        "/opt/homebrew/bin/docker",
-        "/usr/bin/docker",
-    ]
-
-    nonisolated private static func findDockerCLI() -> String? {
-        for path in dockerSearchPaths where FileManager.default.isExecutableFile(atPath: path) {
-            return path
-        }
-        // Fallback: check PATH
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/usr/bin/which")
-        proc.arguments = ["docker"]
-        let pipe = Pipe()
-        proc.standardOutput = pipe
-        proc.standardError = FileHandle.nullDevice
-        do {
-            try proc.run()
-            proc.waitUntilExit()
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            let path = String(data: data, encoding: .utf8)?.trimmingCharacters(
-                in: .whitespacesAndNewlines)
-            if let path, !path.isEmpty, FileManager.default.isExecutableFile(atPath: path) {
-                return path
-            }
-        } catch {}
-        return nil
-    }
 }

--- a/ArcBox/Models/ExternalTerminalApp.swift
+++ b/ArcBox/Models/ExternalTerminalApp.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct ExternalTerminalApp: Identifiable, Hashable, Sendable {
+    enum AppleScriptBackend: Hashable, Sendable {
+        case terminal
+        case iTerm
+    }
+
+    static let legacySystemDefaultID = "system"
+    static let terminalBundleIdentifier = "com.apple.Terminal"
+
+    let id: String
+    let displayName: String
+    let bundleIdentifier: String?
+    let appURL: URL?
+    let supportsCommandFiles: Bool
+    let appleScriptBackend: AppleScriptBackend?
+}

--- a/ArcBox/Models/ExternalTerminalDiscovery.swift
+++ b/ArcBox/Models/ExternalTerminalDiscovery.swift
@@ -85,13 +85,10 @@ enum ExternalTerminalDiscovery {
         return terminals
     }
 
-    static func terminalApp(for appURL: URL) -> ExternalTerminalApp? {
+    static func terminalApp(for appURL: URL, commandHandlerBundleIDs: Set<String>) -> ExternalTerminalApp? {
         guard let bundle = Bundle(url: appURL), let bundleID = bundle.bundleIdentifier else {
             return nil
         }
-        let commandHandlerBundleIDs = Set(
-            commandFileHandlerAppURLs().compactMap { Bundle(url: $0)?.bundleIdentifier }
-        )
         return terminalApp(
             for: appURL,
             bundleID: bundleID,

--- a/ArcBox/Models/ExternalTerminalDiscovery.swift
+++ b/ArcBox/Models/ExternalTerminalDiscovery.swift
@@ -1,0 +1,199 @@
+import Foundation
+import AppKit
+
+enum ExternalTerminalDiscovery {
+    private static let legacyPreferenceBundleIDs = [
+        "terminal": ExternalTerminalApp.terminalBundleIdentifier,
+        "iterm": "com.googlecode.iterm2",
+    ]
+
+    private static let appleScriptBackends: [String: ExternalTerminalApp.AppleScriptBackend] = [
+        ExternalTerminalApp.terminalBundleIdentifier: .terminal,
+        "com.googlecode.iterm2": .iTerm,
+    ]
+
+    private static let likelyTerminalNameTokens = [
+        "terminal",
+        "iterm",
+        "term",
+        "warp",
+        "ghostty",
+        "wezterm",
+        "alacritty",
+        "kitty",
+        "tabby",
+        "hyper",
+        "rio",
+    ]
+
+    static func availableTerminals(preferredBundleIdentifier: String? = nil) -> [ExternalTerminalApp] {
+        var terminals: [ExternalTerminalApp] = []
+        var seenBundleIDs = Set<String>()
+        let commandHandlerAppURLs = commandFileHandlerAppURLs()
+        let commandHandlerBundleIDs = Set(
+            commandHandlerAppURLs.compactMap { Bundle(url: $0)?.bundleIdentifier }
+        )
+
+        if let terminalURL = NSWorkspace.shared.urlForApplication(
+            withBundleIdentifier: ExternalTerminalApp.terminalBundleIdentifier
+        ) {
+            terminals.append(
+                ExternalTerminalApp(
+                    id: ExternalTerminalApp.terminalBundleIdentifier,
+                    displayName: displayName(for: terminalURL) ?? "Terminal",
+                    bundleIdentifier: ExternalTerminalApp.terminalBundleIdentifier,
+                    appURL: terminalURL,
+                    supportsCommandFiles: commandHandlerBundleIDs.contains(
+                        ExternalTerminalApp.terminalBundleIdentifier
+                    ),
+                    appleScriptBackend: .terminal
+                )
+            )
+            seenBundleIDs.insert(ExternalTerminalApp.terminalBundleIdentifier)
+        }
+
+        for appURL in commandHandlerAppURLs {
+            guard let bundle = Bundle(url: appURL),
+                let bundleID = bundle.bundleIdentifier,
+                seenBundleIDs.insert(bundleID).inserted,
+                isLikelyTerminal(appURL: appURL, bundleID: bundleID)
+            else { continue }
+
+            terminals.append(terminalApp(for: appURL, bundleID: bundleID, supportsCommandFiles: true))
+        }
+
+        if let preferredBundleIdentifier,
+            !seenBundleIDs.contains(preferredBundleIdentifier),
+            let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: preferredBundleIdentifier)
+        {
+            terminals.append(
+                terminalApp(
+                    for: appURL,
+                    bundleID: preferredBundleIdentifier,
+                    supportsCommandFiles: commandHandlerBundleIDs.contains(preferredBundleIdentifier)
+                )
+            )
+        }
+
+        terminals.sort { lhs, rhs in
+            let lhsPriority = sortPriority(for: lhs)
+            let rhsPriority = sortPriority(for: rhs)
+            guard lhsPriority == rhsPriority else { return lhsPriority < rhsPriority }
+            return lhs.displayName.localizedStandardCompare(rhs.displayName) == .orderedAscending
+        }
+
+        return terminals
+    }
+
+    static func terminalApp(for appURL: URL) -> ExternalTerminalApp? {
+        guard let bundle = Bundle(url: appURL), let bundleID = bundle.bundleIdentifier else {
+            return nil
+        }
+        let commandHandlerBundleIDs = Set(
+            commandFileHandlerAppURLs().compactMap { Bundle(url: $0)?.bundleIdentifier }
+        )
+        return terminalApp(
+            for: appURL,
+            bundleID: bundleID,
+            supportsCommandFiles: commandHandlerBundleIDs.contains(bundleID)
+        )
+    }
+
+    static func resolve(preference: String) -> ExternalTerminalApp {
+        let terminals = availableTerminals()
+        let normalized = normalizedPreference(preference, availableTerminals: terminals)
+        return terminals.first { $0.id == normalized } ?? terminals.first ?? terminalFallback()
+    }
+
+    static func normalizedPreference(
+        _ preference: String,
+        availableTerminals terminals: [ExternalTerminalApp]? = nil
+    ) -> String {
+        let availableTerminals = terminals ?? availableTerminals()
+        let availableIDs = Set(availableTerminals.map(\.id))
+        let normalized: String
+
+        switch preference {
+        case ExternalTerminalApp.legacySystemDefaultID, "lastUsed":
+            normalized = ExternalTerminalApp.terminalBundleIdentifier
+        case let preference where legacyPreferenceBundleIDs[preference] != nil:
+            normalized = legacyPreferenceBundleIDs[preference] ?? ExternalTerminalApp.terminalBundleIdentifier
+        default:
+            normalized = preference
+        }
+
+        if availableIDs.contains(normalized) {
+            return normalized
+        }
+        return availableIDs.contains(ExternalTerminalApp.terminalBundleIdentifier)
+            ? ExternalTerminalApp.terminalBundleIdentifier
+            : availableTerminals.first?.id ?? ExternalTerminalApp.terminalBundleIdentifier
+    }
+
+    private static func commandFileHandlerAppURLs() -> [URL] {
+        let probeURL = FileManager.default.temporaryDirectory
+            .appending(path: "arcbox-terminal-handler-probe-\(UUID().uuidString).command")
+
+        do {
+            try "#!/bin/zsh\n".write(to: probeURL, atomically: true, encoding: .utf8)
+            defer { try? FileManager.default.removeItem(at: probeURL) }
+            return NSWorkspace.shared.urlsForApplications(toOpen: probeURL)
+        } catch {
+            return []
+        }
+    }
+
+    private static func isLikelyTerminal(appURL: URL, bundleID: String) -> Bool {
+        let bundleID = bundleID.lowercased()
+        let appName = appURL.deletingPathExtension().lastPathComponent.lowercased()
+        return likelyTerminalNameTokens.contains { token in
+            bundleID.contains(token) || appName.contains(token)
+        }
+    }
+
+    private static func sortPriority(for terminal: ExternalTerminalApp) -> Int {
+        terminal.bundleIdentifier == ExternalTerminalApp.terminalBundleIdentifier ? 0 : 1
+    }
+
+    private static func terminalApp(
+        for appURL: URL,
+        bundleID: String,
+        supportsCommandFiles: Bool
+    ) -> ExternalTerminalApp {
+        ExternalTerminalApp(
+            id: bundleID,
+            displayName: displayName(for: appURL) ?? appURL.deletingPathExtension().lastPathComponent,
+            bundleIdentifier: bundleID,
+            appURL: appURL,
+            supportsCommandFiles: supportsCommandFiles,
+            appleScriptBackend: appleScriptBackends[bundleID]
+        )
+    }
+
+    private static func terminalFallback() -> ExternalTerminalApp {
+        ExternalTerminalApp(
+            id: ExternalTerminalApp.terminalBundleIdentifier,
+            displayName: "Terminal",
+            bundleIdentifier: ExternalTerminalApp.terminalBundleIdentifier,
+            appURL: NSWorkspace.shared.urlForApplication(
+                withBundleIdentifier: ExternalTerminalApp.terminalBundleIdentifier
+            ),
+            supportsCommandFiles: true,
+            appleScriptBackend: .terminal
+        )
+    }
+
+    private static func displayName(for appURL: URL) -> String? {
+        guard let bundle = Bundle(url: appURL) else { return nil }
+        let dictionaries = [bundle.localizedInfoDictionary, bundle.infoDictionary]
+        for dictionary in dictionaries {
+            if let displayName = dictionary?["CFBundleDisplayName"] as? String, !displayName.isEmpty {
+                return displayName
+            }
+            if let bundleName = dictionary?["CFBundleName"] as? String, !bundleName.isEmpty {
+                return bundleName
+            }
+        }
+        return nil
+    }
+}

--- a/ArcBox/Models/ExternalTerminalLauncher.swift
+++ b/ArcBox/Models/ExternalTerminalLauncher.swift
@@ -1,3 +1,4 @@
+import Foundation
 import AppKit
 import Darwin
 import os
@@ -5,18 +6,6 @@ import os
 /// Launches an external terminal app with Docker environment pre-configured.
 enum ExternalTerminalLauncher {
     private static let logger = Log.terminal
-
-    private enum TerminalApp: Sendable {
-        case terminal
-        case iTerm
-
-        var bundleIdentifier: String {
-            switch self {
-            case .terminal: "com.apple.Terminal"
-            case .iTerm: "com.googlecode.iterm2"
-            }
-        }
-    }
 
     /// The Docker socket environment variable value used by ArcBox.
     private static var dockerHost: String {
@@ -26,7 +15,7 @@ enum ExternalTerminalLauncher {
 
     /// Open an external terminal with an optional docker exec command.
     /// - Parameters:
-    ///   - preference: The user's terminal preference: "terminal", "iterm", or "lastUsed".
+    ///   - preference: The user's terminal preference stored by `GeneralSettingsView`.
     ///   - containerID: Optional container ID to exec into.
     ///   - shell: Shell to use (e.g. "/bin/sh"). Only used when containerID is provided.
     static func open(preference: String, containerID: String? = nil, shell: String = "/bin/sh") {
@@ -36,20 +25,9 @@ enum ExternalTerminalLauncher {
 
         openCommandScript(
             scriptURL,
-            terminal: resolveTerminal(preference: preference),
+            terminal: ExternalTerminalDiscovery.resolve(preference: preference),
             fallbackCommand: command
         )
-    }
-
-    private static func resolveTerminal(preference: String) -> TerminalApp {
-        switch preference {
-        case "iterm":
-            .iTerm
-        case "terminal":
-            .terminal
-        default:
-            isITermInstalled() ? .iTerm : .terminal
-        }
     }
 
     private static func makeCommand(containerID: String?, shell: String) -> String {
@@ -92,7 +70,7 @@ enum ExternalTerminalLauncher {
 
     private static func writeCommandScript(_ source: String) -> URL? {
         let scriptURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("arcbox-terminal-\(UUID().uuidString).command")
+            .appending(path: "arcbox-terminal-\(UUID().uuidString).command")
 
         do {
             try source.write(to: scriptURL, atomically: true, encoding: .utf8)
@@ -104,8 +82,12 @@ enum ExternalTerminalLauncher {
         }
     }
 
-    private static func openCommandScript(_ scriptURL: URL, terminal: TerminalApp, fallbackCommand: String) {
-        guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: terminal.bundleIdentifier) else {
+    private static func openCommandScript(
+        _ scriptURL: URL,
+        terminal: ExternalTerminalApp,
+        fallbackCommand: String
+    ) {
+        guard let appURL = terminal.appURL else {
             NSWorkspace.shared.open(scriptURL)
             return
         }
@@ -116,13 +98,17 @@ enum ExternalTerminalLauncher {
             guard let error else { return }
             Task { @MainActor in
                 logger.error("Failed to open command script: \(error.localizedDescription, privacy: .public)")
-                openWithAppleScript(terminal: terminal, command: fallbackCommand)
+                if let backend = terminal.appleScriptBackend {
+                    openWithAppleScript(backend: backend, command: fallbackCommand)
+                } else {
+                    NSWorkspace.shared.open(scriptURL)
+                }
             }
         }
     }
 
-    private static func openWithAppleScript(terminal: TerminalApp, command: String) {
-        switch terminal {
+    private static func openWithAppleScript(backend: ExternalTerminalApp.AppleScriptBackend, command: String) {
+        switch backend {
         case .terminal:
             openTerminalApp(command: command)
         case .iTerm:
@@ -155,10 +141,6 @@ enum ExternalTerminalLauncher {
             end tell
             """
         runAppleScript(script)
-    }
-
-    private static func isITermInstalled() -> Bool {
-        NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.googlecode.iterm2") != nil
     }
 
     // MARK: - Helpers

--- a/ArcBox/Models/ExternalTerminalLauncher.swift
+++ b/ArcBox/Models/ExternalTerminalLauncher.swift
@@ -25,8 +25,7 @@ enum ExternalTerminalLauncher {
 
         openCommandScript(
             scriptURL,
-            terminal: ExternalTerminalDiscovery.resolve(preference: preference),
-            fallbackCommand: command
+            terminal: ExternalTerminalDiscovery.resolve(preference: preference)
         )
     }
 
@@ -84,8 +83,7 @@ enum ExternalTerminalLauncher {
 
     private static func openCommandScript(
         _ scriptURL: URL,
-        terminal: ExternalTerminalApp,
-        fallbackCommand: String
+        terminal: ExternalTerminalApp
     ) {
         guard let appURL = terminal.appURL else {
             NSWorkspace.shared.open(scriptURL)
@@ -99,7 +97,7 @@ enum ExternalTerminalLauncher {
             Task { @MainActor in
                 logger.error("Failed to open command script: \(error.localizedDescription, privacy: .public)")
                 if let backend = terminal.appleScriptBackend {
-                    openWithAppleScript(backend: backend, command: fallbackCommand)
+                    openWithAppleScript(backend: backend, command: fallbackCommand(for: scriptURL))
                 } else {
                     NSWorkspace.shared.open(scriptURL)
                 }
@@ -148,6 +146,10 @@ enum ExternalTerminalLauncher {
     /// Wrap a value in single quotes for safe shell interpolation.
     private static func shellEscape(_ string: String) -> String {
         "'" + string.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    private static func fallbackCommand(for scriptURL: URL) -> String {
+        shellEscape(scriptURL.path)
     }
 
     private static func escapeForAppleScript(_ string: String) -> String {

--- a/ArcBox/Models/ExternalTerminalLauncher.swift
+++ b/ArcBox/Models/ExternalTerminalLauncher.swift
@@ -1,9 +1,22 @@
 import AppKit
+import Darwin
 import os
 
 /// Launches an external terminal app with Docker environment pre-configured.
 enum ExternalTerminalLauncher {
     private static let logger = Log.terminal
+
+    private enum TerminalApp: Sendable {
+        case terminal
+        case iTerm
+
+        var bundleIdentifier: String {
+            switch self {
+            case .terminal: "com.apple.Terminal"
+            case .iTerm: "com.googlecode.iterm2"
+            }
+        }
+    }
 
     /// The Docker socket environment variable value used by ArcBox.
     private static var dockerHost: String {
@@ -17,25 +30,103 @@ enum ExternalTerminalLauncher {
     ///   - containerID: Optional container ID to exec into.
     ///   - shell: Shell to use (e.g. "/bin/sh"). Only used when containerID is provided.
     static func open(preference: String, containerID: String? = nil, shell: String = "/bin/sh") {
-        let command: String
-        if let containerID {
-            command =
-                "export DOCKER_HOST=\(shellEscape(dockerHost)) && docker exec -it \(shellEscape(containerID)) \(shellEscape(shell))"
-        } else {
-            command = "export DOCKER_HOST=\(shellEscape(dockerHost))"
-        }
+        let command = makeCommand(containerID: containerID, shell: shell)
+        let script = makeCommandScript(command: command)
+        guard let scriptURL = writeCommandScript(script) else { return }
 
+        openCommandScript(
+            scriptURL,
+            terminal: resolveTerminal(preference: preference),
+            fallbackCommand: command
+        )
+    }
+
+    private static func resolveTerminal(preference: String) -> TerminalApp {
         switch preference {
         case "iterm":
-            openITerm(command: command)
+            .iTerm
         case "terminal":
-            openTerminalApp(command: command)
-        default:  // "lastUsed" — try iTerm first, fall back to Terminal.app
-            if isITermInstalled() {
-                openITerm(command: command)
-            } else {
-                openTerminalApp(command: command)
+            .terminal
+        default:
+            isITermInstalled() ? .iTerm : .terminal
+        }
+    }
+
+    private static func makeCommand(containerID: String?, shell: String) -> String {
+        let dockerHostExport = "export DOCKER_HOST=\(shellEscape(dockerHost))"
+        guard let dockerPath = DockerCLIResolver.findDockerCLI() else {
+            return [
+                dockerHostExport,
+                "printf '\\nArcBox: Docker CLI not found. Install Docker CLI or make it available at /opt/homebrew/bin/docker or /usr/local/bin/docker.\\n'",
+                "arcbox_status=127",
+            ].joined(separator: "\n")
+        }
+
+        guard let containerID else {
+            return [
+                dockerHostExport,
+                "printf 'ArcBox Docker host configured: %s\\n' \"$DOCKER_HOST\"",
+                "\"${SHELL:-/bin/zsh}\" -l",
+                "arcbox_status=$?",
+            ].joined(separator: "\n")
+        }
+
+        return [
+            dockerHostExport,
+            "\(shellEscape(dockerPath)) exec -it \(shellEscape(containerID)) \(shellEscape(shell))",
+            "arcbox_status=$?",
+            "if [ \"$arcbox_status\" -ne 0 ]; then printf '\\nArcBox: docker exec failed with exit code %s. Check that the container is running and that the selected shell exists.\\n' \"$arcbox_status\"; fi",
+        ].joined(separator: "\n")
+    }
+
+    private static func makeCommandScript(command: String) -> String {
+        [
+            "#!/bin/zsh",
+            "arcbox_script_path=\"$0\"",
+            "trap 'rm -f \"$arcbox_script_path\"' EXIT",
+            command,
+            "if [ \"${arcbox_status:-0}\" -ne 0 ]; then printf '\\nPress return to close this window. '; read -r _; fi",
+            "exit \"${arcbox_status:-0}\"",
+        ].joined(separator: "\n")
+    }
+
+    private static func writeCommandScript(_ source: String) -> URL? {
+        let scriptURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("arcbox-terminal-\(UUID().uuidString).command")
+
+        do {
+            try source.write(to: scriptURL, atomically: true, encoding: .utf8)
+            chmod(scriptURL.path, S_IRUSR | S_IWUSR | S_IXUSR)
+            return scriptURL
+        } catch {
+            logger.error("Failed to write external terminal command: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+
+    private static func openCommandScript(_ scriptURL: URL, terminal: TerminalApp, fallbackCommand: String) {
+        guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: terminal.bundleIdentifier) else {
+            NSWorkspace.shared.open(scriptURL)
+            return
+        }
+
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = true
+        NSWorkspace.shared.open([scriptURL], withApplicationAt: appURL, configuration: configuration) { _, error in
+            guard let error else { return }
+            Task { @MainActor in
+                logger.error("Failed to open command script: \(error.localizedDescription, privacy: .public)")
+                openWithAppleScript(terminal: terminal, command: fallbackCommand)
             }
+        }
+    }
+
+    private static func openWithAppleScript(terminal: TerminalApp, command: String) {
+        switch terminal {
+        case .terminal:
+            openTerminalApp(command: command)
+        case .iTerm:
+            openITerm(command: command)
         }
     }
 

--- a/ArcBox/Views/Settings/GeneralSettingsView.swift
+++ b/ArcBox/Views/Settings/GeneralSettingsView.swift
@@ -25,6 +25,8 @@ struct GeneralSettingsView: View {
     @State private var isExportingDiagnostics = false
     @State private var externalTerminalApps = ExternalTerminalDiscovery.availableTerminals()
     @State private var externalTerminalSelection = ExternalTerminalApp.terminalBundleIdentifier
+    @State private var isShowingExternalTerminalSelectionError = false
+    @State private var externalTerminalSelectionErrorMessage = ""
 
     var body: some View {
         Form {
@@ -130,6 +132,11 @@ struct GeneralSettingsView: View {
             syncLoginItemState()
             refreshExternalTerminalApps()
         }
+        .alert("External terminal not available", isPresented: $isShowingExternalTerminalSelectionError) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(externalTerminalSelectionErrorMessage)
+        }
     }
 
     private func refreshExternalTerminalApps(additionalTerminal: ExternalTerminalApp? = nil) {
@@ -171,16 +178,38 @@ struct GeneralSettingsView: View {
         panel.canChooseDirectories = false
         panel.canChooseFiles = true
 
-        guard panel.runModal() == .OK,
-            let appURL = panel.url,
-            let terminal = ExternalTerminalDiscovery.terminalApp(for: appURL)
-        else {
+        guard panel.runModal() == .OK else {
             externalTerminalSelection = externalTerminal
+            return
+        }
+
+        guard let appURL = panel.url else {
+            externalTerminalSelection = externalTerminal
+            showExternalTerminalSelectionError("No application was selected.")
+            return
+        }
+
+        let commandHandlerBundleIDs = Set(
+            externalTerminalApps.filter(\.supportsCommandFiles).compactMap(\.bundleIdentifier)
+        )
+        guard let terminal = ExternalTerminalDiscovery.terminalApp(
+            for: appURL,
+            commandHandlerBundleIDs: commandHandlerBundleIDs
+        ) else {
+            externalTerminalSelection = externalTerminal
+            showExternalTerminalSelectionError(
+                "ArcBox could not read a bundle identifier from the selected app."
+            )
             return
         }
 
         externalTerminal = terminal.id
         refreshExternalTerminalApps(additionalTerminal: terminal)
+    }
+
+    private func showExternalTerminalSelectionError(_ message: String) {
+        externalTerminalSelectionErrorMessage = message
+        isShowingExternalTerminalSelectionError = true
     }
 
     // MARK: - Login Item

--- a/ArcBox/Views/Settings/GeneralSettingsView.swift
+++ b/ArcBox/Views/Settings/GeneralSettingsView.swift
@@ -1,9 +1,13 @@
-import ArcBoxClient
-import PostHog
 import ServiceManagement
 import SwiftUI
+import UniformTypeIdentifiers
+
+import ArcBoxClient
+import PostHog
 
 struct GeneralSettingsView: View {
+    private static let chooseExternalTerminalID = "__arcbox_choose_external_terminal__"
+
     @Environment(DaemonManager.self) private var daemonManager
     @Environment(ContainersViewModel.self) private var containersVM
     @Environment(ImagesViewModel.self) private var imagesVM
@@ -14,11 +18,13 @@ struct GeneralSettingsView: View {
     @AppStorage("autoUpdate") private var autoUpdate = false
     @AppStorage("updateChannel") private var updateChannel = "stable"
     @AppStorage("terminalTheme") private var terminalTheme = "system"
-    @AppStorage("externalTerminal") private var externalTerminal = "lastUsed"
+    @AppStorage("externalTerminal") private var externalTerminal = ExternalTerminalApp.terminalBundleIdentifier
     @AppStorage("telemetryEnabled") private var telemetryEnabled = true
 
     @State private var isSyncingLoginItem = false
     @State private var isExportingDiagnostics = false
+    @State private var externalTerminalApps = ExternalTerminalDiscovery.availableTerminals()
+    @State private var externalTerminalSelection = ExternalTerminalApp.terminalBundleIdentifier
 
     var body: some View {
         Form {
@@ -72,13 +78,18 @@ struct GeneralSettingsView: View {
                     Text("Dark").tag("dark")
                 }
                 LabeledContent {
-                    Picker("", selection: $externalTerminal) {
-                        Text("Last used").tag("lastUsed")
-                        Text("Terminal").tag("terminal")
-                        Text("iTerm").tag("iterm")
+                    Picker("", selection: $externalTerminalSelection) {
+                        ForEach(externalTerminalApps) { app in
+                            Text(app.displayName).tag(app.id)
+                        }
+                        Divider()
+                        Text("Choose...").tag(Self.chooseExternalTerminalID)
                     }
                     .labelsHidden()
-                    .frame(width: 120)
+                    .fixedSize()
+                    .onChange(of: externalTerminalSelection) { _, newValue in
+                        updateExternalTerminalSelection(newValue)
+                    }
                 } label: {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("External terminal app")
@@ -117,7 +128,59 @@ struct GeneralSettingsView: View {
         .scrollContentBackground(.hidden)
         .onAppear {
             syncLoginItemState()
+            refreshExternalTerminalApps()
         }
+    }
+
+    private func refreshExternalTerminalApps(additionalTerminal: ExternalTerminalApp? = nil) {
+        var terminals = ExternalTerminalDiscovery.availableTerminals(
+            preferredBundleIdentifier: externalTerminal
+        )
+        if let additionalTerminal, !terminals.contains(where: { $0.id == additionalTerminal.id }) {
+            terminals.append(additionalTerminal)
+        }
+        externalTerminalApps = terminals
+
+        let normalized = ExternalTerminalDiscovery.normalizedPreference(
+            externalTerminal,
+            availableTerminals: terminals
+        )
+        if normalized != externalTerminal {
+            externalTerminal = normalized
+        }
+        externalTerminalSelection = normalized
+    }
+
+    private func updateExternalTerminalSelection(_ selection: String) {
+        guard selection != Self.chooseExternalTerminalID else {
+            chooseExternalTerminal()
+            return
+        }
+
+        externalTerminal = selection
+        refreshExternalTerminalApps()
+    }
+
+    private func chooseExternalTerminal() {
+        let panel = NSOpenPanel()
+        panel.title = "Choose External Terminal"
+        panel.prompt = "Choose"
+        panel.directoryURL = URL(fileURLWithPath: "/Applications", isDirectory: true)
+        panel.allowedContentTypes = [.applicationBundle]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+
+        guard panel.runModal() == .OK,
+            let appURL = panel.url,
+            let terminal = ExternalTerminalDiscovery.terminalApp(for: appURL)
+        else {
+            externalTerminalSelection = externalTerminal
+            return
+        }
+
+        externalTerminal = terminal.id
+        refreshExternalTerminalApps(additionalTerminal: terminal)
     }
 
     // MARK: - Login Item


### PR DESCRIPTION
## Summary
- open external terminal sessions through temporary command scripts so container shells execute in the selected terminal
- discover available terminal apps through LaunchServices instead of hardcoded Terminal/iTerm options
- default external terminal selection to Terminal.app and allow manual app selection from /Applications

## Testing
- xcodebuild build -project ArcBox.xcodeproj -scheme ArcBox -configuration Debug SKIP_RUST_BUILD=1 CODE_SIGN_IDENTITY=-