### PR TITLE
ci(release): use homebrew-tap bump-cask action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -776,7 +776,7 @@ jobs:
           echo "arm=$(sha256sum "$dmg_path" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
       - name: Bump Homebrew cask
-        uses: arcboxlabs/homebrew-tap/.github/actions/bump-cask@master
+        uses: arcboxlabs/homebrew-tap/.github/actions/bump-cask@19f97aa3ca8a15c3fdbbf018c1b79651bfdebb8d
         with:
           token: ${{ steps.app-token.outputs.token }}
           cask: arcbox

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -736,7 +736,8 @@ jobs:
             core.info(`Updated ARM64 download link -> ${cdnUrl}`);
 
   # ==========================================================================
-  # Update Homebrew tap Cask with new version and SHA256
+  # Update Homebrew tap Cask with new version and SHA256.
+  # The tap edit lives in arcboxlabs/homebrew-tap/.github/actions/bump-cask.
   # ==========================================================================
   update-homebrew-tap:
     name: Update Homebrew tap
@@ -759,37 +760,28 @@ jobs:
           name: arcbox-desktop-dmg
           path: artifacts/
 
-      - name: Update Cask
+      - name: Hash ArcBox DMG
+        id: cask-shas
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ needs.build-dmg.outputs.version }}
         run: |
-          CASK_VERSION="${VERSION#v}"
-          DMG_PATH="$(find artifacts/ -type f -name '*.dmg' -print -quit)"
-          if [ -z "$DMG_PATH" ]; then
-            echo "Error: No DMG file found under artifacts/"
+          set -euo pipefail
+          version="${VERSION#v}"
+          dmg_path="$(find artifacts/ -type f -name '*.dmg' -print -quit)"
+          if [ -z "$dmg_path" ]; then
+            echo "Error: No DMG file found under artifacts/" >&2
             exit 1
           fi
-          SHA256=$(sha256sum "$DMG_PATH" | awk '{print $1}')
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "arm=$(sha256sum "$dmg_path" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
-          git clone --depth 1 \
-            "https://x-access-token:${GH_TOKEN}@github.com/arcboxlabs/homebrew-tap.git" \
-            /tmp/homebrew-tap
-          cd /tmp/homebrew-tap
-          git config user.name "arcbox-labs[bot]"
-          git config user.email "254083426+arcbox-labs[bot]@users.noreply.github.com"
-
-          CASK="Casks/arcbox.rb"
-          sed -i "s|version \".*\"|version \"${CASK_VERSION}\"|" "$CASK"
-          sed -i "s|sha256 arm: *\".*\"|sha256 arm:   \"${SHA256}\"|" "$CASK"
-
-          if git diff --quiet; then
-            echo "Cask already up to date"
-            exit 0
-          fi
-          git add "$CASK"
-          git commit -m "arcbox ${VERSION}"
-          git push
+      - name: Bump Homebrew cask
+        uses: arcboxlabs/homebrew-tap/.github/actions/bump-cask@master
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          cask: arcbox
+          version: ${{ steps.cask-shas.outputs.version }}
+          arm_sha256: ${{ steps.cask-shas.outputs.arm }}
 
   # ==========================================================================
   # Sync shipped issues to Linear Releases (continuous, stable channel only)


### PR DESCRIPTION
## Summary
- Replace the inlined ArcBox Homebrew cask bump with the shared composite action at `arcboxlabs/homebrew-tap/.github/actions/bump-cask`.
- Keep minting the App token, downloading the DMG, and hashing it here; only the tap edit/push is delegated.
- Gains the action's post-sed verification (grep) that the old script lacked.

## Test plan
- [ ] Confirm `homebrew-tap` master has `.github/actions/bump-cask/action.yml` (commit `19f97aa`+).
- [ ] On next stable-channel release, verify `update-homebrew-tap` bumps `Casks/arcbox.rb` and pushes.
- [ ] Confirm alpha/beta/rc channels still skip this job.