### PR TITLE
feat(app): register arcbox:// URL scheme and route deep links

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		B52AB7A6781786A6ECB4B59E /* ArcBoxApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DD9A9FA0D6072FD4476A91 /* ArcBoxApp.swift */; };
 		B8F04FD5D42B1934B13D9D3A /* PodDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B38661BA5859384BCCE61B0C /* PodDetailView.swift */; };
 		B91D470DA46003D64389C7DE /* AppColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62FD6244C56EE8E45DF0EC7 /* AppColors.swift */; };
+		BA3195811383AD00D29B32AE /* DeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ADF9F8FFB694C45042664E8 /* DeepLink.swift */; };
 		BA8E4BE30E5FBB6B8548E214 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657D7543F1D47988AEC3339D /* AppDelegate.swift */; };
 		BB31DD543E7E07965B68C0A4 /* ContainerRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33B6873C4DDA948830B9EEC /* ContainerRowView.swift */; };
 		BB6DA9C1B509BF12CDA5A92E /* ImageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185A238D021D6C976574528C /* ImageDetailView.swift */; };
@@ -155,6 +156,7 @@
 		D0518D07973520530916560B /* ServiceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F238F21169A97B94193454CF /* ServiceDetailView.swift */; };
 		D1130C3F57D641955CEE5518 /* MachineCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECF05A96F099B6E80E9077B /* MachineCardView.swift */; };
 		D2F870759080FB9D1DF58A3A /* NewContainerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B011CA693D5A9EFCCF61AA2D /* NewContainerSheet.swift */; };
+		D32166A92BDA2FB6B6037D94 /* DeepLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C649765AA76CFCBFC3302DA /* DeepLinkRouter.swift */; };
 		D49278FBAD2A7E36CD278147 /* MachineRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949DB8BB8139F8D3C37503E9 /* MachineRowView.swift */; };
 		D4B90FF1E30A90C8B962A30B /* AboutWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE313F40E79E409C942B1EE /* AboutWindow.swift */; };
 		D69B9880564FF221556379CF /* SleepWakeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7058C8975F3F2684714E24E2 /* SleepWakeManager.swift */; };
@@ -169,6 +171,7 @@
 		E92C8245EE6AE51D99035E4D /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B37EA00E3A32B9866C9BE293 /* Sparkle */; };
 		E9B0A374B532221710729A34 /* ContainerTerminalTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1AFAED2CB7429B714C8A06 /* ContainerTerminalTab.swift */; };
 		ED3023CCFF235C0CF302C812 /* MenuBarView+Containers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15C37C29F16DD4E28B30271 /* MenuBarView+Containers.swift */; };
+		EE2D38BC76500BF768EEE20F /* DeepLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B3B3C54B6D49C6198E9E26 /* DeepLinkTests.swift */; };
 		F035F2D21380F9DD531E6B04 /* LocalRootFSOutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9EDD0CCB1C4698A31FC1ED1 /* LocalRootFSOutlineView.swift */; };
 		F07FF6E8891692D4D8807F3A /* LocalRootFSOutlineModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6C627A5BC34C783DAEAC31 /* LocalRootFSOutlineModels.swift */; };
 		F0B6CC9DB9992CE44F2A7F70 /* AppViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F707491EC9A47AE534822664 /* AppViewModel.swift */; };
@@ -225,6 +228,7 @@
 		1808332CF700CF6900F556F5 /* SampleData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleData.swift; sourceTree = "<group>"; };
 		185A238D021D6C976574528C /* ImageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDetailView.swift; sourceTree = "<group>"; };
 		1B18FDEC4B5AE8513C98D7B4 /* SandboxDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxDetailView.swift; sourceTree = "<group>"; };
+		1C649765AA76CFCBFC3302DA /* DeepLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkRouter.swift; sourceTree = "<group>"; };
 		1E17CF68FBBA9447E1B15371 /* ImageTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTypes.swift; sourceTree = "<group>"; };
 		1E6C27E068081F8D598F3D7A /* ImageViewModel+Docker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImageViewModel+Docker.swift"; sourceTree = "<group>"; };
 		200F15F29A3634EC779554D4 /* ContainerLogsTab+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContainerLogsTab+Actions.swift"; sourceTree = "<group>"; };
@@ -277,6 +281,7 @@
 		69038D73EF8AC0CC09D4B39C /* NavItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavItem.swift; sourceTree = "<group>"; };
 		699A57392F1D9366CFA78BAF /* VolumesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumesViewModel.swift; sourceTree = "<group>"; };
 		6AC42E91F0BCACABF173B87F /* DockerTerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockerTerminalSession.swift; sourceTree = "<group>"; };
+		6ADF9F8FFB694C45042664E8 /* DeepLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLink.swift; sourceTree = "<group>"; };
 		7058C8975F3F2684714E24E2 /* SleepWakeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepWakeManager.swift; sourceTree = "<group>"; };
 		70D9A8B5B6000070B4D69A07 /* SandboxDisabledView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxDisabledView.swift; sourceTree = "<group>"; };
 		727A1DD3E8D3B0BB875475A8 /* MachineEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachineEmptyState.swift; sourceTree = "<group>"; };
@@ -362,6 +367,7 @@
 		DBEBBF08F0E4AC45D9C0BB83 /* ChangelogParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangelogParser.swift; sourceTree = "<group>"; };
 		DE564AAFEC0EF6D094409728 /* SandboxRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxRowView.swift; sourceTree = "<group>"; };
 		E06B22BB8B92AF78C2B87ADC /* AboutView+LinkButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AboutView+LinkButton.swift"; sourceTree = "<group>"; };
+		E18EB65626D97DF7604580DF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		E1C6B2F85E39321931CEC3ED /* ContainerDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerDetailView.swift; sourceTree = "<group>"; };
 		E37F8C85EB27987F81FFB5F4 /* KubernetesState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KubernetesState.swift; sourceTree = "<group>"; };
 		E3A8FF41635473729BF0A36E /* StatusBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBadge.swift; sourceTree = "<group>"; };
@@ -376,6 +382,7 @@
 		EFB03A05EDADB4F1FA6E10A1 /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		F238F21169A97B94193454CF /* ServiceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceDetailView.swift; sourceTree = "<group>"; };
 		F4705819BA2C07E7EADAC37E /* MachineTerminalTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachineTerminalTab.swift; sourceTree = "<group>"; };
+		F5B3B3C54B6D49C6198E9E26 /* DeepLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkTests.swift; sourceTree = "<group>"; };
 		F5F318A121B0C8EA1A05BFE5 /* InfoRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoRow.swift; sourceTree = "<group>"; };
 		F62FD6244C56EE8E45DF0EC7 /* AppColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppColors.swift; sourceTree = "<group>"; };
 		F707491EC9A47AE534822664 /* AppViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppViewModel.swift; sourceTree = "<group>"; };
@@ -578,6 +585,8 @@
 			children = (
 				657D7543F1D47988AEC3339D /* AppDelegate.swift */,
 				43F21DD7BED5D64B93FF062D /* ArcBoxDesktopApp+Telemetry.swift */,
+				6ADF9F8FFB694C45042664E8 /* DeepLink.swift */,
+				1C649765AA76CFCBFC3302DA /* DeepLinkRouter.swift */,
 				794F192F207790B1A137A816 /* EnvironmentValues+Clients.swift */,
 			);
 			path = App;
@@ -839,6 +848,7 @@
 				57DD9A9FA0D6072FD4476A91 /* ArcBoxApp.swift */,
 				68009FEC4A2F0EB046ACCA4C /* Assets.xcassets */,
 				54DE8B823FD1E94B0073AC5A /* ErrorReporting.swift */,
+				E18EB65626D97DF7604580DF /* Info.plist */,
 				06688AB84392716F1108AE36 /* Logging.swift */,
 				EA6DBFBB43078F295AFE54C0 /* PerformanceTracing.swift */,
 				2C7006D22506414C67AC5475 /* App */,
@@ -905,6 +915,7 @@
 			children = (
 				A10ED4BA65D6B9CC56B6B329 /* ChangelogParserTests.swift */,
 				E610512C9106BB92A47DC044 /* ContainersViewModelTests.swift */,
+				F5B3B3C54B6D49C6198E9E26 /* DeepLinkTests.swift */,
 				06DFFB59D72F27F14A233B81 /* DockerEventMonitorTests.swift */,
 				A2B6587D59B9EFA18E51A3F3 /* ImagesViewModelTests.swift */,
 				7B6FDB677AE01E62877A17AC /* K8sModelsTests.swift */,
@@ -1112,6 +1123,8 @@
 				869B14DB25CD44955C7C32AE /* ContainersViewModel.swift in Sources */,
 				9444132595906417360A9D44 /* ContentView.swift in Sources */,
 				172FA4919687A4616E0BC135 /* DaemonLoadingView.swift in Sources */,
+				BA3195811383AD00D29B32AE /* DeepLink.swift in Sources */,
+				D32166A92BDA2FB6B6037D94 /* DeepLinkRouter.swift in Sources */,
 				632810E9B138C535A11E7EBF /* DiagnosticBundleExporter.swift in Sources */,
 				6EE6805F5EC85742CC665575 /* DockerCLIResolver.swift in Sources */,
 				BD99D14EC5ED57BA1FF283CC /* DockerContextManager.swift in Sources */,
@@ -1239,6 +1252,7 @@
 			files = (
 				31474CB365691C57A5568D14 /* ChangelogParserTests.swift in Sources */,
 				4D2029E55A7979B8BD9EE89A /* ContainersViewModelTests.swift in Sources */,
+				EE2D38BC76500BF768EEE20F /* DeepLinkTests.swift in Sources */,
 				8466B000B68A87CEECA6756F /* DockerEventMonitorTests.swift in Sources */,
 				0BCE503CC2BF6C2BEC9DC4EA /* ImagesViewModelTests.swift in Sources */,
 				F40C3E6023452858EEEA893F /* K8sModelsTests.swift in Sources */,
@@ -1361,6 +1375,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ArcBox/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ArcBox;
 				INFOPLIST_KEY_CFBundleName = ArcBox;
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "ArcBox uses Automation to open your selected terminal app and run container shell commands.";
@@ -1503,6 +1518,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ArcBox/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ArcBox;
 				INFOPLIST_KEY_CFBundleName = ArcBox;
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "ArcBox uses Automation to open your selected terminal app and run container shell commands.";

--- a/ArcBox/App/AppDelegate.swift
+++ b/ArcBox/App/AppDelegate.swift
@@ -9,8 +9,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var startupOrchestrator: StartupOrchestrator?
     var arcboxClient: ArcBoxClient?
     var connectionTask: Task<Void, Never>?
+    let deepLinkRouter = DeepLinkRouter()
     /// Set to true when the user explicitly requests a full quit (e.g. from menu bar).
     var forceQuit = false
+
+    func application(_ application: NSApplication, open urls: [URL]) {
+        for url in urls {
+            deepLinkRouter.handle(url)
+        }
+    }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         let keepRunning = UserDefaults.standard.bool(forKey: "keepRunning")

--- a/ArcBox/App/DeepLink.swift
+++ b/ArcBox/App/DeepLink.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// A parsed `arcbox://` deep link.
+///
+/// Supported forms:
+/// - `arcbox://main` (or no host) — open and activate the main window
+/// - `arcbox://settings` — open the Settings window
+/// - `arcbox://<section>[/<id>]` — navigate to a sidebar section, where
+///   `<section>` is a `NavItem` raw value (`containers`, `volumes`, `images`,
+///   `networks`, `pods`, `services`, `machines`, `sandboxes`, `templates`)
+///   and the optional `<id>` selects the item with that exact ID.
+enum DeepLink: Equatable {
+    static let scheme = "arcbox"
+
+    case main
+    case settings
+    case section(NavItem, id: String?)
+
+    init?(_ url: URL) {
+        guard url.scheme?.lowercased() == Self.scheme else { return nil }
+        switch url.host()?.lowercased() ?? "" {
+        case "", "main":
+            self = .main
+        case "settings":
+            self = .settings
+        case let host:
+            guard let item = NavItem(rawValue: host) else { return nil }
+            self = .section(item, id: url.pathComponents.first { $0 != "/" })
+        }
+    }
+}

--- a/ArcBox/App/DeepLinkRouter.swift
+++ b/ArcBox/App/DeepLinkRouter.swift
@@ -1,0 +1,72 @@
+import AppKit
+import OSLog
+
+/// Applies parsed deep links to app navigation.
+///
+/// URLs arrive via `NSApplicationDelegate`, possibly before the SwiftUI scene
+/// has created the view models (e.g. when a URL launches the app), so links
+/// are buffered until `configure(_:)` provides the navigation target.
+final class DeepLinkRouter {
+    struct Target {
+        let appVM: AppViewModel
+        let containersVM: ContainersViewModel
+        let volumesVM: VolumesViewModel
+        let imagesVM: ImagesViewModel
+        let networksVM: NetworksViewModel
+        let openMainWindow: () -> Void
+        let openSettingsWindow: () -> Void
+    }
+
+    private var target: Target?
+    private var pending: [DeepLink] = []
+
+    func configure(_ target: Target) {
+        self.target = target
+        let buffered = pending
+        pending = []
+        buffered.forEach(apply)
+    }
+
+    func handle(_ url: URL) {
+        guard let link = DeepLink(url) else {
+            Log.deepLink.warning("Ignoring unrecognized deep link: \(url.absoluteString, privacy: .private)")
+            return
+        }
+        Log.deepLink.info("Handling deep link: \(url.absoluteString, privacy: .private)")
+        if target == nil {
+            pending.append(link)
+        } else {
+            apply(link)
+        }
+    }
+
+    private func apply(_ link: DeepLink) {
+        guard let target else { return }
+        switch link {
+        case .main:
+            target.openMainWindow()
+        case .settings:
+            target.openSettingsWindow()
+        case .section(let item, let id):
+            target.openMainWindow()
+            target.appVM.navigate(to: item)
+            if let id {
+                select(id, in: item, with: target)
+            }
+        }
+        NSApp.activate()
+    }
+
+    /// Item selection is only wired for Docker resources; the other sections'
+    /// view models are local to `ContentView` and not reachable from here.
+    private func select(_ id: String, in item: NavItem, with target: Target) {
+        switch item {
+        case .containers: target.containersVM.selectedID = id
+        case .volumes: target.volumesVM.selectedID = id
+        case .images: target.imagesVM.selectedID = id
+        case .networks: target.networksVM.selectedID = id
+        case .pods, .services, .machines, .sandboxes, .templates:
+            Log.deepLink.info("Item selection unsupported for \(item.rawValue, privacy: .public)")
+        }
+    }
+}

--- a/ArcBox/ArcBoxApp.swift
+++ b/ArcBox/ArcBoxApp.swift
@@ -60,6 +60,17 @@ struct ArcBoxDesktopApp: App {
                 .environment(\.startupOrchestrator, startupOrchestrator)
                 .frame(minWidth: 900, minHeight: 600)
                 .task {
+                    appDelegate.deepLinkRouter.configure(
+                        .init(
+                            appVM: appVM,
+                            containersVM: containersVM,
+                            volumesVM: volumesVM,
+                            imagesVM: imagesVM,
+                            networksVM: networksVM,
+                            openMainWindow: { openWindow(id: "main") },
+                            openSettingsWindow: { openWindow(id: "settings") }
+                        ))
+
                     guard startupOrchestrator == nil else { return }
 
                     appDelegate.daemonManager = daemonManager
@@ -95,7 +106,6 @@ struct ArcBoxDesktopApp: App {
                 // ListViews gate their initial load on setupPhase.isDockerReady
                 // (reported via the gRPC WatchSetupStatus stream) to avoid hitting the
                 // Docker API before the daemon has finished initialization.
-                .onOpenURL { url in handleDeepLink(url) }
                 .onChange(of: daemonManager.state) { _, newState in
                     if newState.isRunning {
                         if dockerClient == nil {
@@ -198,18 +208,5 @@ struct ArcBoxDesktopApp: App {
         appDelegate.arcboxClient = client
         appDelegate.connectionTask = task
         return client
-    }
-
-    /// Handle incoming `arcbox://` deep links.
-    /// TODO(ABXD-62): Register URL scheme in Info.plist or project build settings
-    /// (INFOPLIST_KEY_LSApplicationCategoryType / CFBundleURLTypes) once scheme routing is finalized.
-    private func handleDeepLink(_ url: URL) {
-        Log.startup.info("Received deep link: \(url.absoluteString, privacy: .private)")
-        guard url.scheme == "arcbox" else {
-            Log.startup.warning("Ignoring unrecognized URL scheme: \(url.scheme ?? "nil", privacy: .private)")
-            return
-        }
-        // TODO(ABXD-62): Route deep link to appropriate view based on host/path.
-        // e.g. arcbox://containers/<id>, arcbox://settings, etc.
     }
 }

--- a/ArcBox/Info.plist
+++ b/ArcBox/Info.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Merged with the Xcode-generated Info.plist (GENERATE_INFOPLIST_FILE).
+	     Only keys that cannot be expressed as INFOPLIST_KEY_* settings live here. -->
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>arcbox</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/ArcBox/Logging.swift
+++ b/ArcBox/Logging.swift
@@ -14,6 +14,7 @@ nonisolated enum Log {
     static let pods = Logger(subsystem: subsystem, category: "pods")
     static let services = Logger(subsystem: subsystem, category: "services")
     static let context = Logger(subsystem: subsystem, category: "context")
+    static let deepLink = Logger(subsystem: subsystem, category: "deepLink")
     static let sleep = Logger(subsystem: subsystem, category: "sleep")
     static let terminal = Logger(subsystem: subsystem, category: "terminal")
 }

--- a/ArcBoxTests/DeepLinkTests.swift
+++ b/ArcBoxTests/DeepLinkTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+
+@testable import ArcBox
+
+final class DeepLinkTests: XCTestCase {
+
+    @MainActor private func parse(_ string: String) -> DeepLink? {
+        DeepLink(URL(string: string)!)
+    }
+
+    // MARK: - Window links
+
+    @MainActor func testParsesMain() {
+        XCTAssertEqual(parse("arcbox://main"), .main)
+    }
+
+    @MainActor func testParsesEmptyHostAsMain() {
+        XCTAssertEqual(parse("arcbox://"), .main)
+    }
+
+    @MainActor func testParsesSettings() {
+        XCTAssertEqual(parse("arcbox://settings"), .settings)
+    }
+
+    // MARK: - Section links
+
+    @MainActor func testParsesSectionWithoutID() {
+        XCTAssertEqual(parse("arcbox://containers"), .section(.containers, id: nil))
+    }
+
+    @MainActor func testParsesSectionWithTrailingSlashWithoutID() {
+        XCTAssertEqual(parse("arcbox://images/"), .section(.images, id: nil))
+    }
+
+    @MainActor func testParsesSectionWithID() {
+        XCTAssertEqual(parse("arcbox://containers/abc123"), .section(.containers, id: "abc123"))
+    }
+
+    @MainActor func testParsesEverySection() {
+        for item in NavItem.allCases {
+            XCTAssertEqual(parse("arcbox://\(item.rawValue)"), .section(item, id: nil))
+        }
+    }
+
+    @MainActor func testDecodesPercentEncodedID() {
+        XCTAssertEqual(parse("arcbox://volumes/my%20volume"), .section(.volumes, id: "my volume"))
+    }
+
+    @MainActor func testUsesFirstPathComponentAsID() {
+        XCTAssertEqual(parse("arcbox://containers/abc/extra"), .section(.containers, id: "abc"))
+    }
+
+    @MainActor func testHostIsCaseInsensitive() {
+        XCTAssertEqual(parse("arcbox://Containers"), .section(.containers, id: nil))
+        XCTAssertEqual(parse("ARCBOX://settings"), .settings)
+    }
+
+    // MARK: - Rejection
+
+    @MainActor func testRejectsOtherSchemes() {
+        XCTAssertNil(parse("https://containers/abc"))
+    }
+
+    @MainActor func testRejectsUnknownHost() {
+        XCTAssertNil(parse("arcbox://bogus"))
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -162,6 +162,8 @@ targets:
         ENABLE_HARDENED_RUNTIME: YES
         ENABLE_PREVIEWS: YES
         GENERATE_INFOPLIST_FILE: YES
+        # Merged into the generated Info.plist; declares the arcbox:// URL scheme.
+        INFOPLIST_FILE: ArcBox/Info.plist
         INFOPLIST_KEY_CFBundleDisplayName: ArcBox
         INFOPLIST_KEY_CFBundleName: ArcBox
         INFOPLIST_KEY_NSAppleEventsUsageDescription: ArcBox uses Automation to open your selected terminal app and run container shell commands.


### PR DESCRIPTION
## Summary

Adds Custom URL Scheme support (`arcbox://`) for CLI-to-GUI integration.

- Declare `CFBundleURLTypes` in a new partial `ArcBox/Info.plist`, merged into the Xcode-generated Info.plist via `INFOPLIST_FILE` (`INFOPLIST_KEY_*` build settings cannot express array values).
- Receive URLs in `AppDelegate.application(_:open:)` instead of `.onOpenURL` — the app supports running with all windows closed (menu bar mode), where a view modifier would miss the event.
- `DeepLink` (pure, unit-tested parsing) + `DeepLinkRouter` (applies navigation; buffers links that arrive before the SwiftUI scene is ready, e.g. when a URL cold-launches the app).

## Supported links

| URL | Action |
| --- | --- |
| `arcbox://main` (or `arcbox://`) | open/activate the main window |
| `arcbox://settings` | open the Settings window |
| `arcbox://<section>[/<id>]` | navigate to a sidebar section, optionally selecting an item by ID (`containers`, `volumes`, `images`, `networks`, `pods`, `services`, `machines`, `sandboxes`, `templates`) |

Item selection is wired for Docker resources only for now; other sections' view models are local to `ContentView`.

Deliberately **not** included: action links (e.g. `arcbox://container/start/<id>`) — any web page can trigger scheme URLs, so v1 stays navigation-only; and Universal Links, which need an associated-domains entitlement, a Developer ID provisioning profile, and an AASA file hosted on our domain.

## Testing

- `xcodebuild build` succeeds; merged product Info.plist contains the `arcbox` scheme alongside all generated keys (verified with `plutil`).
- 91 unit tests pass, including 12 new `DeepLinkTests` for URL parsing.
- Registered the built app with Launch Services and confirmed it claims the `arcbox:` scheme via `lsregister -dump`.
- `swiftlint --strict` and `swift-format` clean.

Closes ABXD-62 / #149