### PR TITLE
ci: create Local.xcconfig for PR checks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: arcboxlabs/arcbox
-          path: arcbox
+          path: daemon-source
           # Pin to the embedded arcbox version so the drift check matches the
           # daemon the app ships with (see Packages/ArcBoxClient/generate.sh).
           ref: ${{ steps.protoref.outputs.ref }}
@@ -60,7 +60,7 @@ jobs:
           # can find proto at the expected relative path even if cache restore
           # previously created ../arcbox as a real directory.
           rm -rf "$GITHUB_WORKSPACE/../arcbox"
-          ln -s "$GITHUB_WORKSPACE/arcbox" "$GITHUB_WORKSPACE/../arcbox"
+          ln -s "$GITHUB_WORKSPACE/daemon-source" "$GITHUB_WORKSPACE/../arcbox"
 
           # Generate Swift code from local proto definitions
           cd Packages/ArcBoxClient
@@ -85,6 +85,15 @@ jobs:
         run: |
           brew install swiftlint
           swiftlint lint --strict --config .swiftlint.yml
+
+      - name: Create local Xcode config
+        run: |
+          cat > Local.xcconfig <<'XCEOF'
+          #include "Version.xcconfig"
+          DEVELOPMENT_TEAM = 422ACSY6Y5
+          SENTRY_DSN =
+          POSTHOG_API_KEY =
+          XCEOF
 
       - name: Generate Xcode project
         run: |

--- a/ArcBox/Views/Settings/GeneralSettingsView.swift
+++ b/ArcBox/Views/Settings/GeneralSettingsView.swift
@@ -1,9 +1,8 @@
+import ArcBoxClient
+import PostHog
 import ServiceManagement
 import SwiftUI
 import UniformTypeIdentifiers
-
-import ArcBoxClient
-import PostHog
 
 struct GeneralSettingsView: View {
     private static let chooseExternalTerminalID = "__arcbox_choose_external_terminal__"
@@ -192,10 +191,12 @@ struct GeneralSettingsView: View {
         let commandHandlerBundleIDs = Set(
             externalTerminalApps.filter(\.supportsCommandFiles).compactMap(\.bundleIdentifier)
         )
-        guard let terminal = ExternalTerminalDiscovery.terminalApp(
-            for: appURL,
-            commandHandlerBundleIDs: commandHandlerBundleIDs
-        ) else {
+        guard
+            let terminal = ExternalTerminalDiscovery.terminalApp(
+                for: appURL,
+                commandHandlerBundleIDs: commandHandlerBundleIDs
+            )
+        else {
             externalTerminalSelection = externalTerminal
             showExternalTerminalSelectionError(
                 "ArcBox could not read a bundle identifier from the selected app."


### PR DESCRIPTION
## Summary
- create a minimal CI-only Local.xcconfig before running XcodeGen in PR checks
- keeps Local.xcconfig gitignored for developers while allowing project generation in CI

## Why
After XcodeGen became required in PR checks, CI failed before build/test because project.yml references Local.xcconfig and the file is intentionally not committed.

## Validation
- Created the same Local.xcconfig locally and confirmed xcodegen generate completes.