### PR TITLE
feat(files): resolve container filesystems via daemon under the containerd image store

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -1495,6 +1495,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				OTHER_SWIFT_FLAGS = "-Werror ActorIsolatedCall";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(ARCBOX_PRODUCT_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(ARCBOX_PRODUCT_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1636,6 +1637,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				OTHER_SWIFT_FLAGS = "-Werror ActorIsolatedCall";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(ARCBOX_PRODUCT_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(ARCBOX_PRODUCT_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/ArcBox/Integrations/System/GuestDataMount.swift
+++ b/ArcBox/Integrations/System/GuestDataMount.swift
@@ -1,16 +1,23 @@
 import Foundation
 
-/// Maps guest docker-data paths to their host location under `~/ArcBox`.
+/// Maps guest data paths to their host location under `~/ArcBox`.
 ///
 /// The ArcBox daemon exports the guest's docker data root (`/var/lib/docker`)
-/// read-only over NFSv4 and mounts it at `~/ArcBox`. Docker reports paths —
-/// volume mountpoints, image/container layer directories — as *guest* paths
-/// under that root, so browsing them on the host is a prefix rewrite:
-/// `/var/lib/docker/<rest>` → `~/ArcBox/<rest>`.
+/// read-only over NFSv4 and mounts it at `~/ArcBox`; the containerd data root
+/// (`/var/lib/containerd`, where the containerd image store keeps every
+/// snapshot) rides along as a child export at `~/ArcBox/containerd`. Guest
+/// paths — volume mountpoints, image/container layer directories — are
+/// browsed on the host via a prefix rewrite:
+/// `/var/lib/docker/<rest>` → `~/ArcBox/<rest>` and
+/// `/var/lib/containerd/<rest>` → `~/ArcBox/containerd/<rest>`.
 enum GuestDataMount {
     /// Guest docker data root the export corresponds to.
     /// Mirrors `DOCKER_DATA_MOUNT_POINT` in the runtime.
     static let guestDataRoot = "/var/lib/docker"
+
+    /// Guest containerd data root, exported as a child of the docker export.
+    /// Mirrors `CONTAINERD_DATA_MOUNT_POINT` in the runtime.
+    static let guestContainerdRoot = "/var/lib/containerd"
 
     /// Host mount point of the read-only guest data export.
     static var rootURL: URL {
@@ -24,25 +31,40 @@ enum GuestDataMount {
             && isDirectory.boolValue
     }
 
-    /// Rewrites a guest path under the docker data root to its host URL under
-    /// `~/ArcBox`, or `nil` if the path is not within the exported root.
+    /// Rewrites a guest path under one of the exported roots to its host URL
+    /// under `~/ArcBox`, or `nil` if the path is not within an exported root.
     ///
     /// Guest paths can come from image/container labels, i.e. untrusted input;
     /// any `.`/`..` component is rejected so a crafted label cannot escape the
     /// export once the URL is standardized downstream.
     static func hostURL(forGuestPath guestPath: String) -> URL? {
         let trimmed = guestPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed == guestDataRoot || trimmed.hasPrefix(guestDataRoot + "/") else {
+        // Check containerd first: its prefix is not nested inside the docker
+        // root, but keeping the more specific mapping first stays correct if
+        // that ever changes.
+        if let url = rewrite(trimmed, root: guestContainerdRoot, to: containerdHostRoot) {
+            return url
+        }
+        return rewrite(trimmed, root: guestDataRoot, to: rootURL)
+    }
+
+    /// Host location of the containerd child export.
+    private static var containerdHostRoot: URL {
+        rootURL.appendingPathComponent("containerd")
+    }
+
+    private static func rewrite(_ path: String, root: String, to hostRoot: URL) -> URL? {
+        guard path == root || path.hasPrefix(root + "/") else {
             return nil
         }
         let relative =
-            trimmed
-            .dropFirst(guestDataRoot.count)
+            path
+            .dropFirst(root.count)
             .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         guard !relative.split(separator: "/").contains(where: { $0 == ".." || $0 == "." }) else {
             return nil
         }
-        return relative.isEmpty ? rootURL : rootURL.appendingPathComponent(relative)
+        return relative.isEmpty ? hostRoot : hostRoot.appendingPathComponent(relative)
     }
 
     /// A user-facing explanation for why a translated path could not be browsed.

--- a/ArcBox/Integrations/System/LocalRootFSService.swift
+++ b/ArcBox/Integrations/System/LocalRootFSService.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct LocalFileEntry: Identifiable, Hashable {
+nonisolated struct LocalFileEntry: Identifiable, Hashable {
     let url: URL
     let name: String
     let isDirectory: Bool
@@ -20,13 +20,13 @@ struct LocalFileEntry: Identifiable, Hashable {
         return ByteCountFormatter.string(fromByteCount: sizeBytes, countStyle: .file)
     }
 
-    var dateDisplay: String {
+    @MainActor var dateDisplay: String {
         guard let modifiedDate else { return "" }
         return LocalRootFSService.modifiedDateFormatter.string(from: modifiedDate)
     }
 }
 
-struct LocalRootFSService {
+nonisolated struct LocalRootFSService {
     enum RootFSError: LocalizedError {
         case missingRootPath
         case pathNotFound(String)
@@ -44,7 +44,7 @@ struct LocalRootFSService {
         }
     }
 
-    static let modifiedDateFormatter: DateFormatter = {
+    @MainActor static let modifiedDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         formatter.timeStyle = .short

--- a/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
@@ -17,7 +17,10 @@ struct ContainerFilesTab: View {
     @State private var showHiddenFiles = LocalRootFSService.finderDefaultShowHiddenFiles()
 
     private var outlineReloadID: String {
-        "\(container.id)|\(container.resolvedRootFSMountPath ?? "")|\(showHiddenFiles)|\(refreshToken.uuidString)"
+        // Client availability is part of the key: the environment client is
+        // nil during app startup, and the daemon-side resolution must re-run
+        // once it is injected — `.task(id:)` only restarts on an id change.
+        "\(container.id)|\(container.resolvedRootFSMountPath ?? "")|\(arcboxClient != nil)|\(showHiddenFiles)|\(refreshToken.uuidString)"
     }
 
     private var selectedURL: URL? {

--- a/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
@@ -1,9 +1,13 @@
 import AppKit
+import ArcBoxClient
 import SwiftUI
+import os
 
 /// Files tab backed by an already-mounted local rootfs directory.
 struct ContainerFilesTab: View {
     let container: ContainerViewModel
+
+    @Environment(\.arcboxClient) private var arcboxClient
 
     @State private var selectedPath: String?
     @State private var rootURL: URL?
@@ -121,7 +125,7 @@ struct ContainerFilesTab: View {
                 .padding(.horizontal, 20)
 
             Text(
-                "Container filesystems are browsed through the read-only ~/ArcBox export. A running container's live overlay is not yet exported."
+                "Container filesystems are browsed through the read-only ~/ArcBox export. The view shows the container's own writable layer; image layers stay in their own snapshots."
             )
             .font(.system(size: 12))
             .foregroundStyle(AppColors.textMuted)
@@ -147,13 +151,21 @@ struct ContainerFilesTab: View {
         isLoadingRoot = true
         selectedPath = nil
 
-        // The rootfs path is a guest path; browse it through the ~/ArcBox export.
-        guard let guestPath = container.resolvedRootFSMountPath,
+        // Inspect-provided path (classic graph drivers), else ask the daemon
+        // to resolve the container's snapshot layers (containerd image store,
+        // where inspect carries no GraphDriver paths).
+        var guestPath = container.resolvedRootFSMountPath
+        if guestPath == nil {
+            guestPath = await resolveViaDaemon()
+        }
+
+        // The resolved path is a guest path; browse it through the ~/ArcBox export.
+        guard let guestPath,
             let hostURL = GuestDataMount.hostURL(forGuestPath: guestPath)
         else {
             rootURL = nil
             errorMessage =
-                container.resolvedRootFSMountPath == nil
+                guestPath == nil
                 ? "Container has no resolvable filesystem path."
                 : "Container filesystem path is outside the guest data root."
             isLoadingRoot = false
@@ -168,6 +180,27 @@ struct ContainerFilesTab: View {
         }
 
         isLoadingRoot = false
+    }
+
+    /// Resolves the container's writable snapshot layer via the daemon.
+    ///
+    /// Under the containerd image store the layer directories live in
+    /// containerd's snapshotter, so the daemon queries the guest and returns
+    /// guest paths; the writable (upper) layer holds everything the container
+    /// itself wrote.
+    private func resolveViaDaemon() async -> String? {
+        guard let arcboxClient else { return nil }
+        var request = Arcbox_V1_ResolveContainerFsRequest()
+        request.containerID = container.id
+        do {
+            let response = try await arcboxClient.system.resolveContainerFs(
+                request, options: ArcBoxClient.defaultCallOptions)
+            return response.upperDir.isEmpty ? nil : response.upperDir
+        } catch {
+            Log.daemon.error(
+                "Failed to resolve container fs: \(error.localizedDescription, privacy: .private)")
+            return nil
+        }
     }
 
     private func revealSelectedInFinder() {

--- a/ArcBoxTests/GuestDataMountTests.swift
+++ b/ArcBoxTests/GuestDataMountTests.swift
@@ -49,4 +49,29 @@ final class GuestDataMountTests: XCTestCase {
     func testDoubleSlashesDoNotBypassTraversalCheck() {
         XCTAssertNil(GuestDataMount.hostURL(forGuestPath: "/var/lib/docker//..//etc"))
     }
+
+    func testContainerdSnapshotPathMapsUnderContainerdChildExport() {
+        let url = GuestDataMount.hostURL(
+            forGuestPath:
+                "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/269/fs")
+        XCTAssertEqual(
+            url,
+            arcboxRoot.appendingPathComponent(
+                "containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/269/fs"))
+    }
+
+    func testContainerdRootItselfMapsToChildExportRoot() {
+        XCTAssertEqual(
+            GuestDataMount.hostURL(forGuestPath: "/var/lib/containerd"),
+            arcboxRoot.appendingPathComponent("containerd"))
+    }
+
+    func testContainerdSiblingPrefixIsRejected() {
+        XCTAssertNil(GuestDataMount.hostURL(forGuestPath: "/var/lib/containerdfoo/x"))
+    }
+
+    func testContainerdTraversalComponentsAreRejected() {
+        XCTAssertNil(GuestDataMount.hostURL(forGuestPath: "/var/lib/containerd/../docker"))
+        XCTAssertNil(GuestDataMount.hostURL(forGuestPath: "/var/lib/containerd/./snapshots"))
+    }
 }


### PR DESCRIPTION
Companion to arcboxlabs/arcbox#429 — restores the Container Files tab under the containerd image store (docker 29 / boot v0.6.3), where `docker inspect` exposes no GraphDriver paths.

- When inspect gives no path, resolve the container's snapshot layers via the new `SystemService.ResolveContainerFs` and browse the writable (upper) layer.
- `GuestDataMount` learns the containerd child-export mapping `/var/lib/containerd/<rest>` → `~/ArcBox/containerd/<rest>` (same `.`/`..` traversal hardening; unit tests extended).
- Fixed the Files empty-state hint that blamed running-container overlays.

**Draft until** arcbox#429 merges and ships in a release: `verify-arcbox-protobuf` regenerates from the `arcbox.version` pin, so this needs the version bump first (same sequencing as the stats P3 PR). Regenerated protos here came from the local arcbox checkout at that PR.

Validated: Debug build + ArcBoxTests green locally, `swift-format lint --strict` clean.