### PR TITLE
refactor(terminal): use SwiftTerm resize helper

### DIFF
--- a/ArcBox/Models/DockerTerminalSession.swift
+++ b/ArcBox/Models/DockerTerminalSession.swift
@@ -104,7 +104,7 @@ class DockerTerminalSession {
         var winSize = winsize()
         winSize.ws_col = UInt16(cols)
         winSize.ws_row = UInt16(rows)
-        _ = ioctl(primary, TIOCSWINSZ, &winSize)
+        _ = PseudoTerminalHelpers.setWinSize(masterPtyDescriptor: primary, windowSize: &winSize)
 
         // Configure process — use pstramp when available for proper
         // session isolation and controlling-terminal setup.
@@ -194,7 +194,7 @@ class DockerTerminalSession {
         var winSize = winsize()
         winSize.ws_col = UInt16(cols)
         winSize.ws_row = UInt16(rows)
-        _ = ioctl(fd, TIOCSWINSZ, &winSize)
+        _ = PseudoTerminalHelpers.setWinSize(masterPtyDescriptor: fd, windowSize: &winSize)
     }
 
     /// Disconnect and clean up the session.


### PR DESCRIPTION
## Summary
- use SwiftTerm's PseudoTerminalHelpers for PTY window resizing
- preserve the existing TerminalView/TerminalBridge integration
- preserve docker exec/run behavior, DOCKER_HOST, TERM, pstramp wrapping, disconnect, and state transitions

## Why this scope
LocalProcessTerminalView is not a safe drop-in because it owns terminal delegate behavior and would require a broader UI/process rewrite. This PR takes the safe deletion-backed step using the dependency already present.

## Validation
- git diff --check
- /usr/bin/env -u DEVELOPER_DIR -u SDKROOT -u CC -u CXX -u LD PATH=/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin xcodebuild test -project ArcBox.xcodeproj -scheme ArcBox -configuration Debug -destination 'platform=macOS' -skipPackagePluginValidation CODE_SIGN_IDENTITY=- SKIP_RUST_BUILD=1

## Note
This PR targets refactor/xcodegen-cleanup-base because local master contains the preceding cleanup commits that are not on origin/master yet.