### PR TITLE
ci(release): sync shipped issues to Linear Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -700,3 +700,32 @@ jobs:
           git add "$CASK"
           git commit -m "arcbox ${VERSION}"
           git push
+
+  # ==========================================================================
+  # Sync shipped issues to Linear Releases (continuous, per Sparkle channel)
+  #
+  # Runs after the DMG is live on the CDN/appcast, so each Linear release records
+  # what actually reached users on that channel via Sparkle auto-update — the
+  # real "delivered" signal, distinct from a merged PR. stable and beta map to
+  # separate Linear pipelines (separate baselines); alpha/rc builds are skipped.
+  # Issues are associated by scanning commits since the previous release for PR
+  # references (#NNN, which Linear resolves to their linked issues) and ABXD-123
+  # identifiers. Requires the LINEAR_ACCESS_KEY_STABLE / LINEAR_ACCESS_KEY_BETA
+  # secrets (each pipeline's access key from Linear → Settings → Releases).
+  # ==========================================================================
+  linear-release:
+    name: Sync Linear Release
+    needs: [build-dmg, upload-cdn]
+    if: contains(fromJSON('["stable", "beta"]'), needs.build-dmg.outputs.channel)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # full history required for commit-range scanning
+
+      - uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ needs.build-dmg.outputs.channel == 'stable' && secrets.LINEAR_ACCESS_KEY_STABLE || secrets.LINEAR_ACCESS_KEY_BETA }}
+          version: ${{ needs.build-dmg.outputs.version }}
+          links: https://github.com/${{ github.repository }}/releases/tag/${{ needs.build-dmg.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -702,22 +702,24 @@ jobs:
           git push
 
   # ==========================================================================
-  # Sync shipped issues to Linear Releases (continuous, per Sparkle channel)
+  # Sync shipped issues to Linear Releases (continuous, stable channel only)
   #
   # Runs after the DMG is live on the CDN/appcast, so each Linear release records
-  # what actually reached users on that channel via Sparkle auto-update — the
-  # real "delivered" signal, distinct from a merged PR. stable and beta map to
-  # separate Linear pipelines (separate baselines); alpha/rc builds are skipped.
-  # Issues are associated by scanning commits since the previous release for PR
-  # references (#NNN, which Linear resolves to their linked issues) and ABXD-123
-  # identifiers. Requires the LINEAR_ACCESS_KEY_STABLE / LINEAR_ACCESS_KEY_BETA
-  # secrets (each pipeline's access key from Linear → Settings → Releases).
+  # what actually reached stable users via Sparkle auto-update — the real
+  # "delivered" signal, distinct from a merged PR. Only the stable channel is
+  # tracked; alpha/beta/rc builds are skipped. Issues are associated by scanning
+  # commits since the previous release for PR references (#NNN, which Linear
+  # resolves to their linked issues) and ABXD-123 identifiers. Requires the
+  # LINEAR_ACCESS_KEY secret (the pipeline's access key from Linear → Settings →
+  # Releases; not a personal API key).
   # ==========================================================================
   linear-release:
     name: Sync Linear Release
     needs: [build-dmg, upload-cdn]
-    if: contains(fromJSON('["stable", "beta"]'), needs.build-dmg.outputs.channel)
+    if: needs.build-dmg.outputs.channel == 'stable'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -726,6 +728,6 @@ jobs:
 
       - uses: linear/linear-release-action@v0
         with:
-          access_key: ${{ needs.build-dmg.outputs.channel == 'stable' && secrets.LINEAR_ACCESS_KEY_STABLE || secrets.LINEAR_ACCESS_KEY_BETA }}
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           version: ${{ needs.build-dmg.outputs.version }}
           links: https://github.com/${{ github.repository }}/releases/tag/${{ needs.build-dmg.outputs.version }}


### PR DESCRIPTION
## What

Adds a `linear-release` job to `release.yml` that syncs each shipped **stable** DMG to a **Linear Release** ([docs](https://linear.app/docs/releases)). It runs after `upload-cdn`, so a release in Linear records what actually reached stable users via Sparkle auto-update — the real "delivered" signal, distinct from a merged PR.

Uses [`linear/linear-release-action`](https://github.com/linear/linear-release-action). Continuous pipeline model, **stable channel only** (one pipeline, one key); `alpha`/`beta`/`rc` builds are skipped via the `if:` gate. Issues are associated by scanning commits since the previous release for PR refs `(#NNN)` (Linear resolves these to their linked issues) and `ABXD-123` identifiers.

## Required setup before this runs

1. **Linear → Settings → Releases**: create one continuous pipeline (e.g. `ArcBox Desktop`), owner = Desktop team.
2. Generate its **access key** and add it as the repo secret **`LINEAR_ACCESS_KEY`** (Settings → Secrets and variables → Actions). Pipeline key, *not* a personal API key.
3. (Optional) In Linear, add a status automation: *on release completion → move associated issues to Done (Released)*. Combined with the existing Git automation (PR merge → In Review), this gives the merged-vs-shipped distinction.

The job has `permissions: contents: read` and only runs on stable builds; until the secret exists it fails fast. It's a leaf job, so no other release steps are affected.

## Notes / caveats

- A DMG bundles a pinned `arcbox` daemon version, so it also delivers **ABX** (core) changes. This job only associates **ABXD** (desktop) issues from this repo's commits. Attaching the core issues actually delivered in the DMG is a worthwhile follow-up (run the action a second time against the bundled `arcbox-core` checkout with a `base_ref` of the previously shipped daemon ref).
- **Coverage depends on commit history**: changes via a Linear-linked PR (squash subject keeps the default `(#NNN)`) associate; direct pushes without a PR number or issue key won't.
- **First run** uses a fallback baseline and may sweep a large history range. Consider `dry_run: true` for one run to preview before going live.

## Review feedback addressed

- **P1 (key fallthrough)** — resolved by collapsing to a single stable pipeline: no more `&&`/`||` channel ternary, so a missing secret can no longer silently route a stable release into the beta pipeline.
- **CodeQL (token perms)** — added `permissions: contents: read`.
- **P2 (unpinned `@v0`)** — left as a floating tag for now, consistent with the other actions in this workflow (`actions/checkout@v6`, `softprops/action-gh-release@v2`, …); SHA-pinning is best decided repo-wide.