### PR TITLE
fix(auth): ship production OIDC configuration in release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,8 +221,13 @@ jobs:
           # by `cargo xtask macos dmg` (plutil), not via INFOPLIST_KEY_ build
           # settings — those silently drop custom keys. This file only supplies
           # the project base configuration.
-          cat > Local.xcconfig <<XCEOF
+          # The OIDC values expand into Info.plist at build time. They are not
+          # secrets (public client + PKCE); the $() stops xcconfig from reading
+          # "//" in the URL as a comment.
+          cat > Local.xcconfig <<'XCEOF'
           #include "Version.xcconfig"
+          OIDC_ISSUER_URL = https:/$()/auth.arcbox.dev/api/auth
+          OIDC_CLIENT_ID = arcbox-desktop
           XCEOF
 
       - name: Trust SwiftPM plugins

--- a/Local.xcconfig.example
+++ b/Local.xcconfig.example
@@ -13,5 +13,8 @@ POSTHOG_API_KEY = YOUR_POSTHOG_API_KEY_HERE
 // the resolved value is a normal http:// URL.
 //   OIDC_ISSUER_URL = http:/$()/localhost:5556/dex
 //   OIDC_CLIENT_ID = arcbox-desktop
+// Production (what release builds ship with, see release.yml):
+//   OIDC_ISSUER_URL = https:/$()/auth.arcbox.dev/api/auth
+//   OIDC_CLIENT_ID = arcbox-desktop
 OIDC_ISSUER_URL = YOUR_OIDC_ISSUER_URL_HERE
 OIDC_CLIENT_ID = YOUR_OIDC_CLIENT_ID_HERE


### PR DESCRIPTION
## Problem

Release 1.23.0 shipped with OIDC sign-in unconfigured: the Account page shows *"No OIDC provider is configured for this build. See Local.xcconfig.example."*

The issuer URL and client ID live only in the gitignored `Local.xcconfig`, and the release workflow's generated `Local.xcconfig` intentionally left them unset while the production issuer registration was pending (see the note in #268). The issuer has been live at `auth.arcbox.dev` since 2026-07-09, but the workflow was never updated.

## Fix

Write `OIDC_ISSUER_URL` / `OIDC_CLIENT_ID` into the `Local.xcconfig` generated by the release workflow, so `ProcessInfoPlistFile` expands them into the app's Info.plist at build time — the same mechanism local dev builds use.

Notes:
- The values are plaintext in the workflow on purpose: this is a public client using PKCE, so neither value is a secret, and keeping them version-controlled is exactly what was missing.
- The heredoc is now quoted (`<<'XCEOF'`) so `$()` reaches the file literally — xcconfig treats `//` inside a value as a comment, and the empty `$()` expansion splits the slashes (same trick as local configs).
- Also documented the production values in `Local.xcconfig.example`.

## Verification

The generated line is byte-identical to the proven-working local `Local.xcconfig` entry. Full verification is the next release build: the Account page in the DMG should show the issuer host instead of the "not configured" notice.