### PR TITLE
feat(files): browse guest Docker data via the ~/ArcBox export

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		B8F04FD5D42B1934B13D9D3A /* PodDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B38661BA5859384BCCE61B0C /* PodDetailView.swift */; };
 		B91D470DA46003D64389C7DE /* AppColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62FD6244C56EE8E45DF0EC7 /* AppColors.swift */; };
 		BA3195811383AD00D29B32AE /* DeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ADF9F8FFB694C45042664E8 /* DeepLink.swift */; };
+		BA5C4C0A98D9650B14A2ECB8 /* GuestDataMount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FBE0C82E0EB430C69EB944 /* GuestDataMount.swift */; };
 		BA8E4BE30E5FBB6B8548E214 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657D7543F1D47988AEC3339D /* AppDelegate.swift */; };
 		BB31DD543E7E07965B68C0A4 /* ContainerRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33B6873C4DDA948830B9EEC /* ContainerRowView.swift */; };
 		BB6DA9C1B509BF12CDA5A92E /* ImageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185A238D021D6C976574528C /* ImageDetailView.swift */; };
@@ -170,6 +171,7 @@
 		CCAF8E87C516B0ACE300BDCD /* PodsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A76C0B459745654F31B3B2 /* PodsListView.swift */; };
 		D0518D07973520530916560B /* ServiceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F238F21169A97B94193454CF /* ServiceDetailView.swift */; };
 		D1130C3F57D641955CEE5518 /* MachineCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECF05A96F099B6E80E9077B /* MachineCardView.swift */; };
+		D2AB4B6BF0723EE12A0DBC83 /* GuestDataMountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27130DDA57D2645C7E81D75D /* GuestDataMountTests.swift */; };
 		D2F870759080FB9D1DF58A3A /* NewContainerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B011CA693D5A9EFCCF61AA2D /* NewContainerSheet.swift */; };
 		D32166A92BDA2FB6B6037D94 /* DeepLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C649765AA76CFCBFC3302DA /* DeepLinkRouter.swift */; };
 		D49278FBAD2A7E36CD278147 /* MachineRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949DB8BB8139F8D3C37503E9 /* MachineRowView.swift */; };
@@ -256,6 +258,7 @@
 		21565AF3B3606525539AE506 /* SandboxesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxesListView.swift; sourceTree = "<group>"; };
 		23C69EC561EEA79ADE5A9000 /* ContainersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainersViewModel.swift; sourceTree = "<group>"; };
 		269B74A3C7704AB81139FA52 /* ContainerLogsModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerLogsModels.swift; sourceTree = "<group>"; };
+		27130DDA57D2645C7E81D75D /* GuestDataMountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestDataMountTests.swift; sourceTree = "<group>"; };
 		297FCAB334AF289575D13F72 /* NetworksListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworksListView.swift; sourceTree = "<group>"; };
 		2D053B8542825698996A16FE /* ArcBoxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ArcBoxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E3E6C9D6EBE0D9358FB396A /* TemplateEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateEmptyState.swift; sourceTree = "<group>"; };
@@ -323,6 +326,7 @@
 		7DAB7D8E92543D99A995003F /* CheckForUpdatesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckForUpdatesView.swift; sourceTree = "<group>"; };
 		7DDFA2EDA7A3AC8448696F91 /* VolumeFilesTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeFilesTab.swift; sourceTree = "<group>"; };
 		829D8DC499E6339D13A2ADE7 /* SandboxesViewModel+GRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SandboxesViewModel+GRPC.swift"; sourceTree = "<group>"; };
+		83FBE0C82E0EB430C69EB944 /* GuestDataMount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestDataMount.swift; sourceTree = "<group>"; };
 		85321B230A582D1C0AF76B5C /* LocalRootFSService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalRootFSService.swift; sourceTree = "<group>"; };
 		85F6CFF90B9BC6AE2836414C /* LocalRootFSOutlineCoordinator+Loading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalRootFSOutlineCoordinator+Loading.swift"; sourceTree = "<group>"; };
 		867A6CA0B4DD07BE74610FCB /* VolumeViewModel+Docker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VolumeViewModel+Docker.swift"; sourceTree = "<group>"; };
@@ -759,6 +763,7 @@
 		61984323E25B4257423106AD /* System */ = {
 			isa = PBXGroup;
 			children = (
+				83FBE0C82E0EB430C69EB944 /* GuestDataMount.swift */,
 				85321B230A582D1C0AF76B5C /* LocalRootFSService.swift */,
 				7058C8975F3F2684714E24E2 /* SleepWakeManager.swift */,
 			);
@@ -985,6 +990,7 @@
 				E610512C9106BB92A47DC044 /* ContainersViewModelTests.swift */,
 				F5B3B3C54B6D49C6198E9E26 /* DeepLinkTests.swift */,
 				06DFFB59D72F27F14A233B81 /* DockerEventMonitorTests.swift */,
+				27130DDA57D2645C7E81D75D /* GuestDataMountTests.swift */,
 				A2B6587D59B9EFA18E51A3F3 /* ImagesViewModelTests.swift */,
 				7B6FDB677AE01E62877A17AC /* K8sModelsTests.swift */,
 			);
@@ -1209,6 +1215,7 @@
 				4B14BB17843A552B8D1B51BA /* ExternalTerminalDiscovery.swift in Sources */,
 				97E56AA0BEC7024FEBBE1B75 /* ExternalTerminalLauncher.swift in Sources */,
 				F319F8722F145CCFA01650B6 /* GeneralSettingsView.swift in Sources */,
+				BA5C4C0A98D9650B14A2ECB8 /* GuestDataMount.swift in Sources */,
 				FBDC1F10288E1448184A91E3 /* IconButton.swift in Sources */,
 				BB6DA9C1B509BF12CDA5A92E /* ImageDetailView.swift in Sources */,
 				FACCEFF5F4CDC1CCDB664C3D /* ImageEmptyState.swift in Sources */,
@@ -1340,6 +1347,7 @@
 				4D2029E55A7979B8BD9EE89A /* ContainersViewModelTests.swift in Sources */,
 				EE2D38BC76500BF768EEE20F /* DeepLinkTests.swift in Sources */,
 				8466B000B68A87CEECA6756F /* DockerEventMonitorTests.swift in Sources */,
+				D2AB4B6BF0723EE12A0DBC83 /* GuestDataMountTests.swift in Sources */,
 				0BCE503CC2BF6C2BEC9DC4EA /* ImagesViewModelTests.swift in Sources */,
 				F40C3E6023452858EEEA893F /* K8sModelsTests.swift in Sources */,
 			);

--- a/ArcBox/Integrations/System/GuestDataMount.swift
+++ b/ArcBox/Integrations/System/GuestDataMount.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Maps guest docker-data paths to their host location under `~/ArcBox`.
+///
+/// The ArcBox daemon exports the guest's docker data root (`/var/lib/docker`)
+/// read-only over NFSv3 and mounts it at `~/ArcBox`. Docker reports paths —
+/// volume mountpoints, image/container layer directories — as *guest* paths
+/// under that root, so browsing them on the host is a prefix rewrite:
+/// `/var/lib/docker/<rest>` → `~/ArcBox/<rest>`.
+enum GuestDataMount {
+    /// Guest docker data root the export corresponds to.
+    /// Mirrors `DOCKER_DATA_MOUNT_POINT` in the runtime.
+    static let guestDataRoot = "/var/lib/docker"
+
+    /// Host mount point of the read-only guest data export.
+    static var rootURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("ArcBox")
+    }
+
+    /// Whether the guest data export is currently mounted at `~/ArcBox`.
+    static var isMounted: Bool {
+        var isDirectory: ObjCBool = false
+        return FileManager.default.fileExists(atPath: rootURL.path, isDirectory: &isDirectory)
+            && isDirectory.boolValue
+    }
+
+    /// Rewrites a guest path under the docker data root to its host URL under
+    /// `~/ArcBox`, or `nil` if the path is not within the exported root.
+    static func hostURL(forGuestPath guestPath: String) -> URL? {
+        let trimmed = guestPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed == guestDataRoot || trimmed.hasPrefix(guestDataRoot + "/") else {
+            return nil
+        }
+        let relative = trimmed
+            .dropFirst(guestDataRoot.count)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return relative.isEmpty ? rootURL : rootURL.appendingPathComponent(relative)
+    }
+
+    /// A user-facing explanation for why a translated path could not be browsed.
+    ///
+    /// Distinguishes "the export isn't mounted at all" from "the export is
+    /// mounted but this particular path isn't in it" (e.g. a running
+    /// container's overlay filesystem, which is a live submount not carried by
+    /// the read-only bind).
+    static func unavailableMessage(subject: String) -> String {
+        if isMounted {
+            return "\(subject) isn't present in the ~/ArcBox export."
+        }
+        return "Guest data isn't mounted at ~/ArcBox. Ensure the ArcBox daemon is running."
+    }
+}

--- a/ArcBox/Integrations/System/GuestDataMount.swift
+++ b/ArcBox/Integrations/System/GuestDataMount.swift
@@ -35,7 +35,8 @@ enum GuestDataMount {
         guard trimmed == guestDataRoot || trimmed.hasPrefix(guestDataRoot + "/") else {
             return nil
         }
-        let relative = trimmed
+        let relative =
+            trimmed
             .dropFirst(guestDataRoot.count)
             .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         guard !relative.split(separator: "/").contains(where: { $0 == ".." || $0 == "." }) else {

--- a/ArcBox/Integrations/System/GuestDataMount.swift
+++ b/ArcBox/Integrations/System/GuestDataMount.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Maps guest docker-data paths to their host location under `~/ArcBox`.
 ///
 /// The ArcBox daemon exports the guest's docker data root (`/var/lib/docker`)
-/// read-only over NFSv3 and mounts it at `~/ArcBox`. Docker reports paths —
+/// read-only over NFSv4 and mounts it at `~/ArcBox`. Docker reports paths —
 /// volume mountpoints, image/container layer directories — as *guest* paths
 /// under that root, so browsing them on the host is a prefix rewrite:
 /// `/var/lib/docker/<rest>` → `~/ArcBox/<rest>`.
@@ -26,6 +26,10 @@ enum GuestDataMount {
 
     /// Rewrites a guest path under the docker data root to its host URL under
     /// `~/ArcBox`, or `nil` if the path is not within the exported root.
+    ///
+    /// Guest paths can come from image/container labels, i.e. untrusted input;
+    /// any `.`/`..` component is rejected so a crafted label cannot escape the
+    /// export once the URL is standardized downstream.
     static func hostURL(forGuestPath guestPath: String) -> URL? {
         let trimmed = guestPath.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed == guestDataRoot || trimmed.hasPrefix(guestDataRoot + "/") else {
@@ -34,6 +38,9 @@ enum GuestDataMount {
         let relative = trimmed
             .dropFirst(guestDataRoot.count)
             .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard !relative.split(separator: "/").contains(where: { $0 == ".." || $0 == "." }) else {
+            return nil
+        }
         return relative.isEmpty ? rootURL : rootURL.appendingPathComponent(relative)
     }
 

--- a/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
@@ -120,13 +120,11 @@ struct ContainerFilesTab: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 20)
 
-            if container.resolvedRootFSMountPath == nil {
-                Text("Set a rootfs mount path via container labels.")
-                    .font(.system(size: 12))
-                    .foregroundStyle(AppColors.textMuted)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 20)
-            }
+            Text("Container filesystems are browsed through the read-only ~/ArcBox export. A running container's live overlay is not yet exported.")
+                .font(.system(size: 12))
+                .foregroundStyle(AppColors.textMuted)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 20)
 
             Button("Refresh") {
                 refresh()
@@ -147,11 +145,23 @@ struct ContainerFilesTab: View {
         isLoadingRoot = true
         selectedPath = nil
 
+        // The rootfs path is a guest path; browse it through the ~/ArcBox export.
+        guard let guestPath = container.resolvedRootFSMountPath,
+            let hostURL = GuestDataMount.hostURL(forGuestPath: guestPath)
+        else {
+            rootURL = nil
+            errorMessage = container.resolvedRootFSMountPath == nil
+                ? "Container has no resolvable filesystem path."
+                : "Container filesystem path is outside the guest data root."
+            isLoadingRoot = false
+            return
+        }
+
         do {
-            rootURL = try LocalRootFSService.resolveRootURL(path: container.resolvedRootFSMountPath)
+            rootURL = try LocalRootFSService.resolveRootURL(path: hostURL.path)
         } catch {
             rootURL = nil
-            errorMessage = error.localizedDescription
+            errorMessage = GuestDataMount.unavailableMessage(subject: "This container's filesystem")
         }
 
         isLoadingRoot = false

--- a/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
@@ -120,11 +120,13 @@ struct ContainerFilesTab: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 20)
 
-            Text("Container filesystems are browsed through the read-only ~/ArcBox export. A running container's live overlay is not yet exported.")
-                .font(.system(size: 12))
-                .foregroundStyle(AppColors.textMuted)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 20)
+            Text(
+                "Container filesystems are browsed through the read-only ~/ArcBox export. A running container's live overlay is not yet exported."
+            )
+            .font(.system(size: 12))
+            .foregroundStyle(AppColors.textMuted)
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, 20)
 
             Button("Refresh") {
                 refresh()
@@ -150,7 +152,8 @@ struct ContainerFilesTab: View {
             let hostURL = GuestDataMount.hostURL(forGuestPath: guestPath)
         else {
             rootURL = nil
-            errorMessage = container.resolvedRootFSMountPath == nil
+            errorMessage =
+                container.resolvedRootFSMountPath == nil
                 ? "Container has no resolvable filesystem path."
                 : "Container filesystem path is outside the guest data root."
             isLoadingRoot = false

--- a/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
+++ b/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
@@ -144,7 +144,7 @@ struct ImageFilesTab: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 20)
 
-            Text("Set rootfs path via image labels (for example: arcbox.rootfs.mount.path).")
+            Text("Image layers are browsed through the read-only ~/ArcBox export.")
                 .font(.system(size: 12))
                 .foregroundStyle(AppColors.textMuted)
                 .multilineTextAlignment(.center)
@@ -171,25 +171,20 @@ struct ImageFilesTab: View {
         rootURL = nil
 
         do {
+            // The layer directory is a guest path; browse it via ~/ArcBox.
             let mountPoint = try await resolveImageRootFSMountPath()
             resolvedRootFSMountPath = mountPoint
-            rootURL = try LocalRootFSService.resolveRootURL(path: mountPoint)
+            guard let hostURL = GuestDataMount.hostURL(forGuestPath: mountPoint) else {
+                errorMessage = "Image layer path is outside the guest data root."
+                isLoadingRoot = false
+                return
+            }
+            rootURL = try LocalRootFSService.resolveRootURL(path: hostURL.path)
         } catch let error as ImageFilesTabError {
             resolvedRootFSMountPath = nil
             errorMessage = error.localizedDescription
-        } catch let error as LocalRootFSService.RootFSError {
-            resolvedRootFSMountPath = nil
-            switch error {
-            case .missingRootPath:
-                errorMessage = "Image has no configured rootfs mount path."
-            case .pathNotFound(let path):
-                errorMessage = "Image rootfs path does not exist: \(path)"
-            case .notDirectory(let path):
-                errorMessage = "Image rootfs path is not a directory: \(path)"
-            }
         } catch {
-            resolvedRootFSMountPath = nil
-            errorMessage = "Failed to load image filesystem: \(error.localizedDescription)"
+            errorMessage = GuestDataMount.unavailableMessage(subject: "This image's layers")
         }
 
         isLoadingRoot = false

--- a/ArcBox/Views/Volumes/Tabs/VolumeFilesTab.swift
+++ b/ArcBox/Views/Volumes/Tabs/VolumeFilesTab.swift
@@ -153,21 +153,19 @@ struct VolumeFilesTab: View {
             return
         }
 
-        do {
-            rootURL = try LocalRootFSService.resolveRootURL(path: mountPoint)
-        } catch let error as LocalRootFSService.RootFSError {
+        // The mount point is a guest path; browse it through the ~/ArcBox export.
+        guard let hostURL = GuestDataMount.hostURL(forGuestPath: mountPoint) else {
             rootURL = nil
-            switch error {
-            case .missingRootPath:
-                errorMessage = "Volume has no mount point."
-            case .pathNotFound(let path):
-                errorMessage = "Volume mount point does not exist: \(path)"
-            case .notDirectory(let path):
-                errorMessage = "Volume mount point is not a directory: \(path)"
-            }
+            errorMessage = "Volume mount point is outside the guest data root."
+            isLoadingRoot = false
+            return
+        }
+
+        do {
+            rootURL = try LocalRootFSService.resolveRootURL(path: hostURL.path)
         } catch {
             rootURL = nil
-            errorMessage = error.localizedDescription
+            errorMessage = GuestDataMount.unavailableMessage(subject: "This volume's data")
         }
 
         isLoadingRoot = false

--- a/ArcBoxTests/GuestDataMountTests.swift
+++ b/ArcBoxTests/GuestDataMountTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+
+@testable import ArcBox
+
+@MainActor
+final class GuestDataMountTests: XCTestCase {
+    private var arcboxRoot: URL {
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("ArcBox")
+    }
+
+    func testVolumePathMapsUnderArcBox() {
+        let url = GuestDataMount.hostURL(forGuestPath: "/var/lib/docker/volumes/pgdata/_data")
+        XCTAssertEqual(url, arcboxRoot.appendingPathComponent("volumes/pgdata/_data"))
+    }
+
+    func testOverlayLayerPathMapsUnderArcBox() {
+        let url = GuestDataMount.hostURL(forGuestPath: "/var/lib/docker/overlay2/abc123/diff")
+        XCTAssertEqual(url, arcboxRoot.appendingPathComponent("overlay2/abc123/diff"))
+    }
+
+    func testDataRootItselfMapsToArcBoxRoot() {
+        XCTAssertEqual(GuestDataMount.hostURL(forGuestPath: "/var/lib/docker"), arcboxRoot)
+        XCTAssertEqual(GuestDataMount.hostURL(forGuestPath: "/var/lib/docker/"), arcboxRoot)
+    }
+
+    func testPathOutsideDataRootIsRejected() {
+        XCTAssertNil(GuestDataMount.hostURL(forGuestPath: "/etc/passwd"))
+        XCTAssertNil(GuestDataMount.hostURL(forGuestPath: "/home/user/project"))
+    }
+
+    func testSiblingPrefixIsNotMistakenForDataRoot() {
+        // Must not treat /var/lib/dockerfoo as being under /var/lib/docker.
+        XCTAssertNil(GuestDataMount.hostURL(forGuestPath: "/var/lib/dockerfoo/x"))
+    }
+
+    func testSurroundingWhitespaceIsTrimmed() {
+        let url = GuestDataMount.hostURL(forGuestPath: "  /var/lib/docker/volumes/v/_data\n")
+        XCTAssertEqual(url, arcboxRoot.appendingPathComponent("volumes/v/_data"))
+    }
+}

--- a/ArcBoxTests/GuestDataMountTests.swift
+++ b/ArcBoxTests/GuestDataMountTests.swift
@@ -37,4 +37,16 @@ final class GuestDataMountTests: XCTestCase {
         let url = GuestDataMount.hostURL(forGuestPath: "  /var/lib/docker/volumes/v/_data\n")
         XCTAssertEqual(url, arcboxRoot.appendingPathComponent("volumes/v/_data"))
     }
+
+    func testTraversalComponentsAreRejected() {
+        // Guest paths can come from image labels; ".." must never escape the export.
+        XCTAssertNil(GuestDataMount.hostURL(forGuestPath: "/var/lib/docker/.."))
+        XCTAssertNil(GuestDataMount.hostURL(forGuestPath: "/var/lib/docker/../../Users/x/.ssh"))
+        XCTAssertNil(GuestDataMount.hostURL(forGuestPath: "/var/lib/docker/volumes/../../../etc"))
+        XCTAssertNil(GuestDataMount.hostURL(forGuestPath: "/var/lib/docker/./volumes"))
+    }
+
+    func testDoubleSlashesDoNotBypassTraversalCheck() {
+        XCTAssertNil(GuestDataMount.hostURL(forGuestPath: "/var/lib/docker//..//etc"))
+    }
 }


### PR DESCRIPTION
## Summary

Makes the Volume / Image / Container **Files** tabs actually browse guest data.
They resolved Docker's *guest* paths (e.g. `/var/lib/docker/volumes/<name>/_data`)
directly against the macOS host filesystem, where those paths never exist — so
every tab failed with a misleading error suggesting rootfs labels.

The daemon now exports the guest Docker data read-only at `~/ArcBox`
(arcboxlabs/arcbox#399). This adds `GuestDataMount`, which rewrites guest paths
under `/var/lib/docker` to their host location under `~/ArcBox`
(`/var/lib/docker/<rest>` → `~/ArcBox/<rest>`), and points all three tabs at it.
The dead label-hint text is replaced with honest messaging (mounted vs. not).

## Notes

- **Depends on arcboxlabs/arcbox#399** — the tabs are only populated once the
  daemon mounts `~/ArcBox` (i.e. a build that ships the NFSv4 export). Until
  then they show "Guest data isn't mounted at ~/ArcBox."
- Volumes and image layers browse directly; a running container's live overlay
  is a submount not yet carried by the read-only bind (surfaced in the tab).
- `GuestDataMount` translation is unit-tested (`GuestDataMountTests`, 6 cases).

## Validation

Full app builds under Swift 6 / strict concurrency; `GuestDataMountTests`
6/6 pass (`xcodebuild test`); SwiftLint `--strict` clean.
