### PR TITLE
refactor(k8s): parse kubeconfig with Yams

### DIFF
--- a/ArcBox.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ArcBox.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3c30451ad72758634b2546911f9832537331532b021053fcb9acf42c46402650",
+  "originHash" : "f0f7b55edd95ed87303e2996a1304bd840405310e11144ee1f67d0f6907c558d",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -330,8 +330,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams",
       "state" : {
-        "revision" : "deaf82e867fa2cbd3cd865978b079bfcf384ac28",
-        "version" : "6.2.1"
+        "revision" : "a27b21e0c81c5bf42049b897a62aaf387e80f279",
+        "version" : "6.2.2"
       }
     }
   ],

--- a/Packages/K8sClient/Package.resolved
+++ b/Packages/K8sClient/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "2ca449a5b93c501c789713138136b5f15efee86adca26da186eb0a501b6f6401",
+  "pins" : [
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "a27b21e0c81c5bf42049b897a62aaf387e80f279",
+        "version" : "6.2.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Packages/K8sClient/Package.swift
+++ b/Packages/K8sClient/Package.swift
@@ -10,7 +10,10 @@ let package = Package(
     products: [
         .library(name: "K8sClient", targets: ["K8sClient"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/jpsim/Yams.git", from: "6.2.2")
+    ],
     targets: [
-        .target(name: "K8sClient")
+        .target(name: "K8sClient", dependencies: ["Yams"])
     ]
 )

--- a/Packages/K8sClient/Sources/K8sClient/KubeConfig/KubeConfig+Exec.swift
+++ b/Packages/K8sClient/Sources/K8sClient/KubeConfig/KubeConfig+Exec.swift
@@ -3,98 +3,32 @@ import Foundation
 extension KubeConfig {
     // MARK: - Exec Credential Plugin
 
-    struct ExecConfig {
+    struct ExecConfig: Decodable {
         let command: String
         let args: [String]
-        let env: [(String, String)]
+        let env: [ExecEnv]
+
+        private enum CodingKeys: String, CodingKey {
+            case command
+            case args
+            case env
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.command = try container.decode(String.self, forKey: .command)
+            self.args = try container.decodeIfPresent([String].self, forKey: .args) ?? []
+            self.env = try container.decodeIfPresent([ExecEnv].self, forKey: .env) ?? []
+        }
     }
 
-    /// Extract the exec credential plugin config from kubeconfig YAML.
-    static func extractExecConfig(from yaml: String) -> ExecConfig? {
-        let lines = yaml.components(separatedBy: .newlines)
-
-        // Find the "exec:" line
-        guard
-            let execIndex = lines.firstIndex(where: {
-                $0.trimmingCharacters(in: .whitespaces).hasPrefix("exec:")
-            })
-        else {
-            return nil
-        }
-
-        // Determine indentation of the exec block's children
-        let execLine = lines[execIndex]
-        let execIndent = execLine.prefix(while: { $0 == " " }).count
-        let childIndent = execIndent + 2  // expected child indentation
-
-        // Collect lines belonging to the exec block
-        var command: String?
-        var args: [String] = []
-        var env: [(String, String)] = []
-        var inArgs = false
-        var inEnv = false
-        var pendingEnvName: String?
-
-        for i in (execIndex + 1)..<lines.count {
-            let line = lines[i]
-            let stripped = line.trimmingCharacters(in: .whitespaces)
-            if stripped.isEmpty { continue }
-
-            let currentIndent = line.prefix(while: { $0 == " " }).count
-            // If we've de-dented back to or past the exec level, stop
-            if currentIndent <= execIndent && !stripped.isEmpty {
-                break
-            }
-
-            // Direct children of exec (at childIndent level)
-            if currentIndent == childIndent {
-                inArgs = false
-                inEnv = false
-
-                if stripped.hasPrefix("command:") {
-                    command = stripped.dropFirst("command:".count)
-                        .trimmingCharacters(in: .whitespaces)
-                        .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-                } else if stripped.hasPrefix("args:") {
-                    inArgs = true
-                } else if stripped.hasPrefix("env:") {
-                    inEnv = true
-                }
-                // Ignore apiVersion, interactiveMode, etc.
-                continue
-            }
-
-            // Deeper children
-            if inArgs && stripped.hasPrefix("- ") {
-                let arg = stripped.dropFirst(2)
-                    .trimmingCharacters(in: .whitespaces)
-                    .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-                args.append(arg)
-            } else if inEnv {
-                if stripped.hasPrefix("- name:") {
-                    pendingEnvName = stripped.dropFirst("- name:".count)
-                        .trimmingCharacters(in: .whitespaces)
-                        .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-                } else if stripped.hasPrefix("name:") {
-                    pendingEnvName = stripped.dropFirst("name:".count)
-                        .trimmingCharacters(in: .whitespaces)
-                        .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-                } else if stripped.hasPrefix("value:"), let name = pendingEnvName {
-                    let value = stripped.dropFirst("value:".count)
-                        .trimmingCharacters(in: .whitespaces)
-                        .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-                    env.append((name, value))
-                    pendingEnvName = nil
-                }
-            }
-        }
-
-        guard let command else { return nil }
-        return ExecConfig(command: command, args: args, env: env)
+    struct ExecEnv: Decodable {
+        let name: String
+        let value: String
     }
 
     /// Run an exec credential plugin command and return the bearer token.
-    static func runExecPlugin(command: String, args: [String], env: [(String, String)]) throws -> String {
+    static func runExecPlugin(command: String, args: [String], env: [ExecEnv]) throws -> String {
         let process = Process()
 
         // Resolve the command path. If it's a bare name, search PATH.
@@ -110,8 +44,8 @@ extension KubeConfig {
 
         // Inherit current environment and overlay exec env vars
         var processEnv = ProcessInfo.processInfo.environment
-        for (name, value) in env {
-            processEnv[name] = value
+        for variable in env {
+            processEnv[variable.name] = variable.value
         }
         process.environment = processEnv
 

--- a/Packages/K8sClient/Sources/K8sClient/KubeConfig/KubeConfig+Parsing.swift
+++ b/Packages/K8sClient/Sources/K8sClient/KubeConfig/KubeConfig+Parsing.swift
@@ -36,6 +36,14 @@ extension KubeConfig {
             case contexts
             case users
         }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            currentContext = try container.decodeIfPresent(String.self, forKey: .currentContext)
+            clusters = try container.decodeIfPresent([NamedCluster].self, forKey: .clusters) ?? []
+            contexts = try container.decodeIfPresent([NamedContext].self, forKey: .contexts)
+            users = try container.decodeIfPresent([NamedUser].self, forKey: .users) ?? []
+        }
     }
 
     struct NamedCluster: Decodable {
@@ -44,8 +52,8 @@ extension KubeConfig {
     }
 
     struct Cluster: Decodable {
-        let server: String
-        let certificateAuthorityData: String
+        let server: String?
+        let certificateAuthorityData: String?
 
         enum CodingKeys: String, CodingKey {
             case server

--- a/Packages/K8sClient/Sources/K8sClient/KubeConfig/KubeConfig+Parsing.swift
+++ b/Packages/K8sClient/Sources/K8sClient/KubeConfig/KubeConfig+Parsing.swift
@@ -1,23 +1,11 @@
 import Foundation
+import Yams
 
 extension KubeConfig {
     // MARK: - Private
 
-    /// Extract the first value for a given YAML key from the raw string.
-    /// Handles both `key: value` and `key: "value"` forms.
-    static func extractValue(for key: String, from yaml: String) -> String? {
-        for line in yaml.components(separatedBy: .newlines) {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            guard trimmed.hasPrefix(key) else { continue }
-            var value = String(trimmed.dropFirst(key.count))
-                .trimmingCharacters(in: .whitespaces)
-            // Strip surrounding quotes if present
-            if value.hasPrefix("\"") && value.hasSuffix("\"") && value.count >= 2 {
-                value = String(value.dropFirst().dropLast())
-            }
-            if !value.isEmpty { return value }
-        }
-        return nil
+    static func parseKubeConfigDocument(from yaml: String) throws -> KubeConfigDocument {
+        try YAMLDecoder().decode(KubeConfigDocument.self, from: yaml)
     }
 
     /// Convert PEM-encoded data to DER by stripping headers and decoding inner base64.
@@ -34,6 +22,62 @@ extension KubeConfig {
             .filter { !$0.hasPrefix("-----") }
             .joined()
         return Data(base64Encoded: base64) ?? data
+    }
+
+    struct KubeConfigDocument: Decodable {
+        let currentContext: String?
+        let clusters: [NamedCluster]
+        let contexts: [NamedContext]?
+        let users: [NamedUser]
+
+        enum CodingKeys: String, CodingKey {
+            case currentContext = "current-context"
+            case clusters
+            case contexts
+            case users
+        }
+    }
+
+    struct NamedCluster: Decodable {
+        let name: String
+        let cluster: Cluster
+    }
+
+    struct Cluster: Decodable {
+        let server: String
+        let certificateAuthorityData: String
+
+        enum CodingKeys: String, CodingKey {
+            case server
+            case certificateAuthorityData = "certificate-authority-data"
+        }
+    }
+
+    struct NamedContext: Decodable {
+        let name: String
+        let context: Context
+    }
+
+    struct Context: Decodable {
+        let cluster: String
+        let user: String
+    }
+
+    struct NamedUser: Decodable {
+        let name: String
+        let user: User
+    }
+
+    struct User: Decodable {
+        let clientCertificateData: String?
+        let clientKeyData: String?
+        let exec: ExecConfig?
+
+        enum CodingKeys: String, CodingKey {
+            case clientCertificateData = "client-certificate-data"
+            case clientKeyData = "client-key-data"
+            case exec
+        }
     }
 
 }

--- a/Packages/K8sClient/Sources/K8sClient/KubeConfig/KubeConfig.swift
+++ b/Packages/K8sClient/Sources/K8sClient/KubeConfig/KubeConfig.swift
@@ -35,23 +35,40 @@ public struct KubeConfig: Sendable {
             document.contexts?.first { $0.name == currentContext }?.context
         }
 
-        let cluster = context.flatMap { context in
-            document.clusters.first { $0.name == context.cluster }
-        } ?? document.clusters.first
+        let cluster: KubeConfig.NamedCluster?
+        if let context {
+            cluster = document.clusters.first { $0.name == context.cluster }
+            guard cluster != nil else {
+                throw KubeConfigError.missingField("cluster \(context.cluster)")
+            }
+        } else {
+            cluster = document.clusters.first
+        }
 
         guard let cluster else {
             throw KubeConfigError.missingField("server")
         }
-        guard let caData = Data(base64Encoded: cluster.cluster.certificateAuthorityData) else {
+        guard let server = cluster.cluster.server else {
+            throw KubeConfigError.missingField("server")
+        }
+        guard let caB64 = cluster.cluster.certificateAuthorityData,
+            let caData = Data(base64Encoded: caB64)
+        else {
             throw KubeConfigError.missingField("certificate-authority-data")
         }
 
-        self.server = cluster.cluster.server
+        self.server = server
         self.certificateAuthorityData = caData
 
-        let user = context.flatMap { context in
-            document.users.first { $0.name == context.user }
-        } ?? document.users.first
+        let user: KubeConfig.NamedUser?
+        if let context {
+            user = document.users.first { $0.name == context.user }
+            guard user != nil else {
+                throw KubeConfigError.missingField("user \(context.user)")
+            }
+        } else {
+            user = document.users.first
+        }
 
         // Try certificate auth first
         let certB64 = user?.user.clientCertificateData

--- a/Packages/K8sClient/Sources/K8sClient/KubeConfig/KubeConfig.swift
+++ b/Packages/K8sClient/Sources/K8sClient/KubeConfig/KubeConfig.swift
@@ -30,21 +30,32 @@ public struct KubeConfig: Sendable {
     ///
     /// If both are present, certificate auth takes precedence.
     public init(yaml: String) throws {
-        guard let server = Self.extractValue(for: "server:", from: yaml) else {
+        let document = try Self.parseKubeConfigDocument(from: yaml)
+        let context = document.currentContext.flatMap { currentContext in
+            document.contexts?.first { $0.name == currentContext }?.context
+        }
+
+        let cluster = context.flatMap { context in
+            document.clusters.first { $0.name == context.cluster }
+        } ?? document.clusters.first
+
+        guard let cluster else {
             throw KubeConfigError.missingField("server")
         }
-        guard let caB64 = Self.extractValue(for: "certificate-authority-data:", from: yaml),
-            let caData = Data(base64Encoded: caB64)
-        else {
+        guard let caData = Data(base64Encoded: cluster.cluster.certificateAuthorityData) else {
             throw KubeConfigError.missingField("certificate-authority-data")
         }
 
-        self.server = server
+        self.server = cluster.cluster.server
         self.certificateAuthorityData = caData
 
+        let user = context.flatMap { context in
+            document.users.first { $0.name == context.user }
+        } ?? document.users.first
+
         // Try certificate auth first
-        let certB64 = Self.extractValue(for: "client-certificate-data:", from: yaml)
-        let keyB64 = Self.extractValue(for: "client-key-data:", from: yaml)
+        let certB64 = user?.user.clientCertificateData
+        let keyB64 = user?.user.clientKeyData
 
         if let certB64, let keyB64,
             let certData = Data(base64Encoded: certB64),
@@ -57,7 +68,7 @@ public struct KubeConfig: Sendable {
         }
 
         // Fall back to exec credential plugin
-        let exec = Self.extractExecConfig(from: yaml)
+        let exec = user?.user.exec
         if let exec {
             let token = try Self.runExecPlugin(
                 command: exec.command,


### PR DESCRIPTION
## Summary
- add Yams to K8sClient
- replace hand-written kubeconfig YAML scanning with typed YAML decoding
- keep the existing K8sClient app-facing API and lightweight Pod/Service models

## Why not Swiftkube in this PR
Swiftkube would be a broader app-facing rewrite. This keeps the PR small while deleting the brittle hand-written YAML parser.

## Validation
- xcodebuild -resolvePackageDependencies -project ArcBox.xcodeproj -scheme ArcBox
- swift build from Packages/K8sClient
- /usr/bin/env -u DEVELOPER_DIR -u SDKROOT -u CC -u CXX -u LD PATH=/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin xcodebuild test -project ArcBox.xcodeproj -scheme ArcBox -configuration Debug -destination 'platform=macOS' -skipPackagePluginValidation CODE_SIGN_IDENTITY=- SKIP_RUST_BUILD=1

## Note
This PR targets refactor/xcodegen-cleanup-base because local master contains the preceding cleanup commits that are not on origin/master yet.