### PR TITLE
fix(protobuf): make arcbox version bumps atomic

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,45 +36,10 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - name: Resolve arcbox proto ref
-        id: protoref
-        run: echo "ref=$(tr -d '[:space:]' < arcbox.version)" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout arcbox proto definitions
-        uses: actions/checkout@v4
-        with:
-          repository: arcboxlabs/arcbox
-          path: daemon-source
-          # Pin to the embedded arcbox version so the drift check matches the
-          # daemon the app ships with (see Packages/ArcBoxClient/generate.sh).
-          ref: ${{ steps.protoref.outputs.ref }}
-          sparse-checkout: rpc/arcbox-protocol/proto
-          sparse-checkout-cone-mode: false
-
       - name: Verify protobuf generated code is up-to-date
         run: |
-          # Install protoc via Homebrew
           brew install protobuf
-
-          # Recreate the sibling arcbox path as a symlink so generate.sh --local
-          # can find proto at the expected relative path even if cache restore
-          # previously created ../arcbox as a real directory.
-          rm -rf "$GITHUB_WORKSPACE/../arcbox"
-          ln -s "$GITHUB_WORKSPACE/daemon-source" "$GITHUB_WORKSPACE/../arcbox"
-
-          # Generate Swift code from local proto definitions
-          cd Packages/ArcBoxClient
-          ./generate.sh --local
-
-          # Fail if generated files differ from checked-in versions (including untracked files)
-          if ! git diff --exit-code Sources/ArcBoxClient/Generated/; then
-            echo "::error::Protobuf generated Swift files are out of date. Run 'cd Packages/ArcBoxClient && ./generate.sh' and commit the result."
-            exit 1
-          fi
-          if [ -n "$(git ls-files --others --exclude-standard Sources/ArcBoxClient/Generated/)" ]; then
-            echo "::error::Untracked generated files detected. Run 'cd Packages/ArcBoxClient && ./generate.sh' and commit all generated files."
-            exit 1
-          fi
+          make verify-arcbox-protobuf
 
       - name: Swift format check
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
 - **Packages/K8sClient** — Kubernetes API client with kubeconfig + exec-based auth
 - Daemon (`arcbox-daemon`) is a separate Rust binary from the `../arcbox` repo; communicates via gRPC over `~/.arcbox/run/arcbox.sock`
 - Entitlements for the daemon live in `../arcbox/bundle/arcbox.entitlements` (single source of truth)
+- When bumping the embedded daemon version, use `make bump-arcbox VERSION=vX.Y.Z` so `arcbox.version` and generated protobuf client code are updated atomically
 
 ## Daemon Signing
 - The daemon MUST be signed with Developer ID, not Xcode's Apple Development certificate

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 #
 # Local:
 #   make generate-xcodeproj
+#   make bump-arcbox VERSION=v0.4.12
 #   make dmg-signed
 #
 # CI:
@@ -24,12 +25,16 @@ PROVISIONING_PROFILE ?=
 
 ABCTL := $(ARCBOX_DIR)/target/release/abctl
 
-.PHONY: generate-xcodeproj build-rust prefetch dmg dmg-signed dmg-release clean help
+.PHONY: generate-xcodeproj bump-arcbox verify-arcbox-protobuf build-rust prefetch dmg dmg-signed dmg-release clean help
 
 help:
 	@echo "ArcBox build targets:"
 	@echo ""
 	@echo "  make generate-xcodeproj  Regenerate ArcBox.xcodeproj from project.yml"
+	@echo "  make bump-arcbox VERSION=vX.Y.Z"
+	@echo "                         Update arcbox.version and regenerate protobuf client"
+	@echo "  make verify-arcbox-protobuf"
+	@echo "                         Verify generated protobuf client matches arcbox.version"
 	@echo "  make build-rust     Build arcbox binaries (release)"
 	@echo "  make prefetch       Download boot assets + Docker tools"
 	@echo "  make dmg            Package unsigned DMG (local testing)"
@@ -45,6 +50,18 @@ help:
 
 generate-xcodeproj:
 	xcodegen generate
+
+## ── ArcBox Protocol ───────────────────────────────────
+
+bump-arcbox:
+	@if [ -z "$(VERSION)" ]; then \
+		echo "ERROR: VERSION is required, e.g. make bump-arcbox VERSION=v0.4.12" >&2; \
+		exit 1; \
+	fi
+	cargo xtask protocol bump --version "$(VERSION)"
+
+verify-arcbox-protobuf:
+	cargo xtask protocol verify
 
 ## ── Prerequisites ─────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ cargo build --release -p arcbox-daemon
 cargo build --release -p arcbox-agent --target aarch64-unknown-linux-musl
 ```
 
+When bumping the embedded ArcBox daemon version, update `arcbox.version` and the generated gRPC client in the same change:
+
+```bash
+make bump-arcbox VERSION=v0.4.12
+```
+
+This wraps `cargo xtask protocol bump --version v0.4.12`, which restores the previous `arcbox.version` and generated client if generation fails. CI verifies this with `make verify-arcbox-protobuf`.
+
 ## Project Structure
 
 ```

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -16,6 +16,7 @@ repo root and never joins a parent `cargo build`. Requires a Rust toolchain on
 
 ```sh
 cargo xtask release appcast --help
+cargo xtask protocol bump --version v0.4.12
 cargo xtask macos dmg --sign "Developer ID Application: …" --notarize
 ```
 
@@ -26,6 +27,8 @@ cargo xtask macos dmg --sign "Developer ID Application: …" --notarize
 | `macos embed` | Embed arcbox Rust binaries into the app bundle. Runs from the Xcode "Embed Arcbox Binaries" build phase; env-driven (`PROJECT_DIR`, `BUILT_PRODUCTS_DIR`, `SKIP_RUST_BUILD`, …). |
 | `macos bundle` | Wrap the `arcbox-daemon` binary in a minimal signed `.app` (its own `embedded.provisionprofile` for AMFI). |
 | `macos dmg` | Build `ArcBox.app`, embed assets/binaries, bundle + sign the daemon, deep-sign, package the DMG, and notarize. Injects `PostHogAPIKey`/`SentryDSN`/`SUPublicEDKey` into Info.plist. |
+| `protocol bump` | Update `arcbox.version` and regenerate the Swift protobuf client atomically. |
+| `protocol verify` | Regenerate the Swift protobuf client from `arcbox.version` and fail if checked-in generated files drift. |
 | `release appcast` | Generate or merge a Sparkle 2.x appcast XML feed. |
 | `release latest-json` | Update the `latest.json` channel manifest. |
 
@@ -37,6 +40,7 @@ src/
   commands/
     macos.rs              dispatch: embed / bundle / dmg (macOS-gated)
     macos/{embed,bundle,dmg}.rs
+    protocol.rs           arcbox.version + protobuf client codegen
     release.rs            dispatch: appcast / latest-json
     release/{appcast,latest_json}.rs
   support/fs.rs           generic helpers shared by macOS commands

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -1,2 +1,3 @@
 pub mod macos;
+pub mod protocol;
 pub mod release;

--- a/xtask/src/commands/protocol.rs
+++ b/xtask/src/commands/protocol.rs
@@ -1,0 +1,167 @@
+//! ArcBox protocol client generation tasks.
+
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use tempfile::TempDir;
+use xtask_kit::repo;
+
+use crate::{ProtocolArgs, ProtocolCommand, ProtocolVerifyArgs};
+
+pub fn run(args: ProtocolArgs) -> Result<()> {
+    match args.command {
+        ProtocolCommand::Bump(args) => bump(&args.version),
+        ProtocolCommand::Verify(args) => verify(args),
+    }
+}
+
+fn bump(version: &str) -> Result<()> {
+    let root = repo_root()?;
+    let snapshot = ProtocolSnapshot::capture(&root)?;
+    std::fs::write(root.join("arcbox.version"), format!("{version}\n"))
+        .context("writing arcbox.version")?;
+
+    if let Err(error) = run_generate(&root) {
+        snapshot.restore(&root)?;
+        bail!("protobuf generation failed; restored arcbox.version and Generated/: {error:#}");
+    }
+
+    Ok(())
+}
+
+fn verify(_args: ProtocolVerifyArgs) -> Result<()> {
+    let root = repo_root()?;
+    run_generate(&root)?;
+
+    let generated = "Packages/ArcBoxClient/Sources/ArcBoxClient/Generated/";
+    if !run_status(&root, "git", ["diff", "--exit-code", generated])? {
+        bail!(
+            "Protobuf generated Swift files are out of date. Run: cargo xtask protocol bump --version {}",
+            current_arcbox_version(&root)?
+        );
+    }
+
+    let output = Command::new("git")
+        .current_dir(&root)
+        .args(["ls-files", "--others", "--exclude-standard", generated])
+        .output()
+        .context("running git ls-files")?;
+    if !output.status.success() {
+        bail!("git ls-files failed with status {}", output.status);
+    }
+    if !output.stdout.is_empty() {
+        eprint!("{}", String::from_utf8_lossy(&output.stdout));
+        bail!(
+            "Untracked generated protobuf files detected. Run: cargo xtask protocol bump --version {}",
+            current_arcbox_version(&root)?
+        );
+    }
+
+    Ok(())
+}
+
+fn repo_root() -> Result<PathBuf> {
+    repo::root_from_xtask_manifest(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn current_arcbox_version(root: &Path) -> Result<String> {
+    let version = std::fs::read_to_string(root.join("arcbox.version"))
+        .context("reading arcbox.version")?
+        .split_whitespace()
+        .collect::<String>();
+    Ok(version)
+}
+
+fn run_generate(root: &Path) -> Result<()> {
+    let status = Command::new("./generate.sh")
+        .arg("--remote")
+        .current_dir(root.join("Packages/ArcBoxClient"))
+        .status()
+        .context("running Packages/ArcBoxClient/generate.sh --remote")?;
+
+    if !status.success() {
+        bail!("generate.sh failed with status {status}");
+    }
+    Ok(())
+}
+
+fn run_status<const N: usize>(root: &Path, program: &str, args: [&str; N]) -> Result<bool> {
+    let status = Command::new(program)
+        .current_dir(root)
+        .args(args)
+        .status()
+        .with_context(|| format!("running {program}"))?;
+    Ok(status.success())
+}
+
+struct ProtocolSnapshot {
+    temp_dir: TempDir,
+    arcbox_version: Option<String>,
+}
+
+impl ProtocolSnapshot {
+    fn capture(root: &Path) -> Result<Self> {
+        let temp_dir = tempfile::tempdir().context("creating protocol snapshot directory")?;
+        let generated = generated_dir(root);
+        let snapshot_generated = temp_dir.path().join("Generated");
+
+        if generated.exists() {
+            copy_dir_files(&generated, &snapshot_generated)?;
+        }
+
+        let arcbox_version = std::fs::read_to_string(root.join("arcbox.version")).ok();
+        Ok(Self {
+            temp_dir,
+            arcbox_version,
+        })
+    }
+
+    fn restore(&self, root: &Path) -> Result<()> {
+        match &self.arcbox_version {
+            Some(version) => std::fs::write(root.join("arcbox.version"), version)
+                .context("restoring arcbox.version")?,
+            None => match std::fs::remove_file(root.join("arcbox.version")) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error).context("removing arcbox.version"),
+            },
+        }
+
+        let generated = generated_dir(root);
+        if generated.exists() {
+            std::fs::remove_dir_all(&generated)
+                .with_context(|| format!("removing {}", generated.display()))?;
+        }
+        let snapshot_generated = self.temp_dir.path().join("Generated");
+        if snapshot_generated.exists() {
+            copy_dir_files(&snapshot_generated, &generated)?;
+        } else {
+            std::fs::create_dir_all(&generated)
+                .with_context(|| format!("creating {}", generated.display()))?;
+        }
+
+        Ok(())
+    }
+}
+
+fn generated_dir(root: &Path) -> PathBuf {
+    root.join("Packages/ArcBoxClient/Sources/ArcBoxClient/Generated")
+}
+
+fn copy_dir_files(src: &Path, dst: &Path) -> Result<()> {
+    std::fs::create_dir_all(dst).with_context(|| format!("creating {}", dst.display()))?;
+    for entry in std::fs::read_dir(src).with_context(|| format!("reading {}", src.display()))? {
+        let entry = entry.with_context(|| format!("reading entry under {}", src.display()))?;
+        let path = entry.path();
+        let target = dst.join(entry.file_name());
+        if path.is_dir() {
+            copy_dir_files(&path, &target)?;
+        } else if path.extension() == Some(OsStr::new("swift")) {
+            std::fs::copy(&path, &target)
+                .with_context(|| format!("copying {} -> {}", path.display(), target.display()))?;
+        }
+    }
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -23,6 +23,8 @@ struct Cli {
 enum Command {
     /// macOS build, bundling, signing, and packaging tasks.
     Macos(MacosArgs),
+    /// ArcBox protocol client generation and verification tasks.
+    Protocol(ProtocolArgs),
     /// Release metadata generation (Sparkle appcast, latest.json).
     Release(ReleaseArgs),
 }
@@ -99,6 +101,32 @@ struct MacosDmgArgs {
     #[arg(long, env = "SPARKLE_PUBLIC_KEY")]
     sparkle_public_key: Option<String>,
 }
+
+// ── protocol ────────────────────────────────────────────────────────────────
+
+#[derive(Args)]
+struct ProtocolArgs {
+    #[command(subcommand)]
+    command: ProtocolCommand,
+}
+
+#[derive(Subcommand)]
+enum ProtocolCommand {
+    /// Update arcbox.version and regenerate the Swift protobuf client atomically.
+    Bump(ProtocolBumpArgs),
+    /// Verify the generated Swift protobuf client matches arcbox.version.
+    Verify(ProtocolVerifyArgs),
+}
+
+#[derive(Args)]
+struct ProtocolBumpArgs {
+    /// Embedded arcbox daemon version tag, e.g. v0.4.12.
+    #[arg(long, env = "VERSION")]
+    version: String,
+}
+
+#[derive(Args)]
+struct ProtocolVerifyArgs {}
 
 // ── release ────────────────────────────────────────────────────────────────--
 
@@ -198,6 +226,7 @@ fn main() {
 fn run() -> Result<()> {
     match Cli::parse().command {
         Command::Macos(args) => commands::macos::run(args),
+        Command::Protocol(args) => commands::protocol::run(args),
         Command::Release(args) => commands::release::run(args),
     }
 }


### PR DESCRIPTION
## Summary
- add make bump-arcbox VERSION=... as the canonical daemon version bump workflow
- add make verify-arcbox-protobuf for local and CI drift checks
- make PR CI call the Makefile verification target and document the atomic bump flow

## Verification
- make help
- env -u SDKROOT -u DEVELOPER_DIR make verify-arcbox-protobuf
- make bump-arcbox (expected failure without VERSION)