### PR TITLE
feat(auth): open sign-in directly in the default browser

### DIFF
--- a/ArcBox/Views/Settings/AccountSettingsView.swift
+++ b/ArcBox/Views/Settings/AccountSettingsView.swift
@@ -5,7 +5,6 @@ import SwiftUI
 /// Sign-in state for the ArcBox platform: identity, session, sign in/out.
 struct AccountSettingsView: View {
     @Environment(AuthSession.self) private var authSession
-    @Environment(\.webAuthenticationSession) private var webAuthenticationSession
     @State private var isConfirmingSignOut = false
 
     var body: some View {
@@ -86,6 +85,7 @@ struct AccountSettingsView: View {
                         Text("Waiting for the browser…")
                             .foregroundStyle(.secondary)
                     }
+                    Button("Cancel") { authSession.cancelSignIn() }
                 } else {
                     Button("Sign In to ArcBox…", action: signIn)
                         .buttonStyle(.borderedProminent)
@@ -100,7 +100,7 @@ struct AccountSettingsView: View {
     // MARK: - Actions
 
     private func signIn() {
-        Task { await authSession.signIn(using: webAuthenticationSession) }
+        Task { await authSession.signIn() }
     }
 
     private func signOut() {

--- a/ArcBox/Views/SidebarAccountButton.swift
+++ b/ArcBox/Views/SidebarAccountButton.swift
@@ -4,12 +4,11 @@ import SwiftUI
 /// Account chip pinned to the bottom of the main-window sidebar.
 ///
 /// Signed out it shows the placeholder avatar and "Sign In" and starts the
-/// browser flow directly; signed in it shows the avatar and display name
-/// and opens Settings > Account.
+/// browser flow directly; signed in (or while a sign-in is in flight) it
+/// shows the current state and opens Settings > Account.
 struct SidebarAccountButton: View {
     @Environment(AppViewModel.self) private var appVM
     @Environment(AuthSession.self) private var authSession
-    @Environment(\.webAuthenticationSession) private var webAuthenticationSession
     @Environment(\.openWindow) private var openWindow
     @State private var isHovered = false
 
@@ -55,22 +54,29 @@ struct SidebarAccountButton: View {
     }
 
     private var isDisabled: Bool {
-        authSession.status == .signingIn
-            || (authSession.status != .signedIn && authSession.configuration.isPlaceholder)
+        authSession.status != .signedIn && authSession.status != .signingIn
+            && authSession.configuration.isPlaceholder
     }
 
     private var helpText: String {
-        if authSession.status == .signedIn { return "Open account settings" }
-        if authSession.configuration.isPlaceholder { return "No OIDC provider is configured" }
-        return "Sign in to ArcBox"
+        switch authSession.status {
+        case .signedIn: return "Open account settings"
+        case .signingIn: return "Waiting for the browser — click to manage"
+        default:
+            return authSession.configuration.isPlaceholder
+                ? "No OIDC provider is configured" : "Sign in to ArcBox"
+        }
     }
 
     private func primaryAction() {
-        if authSession.status == .signedIn {
+        switch authSession.status {
+        case .signedIn, .signingIn:
+            // While signing in, Settings > Account shows progress and offers
+            // Cancel — the only way out of an abandoned browser leg.
             appVM.settingsTab = .account
             openWindow(id: "settings")
-        } else {
-            Task { await authSession.signIn(using: webAuthenticationSession) }
+        default:
+            Task { await authSession.signIn() }
         }
     }
 }

--- a/Packages/ArcBoxAuth/Sources/ArcBoxAuth/Session/AuthSession+SignIn.swift
+++ b/Packages/ArcBoxAuth/Sources/ArcBoxAuth/Session/AuthSession+SignIn.swift
@@ -1,6 +1,5 @@
-import AuthenticationServices
+import AppKit
 import Foundation
-import SwiftUI
 
 extension AuthSession {
     /// Everything needed to finish the code exchange once the browser
@@ -12,36 +11,25 @@ extension AuthSession {
         let endpoints: OIDCEndpoints
     }
 
-    /// Runs the full browser-based Authorization Code + PKCE flow.
+    /// Runs the browser-based Authorization Code + PKCE flow in the user's
+    /// default browser — no `ASWebAuthenticationSession`, so no system
+    /// consent prompt. Launch Services delivers the redirect back as a deep
+    /// link (`handleAuthorizationCallback`). Failures land in `status`
+    /// rather than being thrown.
     ///
-    /// `WebAuthenticationSession` exists only as a SwiftUI environment value,
-    /// so the calling view passes it in; both are MainActor-bound. Failures
-    /// land in `status` rather than being thrown; a user-cancelled browser
-    /// sheet quietly returns to `.signedOut`.
-    ///
-    /// The redirect can come back two ways: the web session returns it
-    /// directly, or — when sign-in finishes in an external browser — Launch
-    /// Services delivers it as a deep link (`handleAuthorizationCallback`).
-    /// Both funnel into `finishAuthorization`; whichever arrives first wins.
-    public func signIn(using webSession: WebAuthenticationSession) async {
+    /// Nothing signals that the user abandoned the browser leg, so the
+    /// session stays `.signingIn` until the callback arrives or the UI
+    /// calls `cancelSignIn()`.
+    public func signIn() async {
         guard status != .signingIn else { return }
         status = .signingIn
         do {
             let authorizationURL = try await beginAuthorization()
-            guard let scheme = OIDCClientConfiguration.redirectURI.scheme else {
-                throw OIDCError.invalidCallbackURL
+            guard NSWorkspace.shared.open(authorizationURL) else {
+                pendingAuthorization = nil
+                status = .error("Could not open the browser to sign in.")
+                return
             }
-            let callbackURL = try await webSession.authenticate(
-                using: authorizationURL,
-                callback: .customScheme(scheme),
-                additionalHeaderFields: [:])
-            await finishAuthorization(callbackURL: callbackURL)
-        } catch let error as ASWebAuthenticationSessionError where error.code == .canceledLogin {
-            // The user may have dismissed the sheet to finish in an external
-            // browser: keep `pendingAuthorization` so a deep-link callback
-            // can still complete, but stop showing progress. Don't clobber a
-            // session a deep link already established.
-            if status == .signingIn { status = .signedOut }
         } catch let error as OIDCError {
             ClientLog.auth.error("Sign-in failed: \(String(describing: error))")
             status = .error(error.userMessage)
@@ -51,9 +39,17 @@ extension AuthSession {
         }
     }
 
-    /// Completes sign-in from an OAuth redirect delivered as a deep link
-    /// (`onOpenURL`) rather than through the web session — the path taken
-    /// when the authorization leg ends in an external browser.
+    /// Abandons an in-flight browser sign-in: drops the pending
+    /// authorization so a late redirect is ignored, and returns to
+    /// `.signedOut`.
+    public func cancelSignIn() {
+        guard status == .signingIn else { return }
+        pendingAuthorization = nil
+        status = .signedOut
+    }
+
+    /// Completes sign-in from the OAuth redirect delivered as a deep link
+    /// (`onOpenURL`) once the authorization leg finishes in the browser.
     ///
     /// Returns `false` when the URL is not this app's OAuth redirect, so the
     /// caller can route it as an ordinary deep link. A redirect with no
@@ -76,8 +72,8 @@ extension AuthSession {
     }
 
     /// Builds the authorization request and records the context needed to
-    /// finish it. Split from `signIn(using:)` so tests can drive the flow
-    /// without a `WebAuthenticationSession`.
+    /// finish it. Split from `signIn()` so tests can drive the flow without
+    /// opening a browser.
     func beginAuthorization() async throws -> URL {
         let endpoints = try await resolvedEndpoints()
         let pkce = PKCE.generateCodePair()
@@ -94,9 +90,9 @@ extension AuthSession {
         return authorizationURL
     }
 
-    /// Single completion funnel: consumes `pendingAuthorization` exactly once
-    /// (MainActor serialization makes take-then-clear race-free) and maps
-    /// failures into `status`. A second arrival is a no-op.
+    /// Consumes `pendingAuthorization` exactly once (MainActor serialization
+    /// makes take-then-clear race-free) and maps failures into `status`.
+    /// A replayed callback is a no-op.
     private func finishAuthorization(callbackURL: URL) async {
         guard let pending = pendingAuthorization else { return }
         pendingAuthorization = nil
@@ -117,9 +113,8 @@ extension AuthSession {
     }
 
     /// Security-critical completion: validates `state` (CSRF) and `nonce`,
-    /// exchanges the code, persists, and publishes the session. Split from
-    /// `signIn(using:)` so it is unit-testable — `WebAuthenticationSession`
-    /// cannot be constructed in tests.
+    /// exchanges the code, persists, and publishes the session. Split out
+    /// so it is unit-testable without a browser round-trip.
     func completeSignIn(
         callbackURL: URL,
         expectedState: String,

--- a/Packages/ArcBoxAuth/Sources/ArcBoxAuth/Session/AuthSession.swift
+++ b/Packages/ArcBoxAuth/Sources/ArcBoxAuth/Session/AuthSession.swift
@@ -20,9 +20,8 @@ public final class AuthSession: AccessTokenProviding {
     @ObservationIgnored private var tokens: StoredTokens?
     @ObservationIgnored private var endpoints: OIDCEndpoints?
     @ObservationIgnored private var refreshTask: Task<StoredTokens, Error>?
-    /// Context for the in-flight browser leg, consumed exactly once by
-    /// whichever completion path returns first: the web-session result or a
-    /// deep-link callback (see `AuthSession+SignIn.swift`).
+    /// Context for the in-flight browser leg, consumed exactly once when
+    /// the deep-link callback arrives (see `AuthSession+SignIn.swift`).
     @ObservationIgnored var pendingAuthorization: PendingAuthorization?
 
     /// Refresh this long before nominal expiry to absorb clock skew.

--- a/Packages/ArcBoxAuth/Tests/ArcBoxAuthTests/AuthSessionTests.swift
+++ b/Packages/ArcBoxAuth/Tests/ArcBoxAuthTests/AuthSessionTests.swift
@@ -256,6 +256,28 @@ struct AuthSessionTests {
         #expect(provider.exchangeCalls == 1)
     }
 
+    // MARK: - cancelSignIn
+
+    @Test func cancelSignInDropsPendingAuthorizationAndIgnoresLateCallback() async throws {
+        let session = makeSession()
+        _ = try await session.beginAuthorization()
+        session.status = .signingIn
+        session.cancelSignIn()
+        #expect(session.status == .signedOut)
+        #expect(session.pendingAuthorization == nil)
+        let handled = await session.handleAuthorizationCallback(callback())
+        #expect(handled)
+        #expect(session.status == .signedOut)
+        #expect(provider.exchangeCalls == 0)
+    }
+
+    @Test func cancelSignInIsNoOpWhenNotSigningIn() async throws {
+        try store.save(freshTokens())
+        let session = makeSession()
+        session.cancelSignIn()
+        #expect(session.status == .signedIn)
+    }
+
     // MARK: - accessToken
 
     @Test func accessTokenThrowsWhenSignedOut() async {


### PR DESCRIPTION
## Summary

Replaces the `ASWebAuthenticationSession` leg of OIDC sign-in with opening the authorization URL directly in the user's default browser, removing the system consent popup ("ArcBox wants to use … to sign in").

- `AuthSession.signIn()` now opens the authorization URL via `NSWorkspace.open`; the redirect returns through the already-registered `com.arcboxlabs.desktop:` deep link, which is now the single completion path.
- Adds `cancelSignIn()` and a **Cancel** button in Settings › Account — an external browser gives no dismissal signal, so an abandoned browser leg needs an escape hatch.
- The sidebar account chip is clickable while signing in and routes to Settings › Account.

This matches RFC 8252 §5/§7.1 and its macOS appendix (B.4): external user-agent + private-use scheme redirect + PKCE, the same pattern GitHub Desktop and Docker Desktop ship.

## Testing

- `swift test` in ArcBoxAuth: 58 tests pass, including two new tests for the cancel path (pending authorization dropped, late callback ignored).
- App builds with `xcodebuild` after merging current `master` (DeepLinkRouter refactor); `DeepLinkRouter.onOAuthCallback` → `handleAuthorizationCallback` wiring verified.
- Manual: sign-in jumps straight to the browser with no consent dialog; redirect completes the session.