### PR TITLE
feat(xtask): embed vm-agent into Resources/bin alongside arcbox-agent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,7 @@ jobs:
           CLI_BIN=$(find "$DOWNLOAD_DIR" -type f -name "abctl" | head -1)
           DAEMON_BIN=$(find "$DOWNLOAD_DIR" -type f -name "arcbox-daemon" | head -1)
           AGENT_BIN=$(find "$DOWNLOAD_DIR" -type f -name "arcbox-agent" | head -1)
+          VM_AGENT_BIN=$(find "$DOWNLOAD_DIR" -type f -name "vm-agent" | head -1)
 
           if [ -z "$CLI_BIN" ] || [ -z "$DAEMON_BIN" ]; then
             echo "Could not find pre-built binaries in release assets"
@@ -171,6 +172,16 @@ jobs:
             echo "Found arcbox-agent in release assets"
           else
             echo "::warning::arcbox-agent not found in release assets"
+          fi
+
+          # Sandbox microVM init; absent from pre-vm-agent arcbox releases,
+          # in which case the DMG packager warns and ships without it.
+          if [ -n "$VM_AGENT_BIN" ]; then
+            cp "$VM_AGENT_BIN" arcbox-core/target/aarch64-unknown-linux-musl/release/vm-agent
+            chmod +x arcbox-core/target/aarch64-unknown-linux-musl/release/vm-agent
+            echo "Found vm-agent in release assets"
+          else
+            echo "::warning::vm-agent not found in release assets"
           fi
 
           # Copy entitlements if present

--- a/xtask/src/commands/macos/dmg.rs
+++ b/xtask/src/commands/macos/dmg.rs
@@ -523,24 +523,26 @@ fn embed_abctl(app_bundle: &Path, arcbox_dir: &Path, sign_identity: &str) -> Res
     Ok(())
 }
 
-fn embed_agent(app_bundle: &Path, arcbox_dir: &Path) -> Result<()> {
-    let agent_bin = arcbox_dir
+/// Embed the Linux guest binaries — arcbox-agent (System VM agent) and
+/// vm-agent (sandbox microVM init) — which the daemon seeds from
+/// Resources/bin into <data_dir>/bin at startup.
+fn embed_guest_binaries(app_bundle: &Path, arcbox_dir: &Path) -> Result<()> {
+    println!("--- Embedding guest binaries ---");
+    let src_dir = arcbox_dir
         .join("target")
         .join("aarch64-unknown-linux-musl")
-        .join("release")
-        .join("arcbox-agent");
-    if !agent_bin.is_file() {
-        println!(
-            "  Warning: arcbox-agent not found at {}",
-            agent_bin.display()
-        );
-        return Ok(());
+        .join("release");
+    let dest_dir = app_bundle.join("Contents").join("Resources").join("bin");
+    std::fs::create_dir_all(&dest_dir)?;
+    for name in ["arcbox-agent", "vm-agent"] {
+        let src = src_dir.join(name);
+        if !src.is_file() {
+            println!("  Warning: {name} not found at {}", src.display());
+            continue;
+        }
+        std::fs::copy(&src, dest_dir.join(name)).with_context(|| format!("copying {name}"))?;
+        println!("  Copied {name} → Resources/bin/{name}");
     }
-    println!("--- Embedding arcbox-agent ---");
-    let agent_dir = app_bundle.join("Contents").join("Resources").join("bin");
-    std::fs::create_dir_all(&agent_dir)?;
-    std::fs::copy(&agent_bin, agent_dir.join("arcbox-agent")).context("copying arcbox-agent")?;
-    println!("  Copied arcbox-agent → Resources/bin/arcbox-agent");
     Ok(())
 }
 
@@ -990,7 +992,7 @@ pub fn run(args: MacosDmgArgs) -> Result<()> {
     prepare_profile_resources(&desktop_repo, &arcbox_dir, profile, &resource_options)?;
     embed_boot_assets(&app_bundle, &arcbox_dir, profile)?;
     embed_abctl(&app_bundle, &arcbox_dir, &sign_identity)?;
-    embed_agent(&app_bundle, &arcbox_dir)?;
+    embed_guest_binaries(&app_bundle, &arcbox_dir)?;
     embed_docker_tools(&app_bundle, &sign_identity, profile)?;
     embed_runtime(&app_bundle, &sign_identity, profile)?;
     embed_completions(&app_bundle)?;

--- a/xtask/src/commands/macos/embed.rs
+++ b/xtask/src/commands/macos/embed.rs
@@ -165,13 +165,14 @@ pub fn run(_args: MacosEmbedArgs) -> Result<()> {
     let arcbox_repo = find_arcbox_repo(&project_dir);
     let profile = BundleProfile::from_environment();
     let daemon_name = profile.daemon_label();
-    let local_dir = arcbox_repo
-        .as_ref()
-        .map(|r| r.join("target").join("release"));
-    let local_agent_dir = arcbox_repo.as_ref().map(|r| {
-        r.join("target")
-            .join("aarch64-unknown-linux-musl")
-            .join("release")
+    // Host binaries dir + guest (Linux musl) binaries dir of a local checkout.
+    let local_dirs = arcbox_repo.as_ref().map(|r| {
+        (
+            r.join("target").join("release"),
+            r.join("target")
+                .join("aarch64-unknown-linux-musl")
+                .join("release"),
+        )
     });
 
     // ── Build (incremental) ──────────────────────────────────────────────────
@@ -193,28 +194,26 @@ pub fn run(_args: MacosEmbedArgs) -> Result<()> {
     }
 
     // ── Resolve source ───────────────────────────────────────────────────────
-    let (src_dir, agent_src): (PathBuf, Option<PathBuf>) = if let Some(local) = &local_dir {
-        if local.join("abctl").is_file() && local.join("arcbox-daemon").is_file() {
-            if !xfs::is_macho(&local.join("arcbox-daemon")) {
-                bail!(
-                    "{}/arcbox-daemon is not a valid Mach-O binary",
+    let (src_dir, guest_bin_dir): (PathBuf, PathBuf) =
+        if let Some((local, local_guest)) = &local_dirs {
+            if local.join("abctl").is_file() && local.join("arcbox-daemon").is_file() {
+                if !xfs::is_macho(&local.join("arcbox-daemon")) {
+                    bail!(
+                        "{}/arcbox-daemon is not a valid Mach-O binary",
+                        local.display()
+                    );
+                }
+                note(&format!(
+                    "Using local arcbox binaries from {}",
                     local.display()
-                );
+                ));
+                (local.clone(), local_guest.clone())
+            } else {
+                resolve_cache(&cache_dir, &version, &project_dir)?
             }
-            note(&format!(
-                "Using local arcbox binaries from {}",
-                local.display()
-            ));
-            (
-                local.clone(),
-                local_agent_dir.as_ref().map(|d| d.join("arcbox-agent")),
-            )
         } else {
             resolve_cache(&cache_dir, &version, &project_dir)?
-        }
-    } else {
-        resolve_cache(&cache_dir, &version, &project_dir)?
-    };
+        };
 
     // ── Embed daemon → Contents/Frameworks/*.app ──────────────────────────────
     let frameworks_dir = built_products.join(&contents_folder).join("Frameworks");
@@ -326,22 +325,28 @@ pub fn run(_args: MacosEmbedArgs) -> Result<()> {
         ));
     }
 
-    // ── Embed arcbox-agent → Contents/Resources/bin/ ──────────────────────────
-    match &agent_src {
-        Some(agent) if agent.is_file() => {
-            let agent_dir = built_products
-                .join(&contents_folder)
-                .join("Resources")
-                .join("bin");
-            std::fs::create_dir_all(&agent_dir)
-                .with_context(|| format!("creating {}", agent_dir.display()))?;
-            if sync_binary(agent, &agent_dir.join("arcbox-agent"))? {
-                note("Embedded arcbox-agent → Resources/bin/arcbox-agent");
-            } else {
-                note("arcbox-agent unchanged, skipping copy");
-            }
+    // ── Embed guest binaries → Contents/Resources/bin/ ────────────────────────
+    // arcbox-agent (System VM agent) and vm-agent (sandbox microVM init); the
+    // daemon seeds both from Resources/bin into <data_dir>/bin at startup.
+    let guest_dest = built_products
+        .join(&contents_folder)
+        .join("Resources")
+        .join("bin");
+    std::fs::create_dir_all(&guest_dest)
+        .with_context(|| format!("creating {}", guest_dest.display()))?;
+    for name in ["arcbox-agent", "vm-agent"] {
+        let src = guest_bin_dir.join(name);
+        if !src.is_file() {
+            // Tolerated: pre-vm-agent release tarballs and partial local
+            // builds; the daemon degrades gracefully without either binary.
+            warn(&format!("{name} not found at {}, skipping", src.display()));
+            continue;
         }
-        _ => warn("arcbox-agent not found, skipping"),
+        if sync_binary(&src, &guest_dest.join(name))? {
+            note(&format!("Embedded {name} → Resources/bin/{name}"));
+        } else {
+            note(&format!("{name} unchanged, skipping copy"));
+        }
     }
 
     Ok(())
@@ -369,11 +374,13 @@ fn embed_signed_cli(
     Ok(())
 }
 
+/// Returns (host binaries dir, guest binaries dir); the release tarball is
+/// flat, so both point at the cache dir.
 fn resolve_cache(
     cache_dir: &Path,
     version: &str,
     project_dir: &Path,
-) -> Result<(PathBuf, Option<PathBuf>)> {
+) -> Result<(PathBuf, PathBuf)> {
     if cache_dir.join("abctl").is_file() && cache_dir.join("arcbox-daemon").is_file() {
         if !xfs::is_macho(&cache_dir.join("arcbox-daemon")) {
             bail!(
@@ -382,10 +389,7 @@ fn resolve_cache(
             );
         }
         note(&format!("Using cached arcbox {version} binaries"));
-        Ok((
-            cache_dir.to_path_buf(),
-            Some(cache_dir.join("arcbox-agent")),
-        ))
+        Ok((cache_dir.to_path_buf(), cache_dir.to_path_buf()))
     } else {
         let arcbox_hint = parent_join(project_dir, "arcbox");
         bail!(


### PR DESCRIPTION
## Problem

`abctl sandbox create` against the shipped app fails with `vm-agent not found at /arcbox/bin/vm-agent`: the daemon seeds `Resources/bin/vm-agent` into `<data_dir>/bin/` at startup (sandbox microVM init), but neither the Xcode embed phase nor the DMG packager ever copied it into the bundle.

## Change

Generalize both embed paths over the two Linux guest binaries (`arcbox-agent`, `vm-agent`):

- **embed.rs** (Xcode build phase): the resolve step now yields a guest-binaries directory (local musl target dir, or the flat release-tarball cache) and embeds both binaries from it into `Resources/bin/`.
- **dmg.rs**: `embed_agent` → `embed_guest_binaries`, same loop.

Missing `vm-agent` stays a warning (same as the existing `arcbox-agent` behavior) so pre-vm-agent arcbox release tarballs and partial local builds keep working.

## Companion

arcboxlabs/arcbox#426 makes the arcbox release pipeline build `vm-agent` (musl) and ship it in the release tarball, and adds it to `make build-agent` so the DMG source-build path finds it. The fix reaches users once that lands, a new arcbox release is cut, and `arcbox.version` is bumped here.

## Validation

`cargo fmt` / `clippy -D warnings` / `cargo test` in `xtask/` all green.