### PR TITLE
feat(activity): Activity Monitor — live resource dashboard (ABX-115 P3)

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0720D45362971FA9338BAA53 /* SwiftTermView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA74DBE71D29DEB680F08E7 /* SwiftTermView.swift */; };
 		07A382D149C73C697CAA1601 /* SandboxRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE564AAFEC0EF6D094409728 /* SandboxRowView.swift */; };
 		0999A1C28C17EFD150E56CF8 /* MachinesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ECCF18CC36CC3579EE2B5B9 /* MachinesView.swift */; };
+		09A2217B8D33E2BD87D23713 /* ActivityViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAC9EE4F067CB69F022C1E0 /* ActivityViewModel.swift */; };
 		09FF7CE0E252DAD805077C7E /* ImagesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 559C97F0CA659149BCBA59A2 /* ImagesViewModel.swift */; };
 		0AF01BD1D2FC14E2F99E9B4C /* K8sClient in Frameworks */ = {isa = PBXBuildFile; productRef = A8DA5BF5FF6E9CABB1BAAD3A /* K8sClient */; };
 		0BCE503CC2BF6C2BEC9DC4EA /* ImagesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B6587D59B9EFA18E51A3F3 /* ImagesViewModelTests.swift */; };
@@ -188,6 +189,7 @@
 		E69436579DA555FA6133A1CF /* ServiceRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A147995028C8DB6F49BBD8EF /* ServiceRowView.swift */; };
 		E92C8245EE6AE51D99035E4D /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = B23ADDA7527EDFFFD6615B12 /* SwiftTerm */; };
 		E9B0A374B532221710729A34 /* ContainerTerminalTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1AFAED2CB7429B714C8A06 /* ContainerTerminalTab.swift */; };
+		ECA0B439D329FA52C529ABE8 /* ActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3D2AE66CD9DD4A18CADB71 /* ActivityView.swift */; };
 		ED3023CCFF235C0CF302C812 /* MenuBarView+Containers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15C37C29F16DD4E28B30271 /* MenuBarView+Containers.swift */; };
 		EE2D38BC76500BF768EEE20F /* DeepLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B3B3C54B6D49C6198E9E26 /* DeepLinkTests.swift */; };
 		F035F2D21380F9DD531E6B04 /* LocalRootFSOutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9EDD0CCB1C4698A31FC1ED1 /* LocalRootFSOutlineView.swift */; };
@@ -265,6 +267,7 @@
 		2E8FB9C9E3349126EF773522 /* DaemonLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaemonLoadingView.swift; sourceTree = "<group>"; };
 		32115BE04C97CECA9C05A273 /* StartupProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupProgressView.swift; sourceTree = "<group>"; };
 		32C86546753C11A9E6CA8CB8 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
+		3DAC9EE4F067CB69F022C1E0 /* ActivityViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityViewModel.swift; sourceTree = "<group>"; };
 		3E30F5FC430804013B58C6F1 /* com.arcboxlabs.desktop.daemon.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = com.arcboxlabs.desktop.daemon.plist; sourceTree = "<group>"; };
 		3ED1683EF0A3490B8B7B5CF6 /* InfoTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoTableView.swift; sourceTree = "<group>"; };
 		4009DCC81EA64B23A77FB0C4 /* ServicesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicesViewModel.swift; sourceTree = "<group>"; };
@@ -292,6 +295,7 @@
 		57DD9A9FA0D6072FD4476A91 /* ArcBoxApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArcBoxApp.swift; sourceTree = "<group>"; };
 		591B3B9F3D3A0B5C43EC7B55 /* TemplatesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplatesViewModel.swift; sourceTree = "<group>"; };
 		5A87C9445565D341EA85D2F4 /* ExternalTerminalLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalTerminalLauncher.swift; sourceTree = "<group>"; };
+		5B3D2AE66CD9DD4A18CADB71 /* ActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityView.swift; sourceTree = "<group>"; };
 		5D70EF1BF223C47C7B8E71A5 /* ExternalTerminalApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalTerminalApp.swift; sourceTree = "<group>"; };
 		5F2D773B0312F0D5695D0ADA /* SandboxesViewModel+Snapshots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SandboxesViewModel+Snapshots.swift"; sourceTree = "<group>"; };
 		61EE316315F864BA1BF0FFED /* MachinesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachinesViewModel.swift; sourceTree = "<group>"; };
@@ -680,6 +684,7 @@
 				AA88097CAC1929269BE210C5 /* ContentView.swift */,
 				7607A876F6C88A440DA53BE1 /* SidebarAccountButton.swift */,
 				FDE4F12642D327661286B8A8 /* About */,
+				8D59468C9CEC7EAAE13C8C83 /* Activity */,
 				93FCB887D6304AC5E61E4D2B /* Containers */,
 				2E2958440C093A8D2A401F92 /* Images */,
 				22980E75C5271DF915A5B85E /* Kubernetes */,
@@ -793,6 +798,7 @@
 		7E0CDD06155210CDD85C4A1B /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				3DAC9EE4F067CB69F022C1E0 /* ActivityViewModel.swift */,
 				F707491EC9A47AE534822664 /* AppViewModel.swift */,
 				7C15DE3BBE549F8F86D82642 /* CheckForUpdatesViewModel.swift */,
 				E37F8C85EB27987F81FFB5F4 /* KubernetesState.swift */,
@@ -833,6 +839,14 @@
 				472F864720948B01C9F5D5A0 /* K8sClient */,
 			);
 			path = Packages;
+			sourceTree = "<group>";
+		};
+		8D59468C9CEC7EAAE13C8C83 /* Activity */ = {
+			isa = PBXGroup;
+			children = (
+				5B3D2AE66CD9DD4A18CADB71 /* ActivityView.swift */,
+			);
+			path = Activity;
 			sourceTree = "<group>";
 		};
 		93FCB887D6304AC5E61E4D2B /* Containers */ = {
@@ -1165,6 +1179,8 @@
 				76F9D4F43F4E73B79D882830 /* AboutView.swift in Sources */,
 				D4B90FF1E30A90C8B962A30B /* AboutWindow.swift in Sources */,
 				801AAF363A7901B7D17F5C55 /* AccountSettingsView.swift in Sources */,
+				ECA0B439D329FA52C529ABE8 /* ActivityView.swift in Sources */,
+				09A2217B8D33E2BD87D23713 /* ActivityViewModel.swift in Sources */,
 				5F8BD0B16CBBDC44080F6EA5 /* Analytics.swift in Sources */,
 				B91D470DA46003D64389C7DE /* AppColors.swift in Sources */,
 				BA8E4BE30E5FBB6B8548E214 /* AppDelegate.swift in Sources */,

--- a/ArcBox/App/DeepLinkRouter.swift
+++ b/ArcBox/App/DeepLinkRouter.swift
@@ -82,7 +82,7 @@ final class DeepLinkRouter {
         case .volumes: target.volumesVM.selectedID = id
         case .images: target.imagesVM.selectedID = id
         case .networks: target.networksVM.selectedID = id
-        case .pods, .services, .machines, .sandboxes, .templates:
+        case .activity, .pods, .services, .machines, .sandboxes, .templates:
             Log.deepLink.info("Item selection unsupported for \(item.rawValue, privacy: .public)")
         }
     }

--- a/ArcBox/Logging.swift
+++ b/ArcBox/Logging.swift
@@ -18,4 +18,5 @@ nonisolated enum Log {
     static let deepLink = Logger(subsystem: subsystem, category: "deepLink")
     static let sleep = Logger(subsystem: subsystem, category: "sleep")
     static let terminal = Logger(subsystem: subsystem, category: "terminal")
+    static let activity = Logger(subsystem: subsystem, category: "activity")
 }

--- a/ArcBox/Models/NavItem.swift
+++ b/ArcBox/Models/NavItem.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// Navigation item in sidebar
 enum NavItem: String, CaseIterable, Identifiable {
+    case activity
     case containers
     case volumes
     case images
@@ -26,6 +27,7 @@ enum NavItem: String, CaseIterable, Identifiable {
 
     var label: String {
         switch self {
+        case .activity: "Activity"
         case .containers: "Containers"
         case .volumes: "Volumes"
         case .images: "Images"
@@ -40,6 +42,7 @@ enum NavItem: String, CaseIterable, Identifiable {
 
     var sfSymbol: String {
         switch self {
+        case .activity: "waveform.path.ecg"
         case .containers: "cube"
         case .volumes: "internaldrive"
         case .images: "circle.circle"
@@ -54,6 +57,7 @@ enum NavItem: String, CaseIterable, Identifiable {
 
     /// Sidebar sections
     enum Section: String, CaseIterable, Identifiable {
+        case system = "SYSTEM"
         case docker = "DOCKER"
         case kubernetes = "KUBERNETES"
         case linux = "LINUX"
@@ -63,6 +67,7 @@ enum NavItem: String, CaseIterable, Identifiable {
 
         var items: [NavItem] {
             switch self {
+            case .system: [.activity]
             case .docker: [.containers, .volumes, .images, .networks]
             case .kubernetes: [.pods, .services]
             case .linux: [.machines]

--- a/ArcBox/ViewModels/ActivityViewModel.swift
+++ b/ArcBox/ViewModels/ActivityViewModel.swift
@@ -11,10 +11,25 @@ import Foundation
 @MainActor
 @Observable
 final class ActivityViewModel {
+    /// Lifecycle of the stats stream, explicit so the UI can distinguish
+    /// "no sample yet" from "had samples, connection dropped, retrying".
+    /// There is no terminal failure: the run loop retries until the view
+    /// disappears, so persistent errors surface as a climbing `attempt`.
+    enum StreamPhase: Equatable {
+        /// Connecting; nothing received on this connection yet.
+        case connecting
+        /// Samples are flowing.
+        case live
+        /// The stream ended or errored; retrying (attempt count for the UI).
+        case reconnecting(attempt: Int)
+    }
+
     /// Latest computed machine stats, or `nil` before the first delta.
     private(set) var current: MachineResourceStats?
+    /// Current stream lifecycle phase.
+    private(set) var phase: StreamPhase = .connecting
     /// Whether a sample arrived on the current stream connection.
-    private(set) var isLive = false
+    var isLive: Bool { phase == .live }
 
     /// Rolling per-metric history (oldest first) for the charts.
     private(set) var cpuHistory: [MetricPoint] = []
@@ -39,17 +54,21 @@ final class ActivityViewModel {
     /// lives in `ArcBoxClient.machineStatsStream()`.
     func run(client: ArcBoxClient) async {
         previousSample = nil
-        defer { isLive = false }
+        phase = .connecting
+        defer { phase = .connecting }
 
+        var attempt = 0
         while !Task.isCancelled {
             // A fresh stream each iteration re-reads the client's transport,
             // which it swaps on recovery.
             for await sample in client.machineStatsStream() {
                 guard !Task.isCancelled else { break }
                 ingest(sample)
+                attempt = 0
             }
-            isLive = false
             guard !Task.isCancelled else { return }
+            attempt += 1
+            phase = .reconnecting(attempt: attempt)
             try? await Task.sleep(for: .milliseconds(500))
         }
     }
@@ -63,7 +82,7 @@ final class ActivityViewModel {
             return
         }
         current = computed
-        isLive = true
+        phase = .live
         sequence += 1
         append(&cpuHistory, computed.cpuPercent)
         append(&memoryHistory, computed.memoryUsedPercent)

--- a/ArcBox/ViewModels/ActivityViewModel.swift
+++ b/ArcBox/ViewModels/ActivityViewModel.swift
@@ -1,0 +1,81 @@
+import ArcBoxClient
+import Foundation
+
+/// Drives the Activity Monitor: subscribes to the daemon's `StatsService`
+/// stream, derives rates from the cumulative counters, and keeps a short
+/// rolling history for the sparklines.
+///
+/// Subscribing is passive observation — the daemon never treats a stats
+/// watch as VM activity, so leaving this view open does not hold the VM
+/// out of idle reclaim.
+@MainActor
+@Observable
+final class ActivityViewModel {
+    /// Latest computed machine stats, or `nil` before the first delta.
+    private(set) var current: MachineResourceStats?
+    /// Whether a sample arrived on the current stream connection.
+    private(set) var isLive = false
+
+    /// Rolling per-metric history (oldest first) for the charts.
+    private(set) var cpuHistory: [MetricPoint] = []
+    private(set) var memoryHistory: [MetricPoint] = []
+    private(set) var networkHistory: [MetricPoint] = []
+
+    /// One charted sample. `index` is a monotonic sequence number so
+    /// Swift Charts has a stable, gap-free x-axis.
+    struct MetricPoint: Identifiable {
+        let index: Int
+        let value: Double
+        var id: Int { index }
+    }
+
+    private var previousSample: Arcbox_V1_MachineStats?
+    private var sequence = 0
+    private static let historyLength = 60  // ~1 min at 1 Hz
+
+    /// Streams stats with reconnect until the calling task is cancelled
+    /// (driven by SwiftUI `.task`, which cancels on view disappearance).
+    /// Mirrors the reconnect loop in `DaemonManager+Watch`; the gRPC detail
+    /// lives in `ArcBoxClient.machineStatsStream()`.
+    func run(client: ArcBoxClient) async {
+        previousSample = nil
+        defer { isLive = false }
+
+        while !Task.isCancelled {
+            // A fresh stream each iteration re-reads the client's transport,
+            // which it swaps on recovery.
+            for await sample in client.machineStatsStream() {
+                guard !Task.isCancelled else { break }
+                ingest(sample)
+            }
+            isLive = false
+            guard !Task.isCancelled else { return }
+            try? await Task.sleep(for: .milliseconds(500))
+        }
+    }
+
+    private func ingest(_ sample: Arcbox_V1_MachineStats) {
+        defer { previousSample = sample }
+        guard let previous = previousSample,
+            let computed = ResourceStatsCalculator.compute(previous: previous, current: sample)
+        else {
+            // First sample or a counter reset (guest reboot): rebaseline.
+            return
+        }
+        current = computed
+        isLive = true
+        sequence += 1
+        append(&cpuHistory, computed.cpuPercent)
+        append(&memoryHistory, computed.memoryUsedPercent)
+        append(
+            &networkHistory,
+            computed.networkReceiveBytesPerSecond + computed.networkTransmitBytesPerSecond)
+    }
+
+    private func append(_ series: inout [MetricPoint], _ value: Double) {
+        series.append(MetricPoint(index: sequence, value: value))
+        if series.count > Self.historyLength {
+            series.removeFirst(series.count - Self.historyLength)
+        }
+    }
+}

--- a/ArcBox/Views/Activity/ActivityView.swift
+++ b/ArcBox/Views/Activity/ActivityView.swift
@@ -86,7 +86,8 @@ struct ActivityView: View {
                 title: "Network",
                 value: StatsFormat.rate(
                     stats.networkReceiveBytesPerSecond + stats.networkTransmitBytesPerSecond),
-                subtitle: "↓ \(StatsFormat.rate(stats.networkReceiveBytesPerSecond))   ↑ \(StatsFormat.rate(stats.networkTransmitBytesPerSecond))",
+                subtitle:
+                    "↓ \(StatsFormat.rate(stats.networkReceiveBytesPerSecond))   ↑ \(StatsFormat.rate(stats.networkTransmitBytesPerSecond))",
                 points: vm.networkHistory,
                 tint: AppColors.warning,
                 yDomain: nil

--- a/ArcBox/Views/Activity/ActivityView.swift
+++ b/ArcBox/Views/Activity/ActivityView.swift
@@ -1,0 +1,309 @@
+import ArcBoxClient
+import Charts
+import SwiftUI
+
+/// Live resource monitor for the System VM: machine CPU / memory / network
+/// with short history sparklines, a PSI memory-pressure gauge, and a
+/// per-container table. Backed by the daemon's `StatsService` stream via
+/// `ActivityViewModel`.
+struct ActivityView: View {
+    @Environment(ActivityViewModel.self) private var vm
+    @Environment(\.arcboxClient) private var arcboxClient
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                header
+
+                if let stats = vm.current {
+                    charts(stats)
+                    containerSection(stats)
+                } else {
+                    waitingForData
+                }
+            }
+            .padding(20)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(AppColors.background)
+        .navigationTitle("Activity")
+        // Re-key on the client's identity so the stream (re)starts when the
+        // client first becomes available or is swapped.
+        .task(id: arcboxClient.map(ObjectIdentifier.init)) {
+            guard let client = arcboxClient else { return }
+            await vm.run(client: client)
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Text("System VM")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(AppColors.text)
+            Spacer()
+            if vm.isLive {
+                StatusBadge(color: AppColors.running, label: "LIVE")
+            }
+        }
+    }
+
+    private var waitingForData: some View {
+        HStack(spacing: 10) {
+            ProgressView().controlSize(.small)
+            Text("Waiting for the first sample…")
+                .foregroundStyle(AppColors.textSecondary)
+                .font(.system(size: 13))
+        }
+        .frame(maxWidth: .infinity, minHeight: 160)
+    }
+
+    // MARK: - Charts
+
+    private func charts(_ stats: MachineResourceStats) -> some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 240), spacing: 12)],
+            spacing: 12
+        ) {
+            SparklineCard(
+                title: "CPU",
+                value: StatsFormat.percent(stats.cpuPercent),
+                subtitle: "\(stats.onlineCPUs) cores · load \(String(format: "%.2f", stats.loadaverage1))",
+                points: vm.cpuHistory,
+                tint: AppColors.running,
+                yDomain: 0...100
+            )
+            SparklineCard(
+                title: "Memory",
+                value: StatsFormat.percent(stats.memoryUsedPercent),
+                subtitle: "\(StatsFormat.bytes(stats.memoryUsedBytes)) / \(StatsFormat.bytes(stats.memoryTotalBytes))",
+                points: vm.memoryHistory,
+                tint: AppColors.accent,
+                yDomain: 0...100
+            )
+            SparklineCard(
+                title: "Network",
+                value: StatsFormat.rate(
+                    stats.networkReceiveBytesPerSecond + stats.networkTransmitBytesPerSecond),
+                subtitle: "↓ \(StatsFormat.rate(stats.networkReceiveBytesPerSecond))   ↑ \(StatsFormat.rate(stats.networkTransmitBytesPerSecond))",
+                points: vm.networkHistory,
+                tint: AppColors.warning,
+                yDomain: nil
+            )
+            PressureCard(stats: stats)
+        }
+    }
+
+    // MARK: - Containers
+
+    @ViewBuilder
+    private func containerSection(_ stats: MachineResourceStats) -> some View {
+        Text("Containers")
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(AppColors.sectionHeader)
+            .textCase(.uppercase)
+            .padding(.top, 4)
+
+        if stats.containers.isEmpty {
+            Text("No running containers")
+                .foregroundStyle(AppColors.textMuted)
+                .font(.system(size: 13))
+                .padding(.vertical, 8)
+        } else {
+            VStack(spacing: 0) {
+                ContainerStatsHeader()
+                ForEach(stats.containers) { container in
+                    ContainerStatsRow(container: container)
+                    if container.id != stats.containers.last?.id {
+                        Divider().overlay(AppColors.borderSubtle)
+                    }
+                }
+            }
+            .cardStyle()
+        }
+    }
+}
+
+// MARK: - Sparkline card
+
+private struct SparklineCard: View {
+    let title: String
+    let value: String
+    let subtitle: String
+    let points: [ActivityViewModel.MetricPoint]
+    let tint: Color
+    /// Fixed y-axis range, or `nil` to autoscale (used for byte rates).
+    let yDomain: ClosedRange<Double>?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(AppColors.textSecondary)
+                .textCase(.uppercase)
+            Text(value)
+                .font(.system(size: 28, weight: .semibold, design: .rounded))
+                .foregroundStyle(AppColors.text)
+                .contentTransition(.numericText())
+            chart
+                .frame(height: 44)
+            Text(subtitle)
+                .font(.system(size: 11))
+                .foregroundStyle(AppColors.textMuted)
+                .lineLimit(1)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .cardStyle()
+    }
+
+    private var chart: some View {
+        Chart(points) { point in
+            AreaMark(x: .value("t", point.index), y: .value("v", point.value))
+                .foregroundStyle(tint.opacity(0.15))
+                .interpolationMethod(.monotone)
+            LineMark(x: .value("t", point.index), y: .value("v", point.value))
+                .foregroundStyle(tint)
+                .interpolationMethod(.monotone)
+        }
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
+        .chartYScale(domain: yDomain ?? autoDomain)
+        .animation(.easeOut(duration: 0.25), value: points.last?.index)
+    }
+
+    /// Headroom above the observed peak so a flat-zero series still renders.
+    private var autoDomain: ClosedRange<Double> {
+        let peak = points.map(\.value).max() ?? 1
+        return 0...max(peak * 1.2, 1)
+    }
+}
+
+// MARK: - Pressure gauge card
+
+private struct PressureCard: View {
+    let stats: MachineResourceStats
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Memory Pressure")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(AppColors.textSecondary)
+                .textCase(.uppercase)
+            Text(valueText)
+                .font(.system(size: 28, weight: .semibold, design: .rounded))
+                .foregroundStyle(tint)
+                .contentTransition(.numericText())
+            Gauge(value: stats.hasMemoryPressure ? min(stats.memoryPressurePercent, 100) : 0, in: 0...100) {
+                EmptyView()
+            }
+            .gaugeStyle(.accessoryLinearCapacity)
+            .tint(tint)
+            .frame(height: 44)
+            .opacity(stats.hasMemoryPressure ? 1 : 0.35)
+            Text(stats.hasMemoryPressure ? "PSI full avg10" : "PSI unavailable (no CONFIG_PSI)")
+                .font(.system(size: 11))
+                .foregroundStyle(AppColors.textMuted)
+                .lineLimit(1)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .cardStyle()
+    }
+
+    private var valueText: String {
+        stats.hasMemoryPressure ? StatsFormat.percent(stats.memoryPressurePercent) : "n/a"
+    }
+
+    /// Green under light pressure, amber past 10%, red past 40% — matching
+    /// the daemon's own pressure thresholds.
+    private var tint: Color {
+        guard stats.hasMemoryPressure else { return AppColors.textMuted }
+        switch stats.memoryPressurePercent {
+        case ..<10: return AppColors.running
+        case ..<40: return AppColors.warning
+        default: return AppColors.error
+        }
+    }
+}
+
+// MARK: - Container table
+
+private struct ContainerStatsHeader: View {
+    var body: some View {
+        HStack(spacing: 12) {
+            cell("CONTAINER", width: nil, alignment: .leading)
+            cell("CPU", width: 64, alignment: .trailing)
+            cell("MEMORY", width: 96, alignment: .trailing)
+            cell("DISK R/W", width: 128, alignment: .trailing)
+            cell("PIDS", width: 48, alignment: .trailing)
+        }
+        .font(.system(size: 10, weight: .medium))
+        .foregroundStyle(AppColors.sectionHeader)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private func cell(_ text: String, width: CGFloat?, alignment: Alignment) -> some View {
+        Text(text)
+            .frame(width: width, alignment: alignment)
+            .frame(maxWidth: width == nil ? .infinity : nil, alignment: alignment)
+    }
+}
+
+private struct ContainerStatsRow: View {
+    let container: ContainerResourceStats
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text(container.displayName)
+                .font(.system(size: 13))
+                .foregroundStyle(AppColors.text)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text(StatsFormat.percent(container.cpuPercent))
+                .frame(width: 64, alignment: .trailing)
+            Text(memoryText)
+                .frame(width: 96, alignment: .trailing)
+            Text(
+                "\(StatsFormat.rate(container.diskReadBytesPerSecond)) / \(StatsFormat.rate(container.diskWriteBytesPerSecond))"
+            )
+            .frame(width: 128, alignment: .trailing)
+            Text("\(container.pids)")
+                .frame(width: 48, alignment: .trailing)
+        }
+        .font(.system(size: 12).monospacedDigit())
+        .foregroundStyle(AppColors.textSecondary)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+    }
+
+    private var memoryText: String {
+        if container.memoryLimitBytes == 0 {
+            return StatsFormat.bytes(container.memoryCurrentBytes)
+        }
+        return
+            "\(StatsFormat.bytes(container.memoryCurrentBytes)) / \(StatsFormat.bytes(container.memoryLimitBytes))"
+    }
+}
+
+// MARK: - Formatting
+
+/// Formatting for resource values, using `ByteCountFormatter` (memory
+/// style) so sizes match Finder/Activity Monitor conventions.
+enum StatsFormat {
+    static func percent(_ value: Double) -> String {
+        String(format: "%.0f%%", value)
+    }
+
+    static func bytes(_ value: UInt64) -> String {
+        ByteCountFormatter.string(fromByteCount: Int64(clamping: value), countStyle: .memory)
+    }
+
+    static func rate(_ bytesPerSecond: Double) -> String {
+        let clamped = Int64(max(0, bytesPerSecond).rounded())
+        return ByteCountFormatter.string(fromByteCount: clamped, countStyle: .memory) + "/s"
+    }
+}

--- a/ArcBox/Views/Activity/ActivityView.swift
+++ b/ArcBox/Views/Activity/ActivityView.swift
@@ -43,8 +43,15 @@ struct ActivityView: View {
                 .font(.system(size: 20, weight: .semibold))
                 .foregroundStyle(AppColors.text)
             Spacer()
-            if vm.isLive {
+            switch vm.phase {
+            case .live:
                 StatusBadge(color: AppColors.running, label: "LIVE")
+            case .reconnecting:
+                // Charts keep showing the last data; the badge tells the
+                // user it is stale while the stream reconnects.
+                StatusBadge(color: AppColors.warning, label: "RECONNECTING")
+            case .connecting:
+                EmptyView()
             }
         }
     }
@@ -52,11 +59,21 @@ struct ActivityView: View {
     private var waitingForData: some View {
         HStack(spacing: 10) {
             ProgressView().controlSize(.small)
-            Text("Waiting for the first sample…")
+            Text(waitingLabel)
                 .foregroundStyle(AppColors.textSecondary)
                 .font(.system(size: 13))
         }
         .frame(maxWidth: .infinity, minHeight: 160)
+    }
+
+    /// Distinguishes a first connection from a stream that keeps failing
+    /// before its first sample, so persistent errors don't render as an
+    /// eternal "waiting" spinner.
+    private var waitingLabel: String {
+        if case .reconnecting(let attempt) = vm.phase {
+            return "Stats stream unavailable — retrying (attempt \(attempt))…"
+        }
+        return "Waiting for the first sample…"
     }
 
     // MARK: - Charts

--- a/ArcBox/Views/Activity/ActivityView.swift
+++ b/ArcBox/Views/Activity/ActivityView.swift
@@ -237,6 +237,7 @@ private struct ContainerStatsHeader: View {
             cell("CPU", width: 64, alignment: .trailing)
             cell("MEMORY", width: 96, alignment: .trailing)
             cell("DISK R/W", width: 128, alignment: .trailing)
+            cell("NET ↓/↑", width: 128, alignment: .trailing)
             cell("PIDS", width: 48, alignment: .trailing)
         }
         .font(.system(size: 10, weight: .medium))
@@ -269,6 +270,10 @@ private struct ContainerStatsRow: View {
                 .frame(width: 96, alignment: .trailing)
             Text(
                 "\(StatsFormat.rate(container.diskReadBytesPerSecond)) / \(StatsFormat.rate(container.diskWriteBytesPerSecond))"
+            )
+            .frame(width: 128, alignment: .trailing)
+            Text(
+                "\(StatsFormat.rate(container.networkReceiveBytesPerSecond)) / \(StatsFormat.rate(container.networkTransmitBytesPerSecond))"
             )
             .frame(width: 128, alignment: .trailing)
             Text("\(container.pids)")

--- a/ArcBox/Views/ContentView.swift
+++ b/ArcBox/Views/ContentView.swift
@@ -11,6 +11,7 @@ struct ContentView: View {
     @Environment(NetworksViewModel.self) private var networksVM
 
     // Feature ViewModels -- local to main window
+    @State private var activityVM = ActivityViewModel()
     @State private var k8sState = KubernetesState()
     @State private var podsVM = PodsViewModel()
     @State private var servicesVM = ServicesViewModel()
@@ -30,6 +31,12 @@ struct ContentView: View {
                 Color.clear
                     .navigationSplitViewColumnWidth(0)
                     .navigationTitle("Templates")
+            } else if appVM.currentNav == .activity {
+                // Activity is a single full-width dashboard rendered in the
+                // detail column; collapse the content column.
+                Color.clear
+                    .navigationSplitViewColumnWidth(0)
+                    .navigationTitle("Activity")
             } else {
                 contentColumn
                     .background(AppColors.background)
@@ -56,6 +63,12 @@ struct ContentView: View {
         @Bindable var vm = appVM
 
         return List(selection: $vm.currentNav) {
+            Section("System") {
+                ForEach(NavItem.Section.system.items) { item in
+                    Label(item.label, systemImage: item.sfSymbol)
+                        .tag(item)
+                }
+            }
             Section("Docker") {
                 ForEach(NavItem.Section.docker.items) { item in
                     Label(item.label, systemImage: item.sfSymbol)
@@ -97,6 +110,9 @@ struct ContentView: View {
     @ViewBuilder
     private var contentColumn: some View {
         switch appVM.currentNav {
+        case .activity:
+            // Rendered full-width in the detail column.
+            Color.clear
         case .containers:
             ContainersListView()
                 .environment(containersVM)
@@ -137,6 +153,9 @@ struct ContentView: View {
     @ViewBuilder
     private var detailPanel: some View {
         switch appVM.currentNav {
+        case .activity:
+            ActivityView()
+                .environment(activityVM)
         case .containers:
             ContainerDetailView()
                 .environment(containersVM)

--- a/ArcBox/Views/MenuBar/MenuBarView/MenuBarView+Layout.swift
+++ b/ArcBox/Views/MenuBar/MenuBarView/MenuBarView+Layout.swift
@@ -18,6 +18,8 @@ extension MenuBarView {
             header
                 .padding(.bottom, 4)
 
+            liveStatsRow
+
             metricCards
 
             containersSection

--- a/ArcBox/Views/MenuBar/MenuBarView/MenuBarView+Metrics.swift
+++ b/ArcBox/Views/MenuBar/MenuBarView/MenuBarView+Metrics.swift
@@ -1,6 +1,74 @@
+import ArcBoxClient
 import SwiftUI
 
 extension MenuBarView {
+    // MARK: - Live Stats
+
+    /// Compact live CPU / memory tiles, fed by the stats stream while the
+    /// popover is open. Tapping either opens the full Activity Monitor.
+    var liveStatsRow: some View {
+        HStack(spacing: 6) {
+            liveMetricTile(
+                title: "CPU",
+                symbol: "cpu",
+                percent: activityVM.current?.cpuPercent,
+                tint: .green
+            )
+            liveMetricTile(
+                title: "Memory",
+                symbol: "memorychip",
+                percent: activityVM.current?.memoryUsedPercent,
+                tint: .accentColor
+            )
+        }
+        .padding(.bottom, 2)
+    }
+
+    func liveMetricTile(
+        title: String,
+        symbol: String,
+        percent: Double?,
+        tint: Color
+    ) -> some View {
+        Button {
+            navigateToPage(.activity)
+        } label: {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 4) {
+                    Image(systemName: symbol)
+                        .font(.caption2)
+                        .foregroundStyle(tint)
+                    Text(title)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 0)
+
+                Text(percent.map { String(format: "%.0f%%", $0) } ?? "—")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(tint)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .contentTransition(.numericText())
+
+                Gauge(value: min(max(percent ?? 0, 0), 100), in: 0...100) {
+                    EmptyView()
+                }
+                .gaugeStyle(.accessoryLinearCapacity)
+                .tint(tint)
+                .opacity(percent == nil ? 0.3 : 1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(8)
+            .frame(height: 70)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(.quaternary.opacity(0.30))
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
     // MARK: - Metric Cards
 
     var metricCards: some View {

--- a/ArcBox/Views/MenuBar/MenuBarView/MenuBarView.swift
+++ b/ArcBox/Views/MenuBar/MenuBarView/MenuBarView.swift
@@ -27,7 +27,11 @@ struct MenuBarView: View {
                 guard docker != nil, daemonManager.state.isRunning else { return }
                 await loadAll()
             }
-            .task(id: daemonManager.state.isRunning) {
+            // Keyed on the client identity as well as daemon state: the
+            // client can be installed (or swapped on recovery) after the
+            // daemon is already running, and only an id change retriggers
+            // the task. Mirrors ActivityView's stream task.
+            .task(id: daemonManager.state.isRunning ? client.map(ObjectIdentifier.init) : nil) {
                 guard let client, daemonManager.state.isRunning else { return }
                 await activityVM.run(client: client)
             }

--- a/ArcBox/Views/MenuBar/MenuBarView/MenuBarView.swift
+++ b/ArcBox/Views/MenuBar/MenuBarView/MenuBarView.swift
@@ -15,6 +15,9 @@ struct MenuBarView: View {
     @Environment(\.dockerClient) var docker
 
     @State var containersExpanded = true
+    /// Drives the live CPU/memory tiles while the menu-bar popover is open;
+    /// the stream stops when the popover closes (`.task` cancellation).
+    @State var activityVM = ActivityViewModel()
 
     var body: some View {
         mainPanel
@@ -23,6 +26,10 @@ struct MenuBarView: View {
             .task(id: docker != nil && daemonManager.state.isRunning) {
                 guard docker != nil, daemonManager.state.isRunning else { return }
                 await loadAll()
+            }
+            .task(id: daemonManager.state.isRunning) {
+                guard let client, daemonManager.state.isRunning else { return }
+                await activityVM.run(client: client)
             }
             .onReceive(NotificationCenter.default.publisher(for: .dockerContainerChanged)) { _ in
                 Task { await containersVM.loadContainersFromDocker(docker: docker, iconClient: client) }

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/ArcBoxClient+Stats.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/ArcBoxClient+Stats.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+extension ArcBoxClient {
+    /// Opens a single `StatsService.Watch` connection and yields machine
+    /// stats samples until the stream ends or errors.
+    ///
+    /// This keeps the gRPC streaming detail (and the `GRPCCore` dependency)
+    /// inside the client library — the app layer consumes a plain
+    /// `AsyncStream` and owns the reconnect loop, mirroring how
+    /// `DaemonManager` drives `WatchSetupStatus`. Cancelling the consuming
+    /// task (or dropping the stream) cancels the underlying RPC.
+    public func machineStatsStream() -> AsyncStream<Arcbox_V1_MachineStats> {
+        let statsService = stats
+        return AsyncStream { continuation in
+            let task = Task {
+                do {
+                    try await statsService.watch(Arcbox_V1_StatsWatchRequest()) { response in
+                        for try await message in response.messages {
+                            continuation.yield(message)
+                        }
+                    }
+                } catch {
+                    ClientLog.daemon.warning(
+                        "WatchStats stream error: \(error.localizedDescription, privacy: .private)")
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+}

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/ArcBoxClient.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/ArcBoxClient.swift
@@ -149,6 +149,11 @@ public final class ArcBoxClient: Sendable {
         .init(wrapping: grpcClient)
     }
 
+    /// Live machine and per-container resource stats (Activity Monitor).
+    public var stats: Arcbox_V1_StatsService.Client<HTTP2ClientTransport.TransportServices> {
+        .init(wrapping: grpcClient)
+    }
+
     /// Volume management operations.
     public var volumes: Arcbox_V1_VolumeService.Client<HTTP2ClientTransport.TransportServices> {
         .init(wrapping: grpcClient)

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/ResourceStats.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/ResourceStats.swift
@@ -68,7 +68,8 @@ public enum ResourceStatsCalculator {
         let totalTicks = Double(current.cpuTotalTicks - previous.cpuTotalTicks)
         let busyTicks = Double(current.cpuBusyTicks.subtractingReportingOverflow(previous.cpuBusyTicks).0)
 
-        let memoryUsed = current.memoryTotalBytes >= current.memoryAvailableBytes
+        let memoryUsed =
+            current.memoryTotalBytes >= current.memoryAvailableBytes
             ? current.memoryTotalBytes - current.memoryAvailableBytes
             : 0
 
@@ -107,7 +108,8 @@ public enum ResourceStatsCalculator {
             let prior = priors[container.id]
             let cpuPercent: Double
             if let prior, container.cpuUsageUsec > prior.cpuUsageUsec {
-                cpuPercent = Double(container.cpuUsageUsec - prior.cpuUsageUsec)
+                cpuPercent =
+                    Double(container.cpuUsageUsec - prior.cpuUsageUsec)
                     / (dt * 1_000_000) * 100
             } else {
                 cpuPercent = 0

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/ResourceStats.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/ResourceStats.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+/// Machine-level resource rates and gauges derived from two consecutive
+/// `Arcbox_V1_MachineStats` samples.
+///
+/// The daemon streams cumulative counters (see `stats.proto`); rates are
+/// derived here from deltas over the guest monotonic clock, mirroring
+/// `abctl top` so the desktop and CLI agree. This keeps the view layer
+/// free of counter arithmetic.
+public struct MachineResourceStats: Sendable, Equatable {
+    public var cpuPercent: Double
+    public var onlineCPUs: UInt32
+    public var loadaverage1: Double
+    public var memoryTotalBytes: UInt64
+    public var memoryUsedBytes: UInt64
+    public var memoryUsedPercent: Double
+    /// PSI memory `full avg10` (0–100). Negative when the guest kernel
+    /// lacks `CONFIG_PSI`; the view shows "n/a" in that case.
+    public var memoryPressurePercent: Double
+    public var diskReadBytesPerSecond: Double
+    public var diskWriteBytesPerSecond: Double
+    public var networkReceiveBytesPerSecond: Double
+    public var networkTransmitBytesPerSecond: Double
+    public var containers: [ContainerResourceStats]
+
+    /// Whether the guest kernel reported a usable PSI pressure gauge.
+    public var hasMemoryPressure: Bool { memoryPressurePercent >= 0 }
+}
+
+/// One container's resource rates and gauges, derived from the same two
+/// samples. `Identifiable` by container ID for use in SwiftUI lists.
+public struct ContainerResourceStats: Sendable, Equatable, Identifiable {
+    public var id: String
+    /// Daemon-enriched name, or the 12-char short ID when unknown.
+    public var displayName: String
+    /// Percent of one core (may exceed 100 for a multi-threaded
+    /// container), matching `docker stats`.
+    public var cpuPercent: Double
+    public var memoryCurrentBytes: UInt64
+    /// 0 means unlimited.
+    public var memoryLimitBytes: UInt64
+    public var diskReadBytesPerSecond: Double
+    public var diskWriteBytesPerSecond: Double
+    public var pids: UInt32
+}
+
+/// Derives `MachineResourceStats` from consecutive raw samples.
+public enum ResourceStatsCalculator {
+    /// Computes rates between two samples.
+    ///
+    /// Returns `nil` when the guest clock or CPU counters went backwards —
+    /// the counters reset (guest reboot) and the caller should treat
+    /// `current` as the new baseline instead of emitting nonsense rates.
+    public static func compute(
+        previous: Arcbox_V1_MachineStats,
+        current: Arcbox_V1_MachineStats
+    ) -> MachineResourceStats? {
+        guard current.monotonicMs > previous.monotonicMs,
+            current.cpuTotalTicks > previous.cpuTotalTicks
+        else {
+            return nil
+        }
+        let dt = Double(current.monotonicMs - previous.monotonicMs) / 1000.0
+        let totalTicks = Double(current.cpuTotalTicks - previous.cpuTotalTicks)
+        let busyTicks = Double(current.cpuBusyTicks.subtractingReportingOverflow(previous.cpuBusyTicks).0)
+
+        let memoryUsed = current.memoryTotalBytes >= current.memoryAvailableBytes
+            ? current.memoryTotalBytes - current.memoryAvailableBytes
+            : 0
+
+        return MachineResourceStats(
+            cpuPercent: min(busyTicks / totalTicks * 100, 100),
+            onlineCPUs: current.onlineCpus,
+            loadaverage1: current.loadavg1,
+            memoryTotalBytes: current.memoryTotalBytes,
+            memoryUsedBytes: memoryUsed,
+            memoryUsedPercent: current.memoryTotalBytes == 0
+                ? 0
+                : Double(memoryUsed) / Double(current.memoryTotalBytes) * 100,
+            memoryPressurePercent: current.memoryPsiFullAvg10,
+            diskReadBytesPerSecond: rate(current.diskReadBytes, previous.diskReadBytes, dt),
+            diskWriteBytesPerSecond: rate(current.diskWrittenBytes, previous.diskWrittenBytes, dt),
+            networkReceiveBytesPerSecond: rate(current.netRxBytes, previous.netRxBytes, dt),
+            networkTransmitBytesPerSecond: rate(current.netTxBytes, previous.netTxBytes, dt),
+            containers: computeContainers(previous: previous, current: current, dt: dt)
+        )
+    }
+
+    /// Joins each current container with its previous sample by ID,
+    /// computes per-container rates, and sorts by CPU descending. A
+    /// container with no prior sample (just started) reports 0% CPU until
+    /// the next frame gives it a baseline.
+    private static func computeContainers(
+        previous: Arcbox_V1_MachineStats,
+        current: Arcbox_V1_MachineStats,
+        dt: Double
+    ) -> [ContainerResourceStats] {
+        let priors = Dictionary(
+            previous.containers.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let computed = current.containers.map { container -> ContainerResourceStats in
+            let prior = priors[container.id]
+            let cpuPercent: Double
+            if let prior, container.cpuUsageUsec > prior.cpuUsageUsec {
+                cpuPercent = Double(container.cpuUsageUsec - prior.cpuUsageUsec)
+                    / (dt * 1_000_000) * 100
+            } else {
+                cpuPercent = 0
+            }
+            return ContainerResourceStats(
+                id: container.id,
+                displayName: container.name.isEmpty
+                    ? String(container.id.prefix(12))
+                    : container.name,
+                cpuPercent: cpuPercent,
+                memoryCurrentBytes: container.memoryCurrentBytes,
+                memoryLimitBytes: container.memoryLimitBytes,
+                diskReadBytesPerSecond: rate(
+                    container.diskReadBytes, prior?.diskReadBytes ?? container.diskReadBytes, dt),
+                diskWriteBytesPerSecond: rate(
+                    container.diskWrittenBytes, prior?.diskWrittenBytes ?? container.diskWrittenBytes, dt),
+                pids: container.pids
+            )
+        }
+        return computed.sorted { $0.cpuPercent > $1.cpuPercent }
+    }
+
+    private static func rate(_ current: UInt64, _ previous: UInt64, _ dt: Double) -> Double {
+        guard current >= previous, dt > 0 else { return 0 }
+        return Double(current - previous) / dt
+    }
+}

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/ResourceStats.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/ResourceStats.swift
@@ -60,13 +60,14 @@ public enum ResourceStatsCalculator {
         current: Arcbox_V1_MachineStats
     ) -> MachineResourceStats? {
         guard current.monotonicMs > previous.monotonicMs,
-            current.cpuTotalTicks > previous.cpuTotalTicks
+            current.cpuTotalTicks > previous.cpuTotalTicks,
+            current.cpuBusyTicks >= previous.cpuBusyTicks
         else {
             return nil
         }
         let dt = Double(current.monotonicMs - previous.monotonicMs) / 1000.0
         let totalTicks = Double(current.cpuTotalTicks - previous.cpuTotalTicks)
-        let busyTicks = Double(current.cpuBusyTicks.subtractingReportingOverflow(previous.cpuBusyTicks).0)
+        let busyTicks = Double(current.cpuBusyTicks - previous.cpuBusyTicks)
 
         let memoryUsed =
             current.memoryTotalBytes >= current.memoryAvailableBytes

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/ResourceStats.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/ResourceStats.swift
@@ -41,6 +41,10 @@ public struct ContainerResourceStats: Sendable, Equatable, Identifiable {
     public var memoryLimitBytes: UInt64
     public var diskReadBytesPerSecond: Double
     public var diskWriteBytesPerSecond: Double
+    /// Read from the container's network namespace; 0 for a host-networked
+    /// container (its traffic is the machine's).
+    public var networkReceiveBytesPerSecond: Double
+    public var networkTransmitBytesPerSecond: Double
     public var pids: UInt32
 }
 
@@ -120,6 +124,10 @@ public enum ResourceStatsCalculator {
                     container.diskReadBytes, prior?.diskReadBytes ?? container.diskReadBytes, dt),
                 diskWriteBytesPerSecond: rate(
                     container.diskWrittenBytes, prior?.diskWrittenBytes ?? container.diskWrittenBytes, dt),
+                networkReceiveBytesPerSecond: rate(
+                    container.netRxBytes, prior?.netRxBytes ?? container.netRxBytes, dt),
+                networkTransmitBytesPerSecond: rate(
+                    container.netTxBytes, prior?.netTxBytes ?? container.netTxBytes, dt),
                 pids: container.pids
             )
         }

--- a/Packages/ArcBoxClient/Tests/ArcBoxClientTests/ResourceStatsTests.swift
+++ b/Packages/ArcBoxClient/Tests/ArcBoxClientTests/ResourceStatsTests.swift
@@ -55,6 +55,14 @@ import Testing
         #expect(ResourceStatsCalculator.compute(previous: prev, current: cur) == nil)
     }
 
+    @Test func busyTickRegressionAsksForNewBaselineInsteadOfWrapping() {
+        // Busy ticks went backwards while the clock and total ticks kept
+        // advancing: an unsigned wrap here used to report 100% CPU.
+        let prev = machine(monotonicMs: 10_000, busy: 4000, total: 50_000)
+        let cur = machine(monotonicMs: 12_000, busy: 10, total: 50_200)
+        #expect(ResourceStatsCalculator.compute(previous: prev, current: cur) == nil)
+    }
+
     @Test func containerCpuFromUsecDeltaAndSortedDescending() {
         var prev = machine(monotonicMs: 10_000, busy: 100, total: 1000)
         var cur = machine(monotonicMs: 12_000, busy: 150, total: 1200)  // +2s

--- a/Packages/ArcBoxClient/Tests/ArcBoxClientTests/ResourceStatsTests.swift
+++ b/Packages/ArcBoxClient/Tests/ArcBoxClientTests/ResourceStatsTests.swift
@@ -97,6 +97,23 @@ import Testing
         #expect(stats.containers[0].displayName == "arcbox-postgres-1")
     }
 
+    @Test func containerNetworkRateFromDeltas() {
+        var prev = machine(monotonicMs: 10_000, busy: 100, total: 1000)
+        var cur = machine(monotonicMs: 12_000, busy: 150, total: 1200)  // +2s
+        var p = container("net", cpuUsec: 0, memory: 100)
+        p.netRxBytes = 1000
+        p.netTxBytes = 2000
+        prev.containers = [p]
+        var n = container("net", cpuUsec: 0, memory: 100)
+        n.netRxBytes = 1000 + 4096  // +2 KiB/s
+        n.netTxBytes = 2000 + 1024  // +512 B/s
+        cur.containers = [n]
+
+        let stats = ResourceStatsCalculator.compute(previous: prev, current: cur)!
+        #expect(abs(stats.containers[0].networkReceiveBytesPerSecond - 2048.0) < 0.001)
+        #expect(abs(stats.containers[0].networkTransmitBytesPerSecond - 512.0) < 0.001)
+    }
+
     @Test func negativePsiMeansNoPressureGauge() {
         let prev = machine(monotonicMs: 10_000, busy: 100, total: 1000)
         var cur = machine(monotonicMs: 12_000, busy: 150, total: 1200)

--- a/Packages/ArcBoxClient/Tests/ArcBoxClientTests/ResourceStatsTests.swift
+++ b/Packages/ArcBoxClient/Tests/ArcBoxClientTests/ResourceStatsTests.swift
@@ -1,0 +1,108 @@
+import Testing
+
+@testable import ArcBoxClient
+
+@Suite struct ResourceStatsTests {
+    private func machine(monotonicMs: UInt64, busy: UInt64, total: UInt64) -> Arcbox_V1_MachineStats {
+        var m = Arcbox_V1_MachineStats()
+        m.monotonicMs = monotonicMs
+        m.cpuBusyTicks = busy
+        m.cpuTotalTicks = total
+        m.onlineCpus = 4
+        m.loadavg1 = 0.5
+        m.memoryTotalBytes = 8 * 1024 * 1024 * 1024
+        m.memoryAvailableBytes = 6 * 1024 * 1024 * 1024
+        m.memoryPsiFullAvg10 = 0.5
+        m.diskReadBytes = 1000
+        m.diskWrittenBytes = 2000
+        m.netRxBytes = 3000
+        m.netTxBytes = 4000
+        return m
+    }
+
+    private func container(_ id: String, cpuUsec: UInt64, memory: UInt64, name: String = "")
+        -> Arcbox_V1_ContainerStats
+    {
+        var c = Arcbox_V1_ContainerStats()
+        c.id = id
+        c.name = name
+        c.cpuUsageUsec = cpuUsec
+        c.memoryCurrentBytes = memory
+        c.pids = 3
+        return c
+    }
+
+    @Test func ratesComeFromDeltasOverGuestTime() {
+        let prev = machine(monotonicMs: 10_000, busy: 100, total: 1000)
+        var cur = machine(monotonicMs: 12_000, busy: 150, total: 1200)  // +2s, 50/200 busy
+        cur.diskReadBytes = 1000 + 2048
+        cur.netTxBytes = 4000 + 1024
+
+        let stats = ResourceStatsCalculator.compute(previous: prev, current: cur)
+        #expect(stats != nil)
+        #expect(abs(stats!.cpuPercent - 25.0) < 0.001)
+        #expect(abs(stats!.diskReadBytesPerSecond - 1024.0) < 0.001)
+        #expect(abs(stats!.networkTransmitBytesPerSecond - 512.0) < 0.001)
+        #expect(abs(stats!.memoryUsedPercent - 25.0) < 0.01)
+    }
+
+    @Test func counterResetAsksForNewBaseline() {
+        // Guest rebooted: monotonic clock and ticks both went backwards.
+        let prev = machine(monotonicMs: 500_000, busy: 4000, total: 50_000)
+        let cur = machine(monotonicMs: 3_000, busy: 10, total: 100)
+        #expect(ResourceStatsCalculator.compute(previous: prev, current: cur) == nil)
+    }
+
+    @Test func containerCpuFromUsecDeltaAndSortedDescending() {
+        var prev = machine(monotonicMs: 10_000, busy: 100, total: 1000)
+        var cur = machine(monotonicMs: 12_000, busy: 150, total: 1200)  // +2s
+        prev.containers = [container("busy", cpuUsec: 0, memory: 100), container("idle", cpuUsec: 0, memory: 50)]
+        cur.containers = [
+            container("idle", cpuUsec: 0, memory: 50),  // no CPU movement
+            container("busy", cpuUsec: 1_000_000, memory: 100),  // +1s cpu over 2s = 50%
+        ]
+
+        let stats = ResourceStatsCalculator.compute(previous: prev, current: cur)!
+        #expect(stats.containers[0].id == "busy")
+        #expect(abs(stats.containers[0].cpuPercent - 50.0) < 0.01)
+        #expect(stats.containers[1].cpuPercent == 0)
+    }
+
+    @Test func freshContainerReportsZeroCpuUntilBaseline() {
+        let prev = machine(monotonicMs: 10_000, busy: 100, total: 1000)
+        var cur = machine(monotonicMs: 12_000, busy: 150, total: 1200)
+        cur.containers = [container("fresh", cpuUsec: 5_000_000, memory: 128)]
+
+        let stats = ResourceStatsCalculator.compute(previous: prev, current: cur)!
+        #expect(stats.containers.count == 1)
+        #expect(stats.containers[0].cpuPercent == 0)  // no baseline → 0, not a spike
+    }
+
+    @Test func emptyNameFallsBackToShortID() {
+        let id = "0a1b2c3d4e5f00112233445566778899aabbccddeeff00112233445566778899"
+        let prev = machine(monotonicMs: 10_000, busy: 100, total: 1000)
+        var cur = machine(monotonicMs: 12_000, busy: 150, total: 1200)
+        cur.containers = [container(id, cpuUsec: 0, memory: 64)]
+
+        let stats = ResourceStatsCalculator.compute(previous: prev, current: cur)!
+        #expect(stats.containers[0].displayName == "0a1b2c3d4e5f")
+    }
+
+    @Test func enrichedNameIsPreferred() {
+        let prev = machine(monotonicMs: 10_000, busy: 100, total: 1000)
+        var cur = machine(monotonicMs: 12_000, busy: 150, total: 1200)
+        cur.containers = [container("abcdef123456", cpuUsec: 0, memory: 64, name: "arcbox-postgres-1")]
+
+        let stats = ResourceStatsCalculator.compute(previous: prev, current: cur)!
+        #expect(stats.containers[0].displayName == "arcbox-postgres-1")
+    }
+
+    @Test func negativePsiMeansNoPressureGauge() {
+        let prev = machine(monotonicMs: 10_000, busy: 100, total: 1000)
+        var cur = machine(monotonicMs: 12_000, busy: 150, total: 1200)
+        cur.memoryPsiFullAvg10 = -1
+
+        let stats = ResourceStatsCalculator.compute(previous: prev, current: cur)!
+        #expect(stats.hasMemoryPressure == false)
+    }
+}

--- a/Packages/ArcBoxClient/Tests/ArcBoxClientTests/ResourceStatsTests.swift
+++ b/Packages/ArcBoxClient/Tests/ArcBoxClientTests/ResourceStatsTests.swift
@@ -20,7 +20,9 @@ import Testing
         return m
     }
 
-    private func container(_ id: String, cpuUsec: UInt64, memory: UInt64, name: String = "")
+    private func container(
+        _ id: String, cpuUsec: UInt64, memory: UInt64, name: String = ""
+    )
         -> Arcbox_V1_ContainerStats
     {
         var c = Arcbox_V1_ContainerStats()


### PR DESCRIPTION
Phase P3 of the resource monitor (ArcBox ABX-115): the desktop **Activity
Monitor** — live System VM CPU / memory / network with history
sparklines, a PSI memory-pressure gauge, and a per-container table.

Consumes the `StatsService.Watch` stream added in arcbox P1/P2
(arcboxlabs/arcbox #397, #398).

## ⚠️ Merge dependency (read first)

This PR regenerates the gRPC Swift stubs from **local** arcbox protos
(the unreleased `stats.proto`). CI's `verify-arcbox-protobuf` regenerates
from the pinned `arcbox.version` (**v0.4.17**), which predates
`stats.proto`, so **that check will fail until**:

1. arcbox #397 (P1) and #398 (P2) merge to arcbox `master`;
2. a new arcbox release tag is cut that contains `stats.proto`;
3. here: `make bump-arcbox VERSION=<that tag>` — regenerates the stubs
   from the release (identical to what's checked in) and bumps
   `arcbox.version`.

Opened as a **draft** for that reason. `arcbox.version` is intentionally
left at v0.4.17 in this PR (bumping it now would break the `--remote`
fetch, since the target tag doesn't exist yet). Everything else is
complete and validated.

## What's in it

**Client library (`ArcBoxClient` package):**
- `generate.sh` learns `stats.proto`; regenerated `stats.{pb,grpc}.swift`
  + the `MachineStats`/`ContainerStats`/`WatchStats` additions to
  `agent.{pb,grpc}.swift`.
- `ArcBoxClient.stats` service facade + `machineStatsStream()` — wraps the
  server-streaming RPC as a plain `AsyncStream<MachineStats>`, keeping
  `GRPCCore` inside the library (same split as `DaemonManager+Watch`).
- `ResourceStats.swift`: pure delta math turning cumulative counters into
  rates (CPU%, mem%, disk/net rates, per-container CPU from `usage_usec`
  deltas, counter-reset rebaseline, short-ID fallback) — mirrors
  `abctl top` so CLI and desktop agree. **7 unit tests, all passing.**

**App:**
- `ActivityViewModel` — subscribes to the stream, computes rates, keeps a
  60-sample rolling history; reconnect loop mirroring `DaemonManager`.
  Passive observation: leaving the view open never holds the VM out of
  idle reclaim.
- `ActivityView` — Swift Charts sparklines (CPU / memory / network), a PSI
  pressure `Gauge` (green→amber→red on the daemon's own thresholds, "n/a"
  without `CONFIG_PSI`), and a per-container table (CPU%, mem, disk R/W,
  pids), using the existing theme tokens and `.cardStyle()` chrome.
- New **Activity** sidebar item under a new **SYSTEM** section
  (`NavItem` + `ContentView` full-width detail wiring, like Sandboxes).

## Validation

- `ArcBoxClient` package: `swift build` + `swift test` green (stubs,
  facade, and the 7 ResourceStats tests).
- Full app: `xcodebuild -scheme ArcBox build` green (Debug, arm64).
- `Swift Charts` is newly introduced (no prior use); `Gauge`
  `.accessoryLinearCapacity` for the pressure meter.

## Not in this PR (follow-ups)

- Menu-bar live CPU/mem gauge (the dashboard is the core P3 deliverable).
- Per-container network (needs the container netns; arcbox P4).
- Adjustable sampling frequency / K8s pod grouping (arcbox P4).
