### PR TITLE
fix(ci): move protoc-plugin SwiftPM scratch dir out of Packages/

### DIFF
--- a/Packages/ArcBoxClient/generate.sh
+++ b/Packages/ArcBoxClient/generate.sh
@@ -106,14 +106,21 @@ fi
 
 echo "Output dir: $OUT_DIR"
 
-# Build protoc plugins from grpc-swift-protobuf
+# Build protoc plugins from grpc-swift-protobuf.
+#
+# The SwiftPM scratch dir must live OUTSIDE Packages/: CI cache keys hash
+# Packages/** (pr.yml/release.yml "Restore Xcode build cache"), and a .build
+# here breaks them — dependency checkouts can carry dangling symlinks that
+# hard-fail hashFiles (sentry-cocoa's .claude/skills did), and checked-out
+# package manifests pollute the swiftpm cache key.
+SCRATCH_DIR="${SCRIPT_DIR}/../../.build/protoc-plugins"
 echo ""
 echo "Building protoc plugins..."
 cd "$SCRIPT_DIR"
-swift build --product protoc-gen-swift 2>&1 | tail -1
-swift build --product protoc-gen-grpc-swift 2>&1 | tail -1
+swift build --scratch-path "$SCRATCH_DIR" --product protoc-gen-swift 2>&1 | tail -1
+swift build --scratch-path "$SCRATCH_DIR" --product protoc-gen-grpc-swift 2>&1 | tail -1
 
-PLUGIN_DIR="$(swift build --show-bin-path)"
+PLUGIN_DIR="$(swift build --scratch-path "$SCRATCH_DIR" --show-bin-path)"
 export PATH="${PLUGIN_DIR}:${PATH}"
 
 echo "Using protoc-gen-swift: $(which protoc-gen-swift)"


### PR DESCRIPTION
## Problem

Every `pr.yml` run since 3f23b9c ("ci(release): build and cache ARM64 DMGs") fails at **Restore Xcode build cache** — master included:

```
##[error]The template is not valid. .github/workflows/pr.yml (Line: 104, Col: 16):
hashFiles('ArcBox/**, ArcBoxTests/**, Packages/**') failed.
Fail to hash files under directory '/Users/runner/work/arcbox-desktop/arcbox-desktop'
```

This currently blocks all PRs (#291, #292, …).

## Root cause (from a `--debug` rerun)

`pr.yml` runs `make verify-arcbox-protobuf` before the cache steps. Its `generate.sh` builds the protoc plugins with `swift build` **inside `Packages/ArcBoxClient`**, leaving a SwiftPM `.build/` (dependency checkouts + index store) under `Packages/`. The cache-key `hashFiles('Packages/**')` then walks into it and dies:

```
##[debug]Error: ENOENT: no such file or directory, stat
'…/Packages/ArcBoxClient/.build/checkouts/sentry-cocoa/.claude/skills'
```

sentry-cocoa ships a dangling `.claude/skills` symlink; `hashFiles` follows symlinks and hard-fails on the stat. The checkouts also poisoned the swiftpm cache key (`Packages/**/Package.resolved`/`Package.swift` matched **74 files** instead of the handful in a clean tree). `release.yml` evaluates the byte-identical expression successfully because it never runs the protobuf verify — `Packages/` stays clean there.

## Fix

Point the plugin builds at a scratch path under the repo-root `.build/` (`--scratch-path .build/protoc-plugins`), which is already the CI cache area and appears in no hash glob. `Packages/` now stays exactly the checkout, restoring the same conditions under which release.yml's expression demonstrably works.

## Validation

Ran `generate.sh --remote` locally with the change: plugins build under `.build/protoc-plugins`, `Packages/ArcBoxClient/.build` is not created, and the regenerated `Generated/` output is byte-identical (`git status` clean). This PR's own CI is the end-to-end proof — its Build & Test must get past the cache-restore step.

After merge: rerun CI on #291 and #292 (pull_request runs build the merge ref, so they pick the fix up from master).