### PR TITLE
feat(files): browse image layers via daemon resolution under the containerd image store

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -1526,6 +1526,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				OTHER_SWIFT_FLAGS = "-Werror ActorIsolatedCall";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(ARCBOX_PRODUCT_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(ARCBOX_PRODUCT_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1667,6 +1668,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				OTHER_SWIFT_FLAGS = "-Werror ActorIsolatedCall";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(ARCBOX_PRODUCT_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(ARCBOX_PRODUCT_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		4113241C123BBBBDEC76E5B0 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB03A05EDADB4F1FA6E10A1 /* ToastView.swift */; };
 		41459C0A45497BA629B8C34D /* NetworksViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ED3EC883A488801DE03195 /* NetworksViewModel.swift */; };
 		415470083B7CD53FB22C4E88 /* MachineModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD5CF45B00B80D85A778AB4 /* MachineModel.swift */; };
+		43CA6777ECD31C582D9EEB09 /* ImageLayerChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6218E84D6C2A8595FE308B5E /* ImageLayerChain.swift */; };
 		43F19AF62096855162AED4D6 /* TerminalLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54B3991292BCEAFE5ED4EF39 /* TerminalLine.swift */; };
 		442BF334C252BDCD3E210745 /* PodRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F5C6F8F92ED8D843FAA6D89 /* PodRowView.swift */; };
 		442FF72709337D1BCAA0643D /* SandboxEventMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C68609B67AC82FF386CB92 /* SandboxEventMonitor.swift */; };
@@ -107,6 +108,7 @@
 		85E19535E0F7AC3500E9BAFD /* TemplateEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E3E6C9D6EBE0D9358FB396A /* TemplateEmptyState.swift */; };
 		869B14DB25CD44955C7C32AE /* ContainersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23C69EC561EEA79ADE5A9000 /* ContainersViewModel.swift */; };
 		8939A06F20FE4F92A72E3372 /* ImageTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E17CF68FBBA9447E1B15371 /* ImageTypes.swift */; };
+		8BBBA54130403D89D35986F7 /* ImageLayerChainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C964312D5336EE55A8E4680B /* ImageLayerChainTests.swift */; };
 		8BEEBFC0F4E258C46C1A347E /* AboutView+LinkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E06B22BB8B92AF78C2B87ADC /* AboutView+LinkButton.swift */; };
 		8C3C03A50C1B7D97829F9DA5 /* SandboxEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE7897EE0D976BB19ADC2C5 /* SandboxEmptyState.swift */; };
 		8CC7CA0E539BF9E435DA2F36 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = 32C86546753C11A9E6CA8CB8 /* CHANGELOG.md */; };
@@ -308,6 +310,7 @@
 		5F2D773B0312F0D5695D0ADA /* SandboxesViewModel+Snapshots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SandboxesViewModel+Snapshots.swift"; sourceTree = "<group>"; };
 		61EE316315F864BA1BF0FFED /* MachinesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachinesViewModel.swift; sourceTree = "<group>"; };
 		620BCE892EDA3E7554384A0E /* NetworkRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRowView.swift; sourceTree = "<group>"; };
+		6218E84D6C2A8595FE308B5E /* ImageLayerChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLayerChain.swift; sourceTree = "<group>"; };
 		657D7543F1D47988AEC3339D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		66F91CF47E53375781959EC9 /* ServicesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicesListView.swift; sourceTree = "<group>"; };
 		68009FEC4A2F0EB046ACCA4C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -406,6 +409,7 @@
 		C0DD79FCBCF65FAFFBBB61D0 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		C15C37C29F16DD4E28B30271 /* MenuBarView+Containers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MenuBarView+Containers.swift"; sourceTree = "<group>"; };
 		C33F6D43F3CE2C79F072C7F3 /* DockerClient */ = {isa = PBXFileReference; lastKnownFileType = folder; name = DockerClient; path = Packages/DockerClient; sourceTree = SOURCE_ROOT; };
+		C964312D5336EE55A8E4680B /* ImageLayerChainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLayerChainTests.swift; sourceTree = "<group>"; };
 		CC86E86A85E46B083853A9AA /* MachineFilesTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachineFilesTab.swift; sourceTree = "<group>"; };
 		CC98017408ED56AFF734125A /* AboutView+Sections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AboutView+Sections.swift"; sourceTree = "<group>"; };
 		CDF5B0B3EC77FB12D8B4EA6A /* PodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodsViewModel.swift; sourceTree = "<group>"; };
@@ -781,6 +785,7 @@
 			isa = PBXGroup;
 			children = (
 				83FBE0C82E0EB430C69EB944 /* GuestDataMount.swift */,
+				6218E84D6C2A8595FE308B5E /* ImageLayerChain.swift */,
 				85321B230A582D1C0AF76B5C /* LocalRootFSService.swift */,
 				7058C8975F3F2684714E24E2 /* SleepWakeManager.swift */,
 			);
@@ -1019,6 +1024,7 @@
 				F5B3B3C54B6D49C6198E9E26 /* DeepLinkTests.swift */,
 				06DFFB59D72F27F14A233B81 /* DockerEventMonitorTests.swift */,
 				27130DDA57D2645C7E81D75D /* GuestDataMountTests.swift */,
+				C964312D5336EE55A8E4680B /* ImageLayerChainTests.swift */,
 				A2B6587D59B9EFA18E51A3F3 /* ImagesViewModelTests.swift */,
 				7B6FDB677AE01E62877A17AC /* K8sModelsTests.swift */,
 				F0647CCB67160C2509345B5E /* MachineModelTests.swift */,
@@ -1251,6 +1257,7 @@
 				BB6DA9C1B509BF12CDA5A92E /* ImageDetailView.swift in Sources */,
 				FACCEFF5F4CDC1CCDB664C3D /* ImageEmptyState.swift in Sources */,
 				BDE44A1851827C2069778F08 /* ImageFilesTab.swift in Sources */,
+				43CA6777ECD31C582D9EEB09 /* ImageLayerChain.swift in Sources */,
 				7F091F3F3F75F500937DC7BC /* ImageModel.swift in Sources */,
 				614A69F2B70BA6E4CCA4CF0D /* ImageRowView.swift in Sources */,
 				3B38458299F141A08B8C7107 /* ImageTerminalTab.swift in Sources */,
@@ -1383,6 +1390,7 @@
 				EE2D38BC76500BF768EEE20F /* DeepLinkTests.swift in Sources */,
 				8466B000B68A87CEECA6756F /* DockerEventMonitorTests.swift in Sources */,
 				D2AB4B6BF0723EE12A0DBC83 /* GuestDataMountTests.swift in Sources */,
+				8BBBA54130403D89D35986F7 /* ImageLayerChainTests.swift in Sources */,
 				0BCE503CC2BF6C2BEC9DC4EA /* ImagesViewModelTests.swift in Sources */,
 				F40C3E6023452858EEEA893F /* K8sModelsTests.swift in Sources */,
 				CCD9ABC3F69FE5DA233E85EC /* MachineModelTests.swift in Sources */,
@@ -1518,7 +1526,6 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				OTHER_SWIFT_FLAGS = "-Werror ActorIsolatedCall";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(ARCBOX_PRODUCT_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(ARCBOX_PRODUCT_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1660,7 +1667,6 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				OTHER_SWIFT_FLAGS = "-Werror ActorIsolatedCall";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(ARCBOX_PRODUCT_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(ARCBOX_PRODUCT_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/ArcBox/Integrations/System/ImageLayerChain.swift
+++ b/ArcBox/Integrations/System/ImageLayerChain.swift
@@ -1,0 +1,23 @@
+import CryptoKit
+import Foundation
+
+/// Layer chain IDs per the OCI image spec.
+///
+/// The containerd image store keys committed layer snapshots by chain ID:
+/// the first chain ID is the first diff ID, and each following one is
+/// `sha256("<previous chain ID> <diff ID>")`. The daemon resolves an
+/// image's layer directories from the top (last) chain ID.
+enum ImageLayerChain {
+    /// Chain ID of the top layer for `diffIDs` (bottom-most first, as
+    /// reported by `RootFS.Layers`), or `nil` when there are no layers.
+    /// Pure computation — nonisolated so callers off the main actor (tests,
+    /// background resolution) can use it directly.
+    nonisolated static func topChainID(diffIDs: [String]) -> String? {
+        guard var chain = diffIDs.first else { return nil }
+        for diff in diffIDs.dropFirst() {
+            let digest = SHA256.hash(data: Data("\(chain) \(diff)".utf8))
+            chain = "sha256:" + digest.map { String(format: "%02x", $0) }.joined()
+        }
+        return chain
+    }
+}

--- a/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
+++ b/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
@@ -1,6 +1,8 @@
 import AppKit
+import ArcBoxClient
 import DockerClient
 import SwiftUI
+import os
 
 /// Files tab showing image layer filesystem browser
 struct ImageFilesTab: View {
@@ -14,7 +16,7 @@ struct ImageFilesTab: View {
             case .dockerUnavailable:
                 return "Docker client is unavailable."
             case .missingRootPath:
-                return "Image has no configured rootfs mount path."
+                return "Image has no resolvable filesystem path."
             case .inspectFailed(let reason):
                 return "Failed to inspect image: \(reason)"
             }
@@ -23,6 +25,7 @@ struct ImageFilesTab: View {
 
     let image: ImageViewModel
     @Environment(\.dockerClient) private var docker
+    @Environment(\.arcboxClient) private var arcboxClient
 
     @State private var selectedPath: String?
     @State private var rootURL: URL?
@@ -33,7 +36,10 @@ struct ImageFilesTab: View {
     @State private var showHiddenFiles = LocalRootFSService.finderDefaultShowHiddenFiles()
 
     private var resolveTaskID: String {
-        "\(image.id)|\(refreshToken.uuidString)"
+        // Client availability is part of the key: the environment clients
+        // are nil during app startup, and resolution must re-run once they
+        // are injected — `.task(id:)` only restarts on an id change.
+        "\(image.id)|\(docker != nil)|\(arcboxClient != nil)|\(refreshToken.uuidString)"
     }
 
     private var outlineReloadID: String {
@@ -203,11 +209,36 @@ struct ImageFilesTab: View {
             ) {
                 return resolvedPath
             }
+            // Containerd image store: inspect carries no layer paths; ask
+            // the daemon to resolve the layer chain and browse the top
+            // layer's directory.
+            if let resolvedPath = await resolveViaDaemon(diffIDs: snapshot.rootfsLayers) {
+                return resolvedPath
+            }
             throw ImageFilesTabError.missingRootPath
         } catch let error as ImageFilesTabError {
             throw error
         } catch {
             throw ImageFilesTabError.inspectFailed(error.localizedDescription)
+        }
+    }
+
+    /// Resolves the image's top layer directory via the daemon, keyed by
+    /// the layer chain ID computed from the inspect diff IDs.
+    private func resolveViaDaemon(diffIDs: [String]) async -> String? {
+        guard let arcboxClient,
+            let topChainID = ImageLayerChain.topChainID(diffIDs: diffIDs)
+        else { return nil }
+        var request = Arcbox_V1_ResolveImageFsRequest()
+        request.topChainID = topChainID
+        do {
+            let response = try await arcboxClient.system.resolveImageFs(
+                request, options: ArcBoxClient.defaultCallOptions)
+            return response.lowerDirs.first
+        } catch {
+            Log.daemon.error(
+                "Failed to resolve image fs: \(error.localizedDescription, privacy: .private)")
+            return nil
         }
     }
 

--- a/ArcBoxTests/ImageLayerChainTests.swift
+++ b/ArcBoxTests/ImageLayerChainTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+
+@testable import ArcBox
+
+final class ImageLayerChainTests: XCTestCase {
+    func testSingleLayerChainIDIsTheDiffID() {
+        // A single-layer image's top chain ID equals its only diff ID —
+        // pinned against a live containerd committed-snapshot key
+        // (alpine:latest, verified in the arcbox container_fs e2e).
+        let diff = "sha256:b2848c02ac6ff53d265469b5b30f649f335e546a83330cd8916d54e65e640409"
+        XCTAssertEqual(ImageLayerChain.topChainID(diffIDs: [diff]), diff)
+    }
+
+    func testMultiLayerChainIDFollowsTheOCIFormula() {
+        // sha256("<chain0> <diff1>") computed independently with
+        // `printf '%s %s' a b | shasum -a 256` over the literal IDs below.
+        let diff0 = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+        let diff1 = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        XCTAssertEqual(
+            ImageLayerChain.topChainID(diffIDs: [diff0, diff1]),
+            "sha256:f94b891e05f6e37c90d87edfd5bb98a02d618a437c35f3a94b3b00e48e894631"
+        )
+    }
+
+    func testEmptyLayersYieldNil() {
+        XCTAssertNil(ImageLayerChain.topChainID(diffIDs: []))
+    }
+}

--- a/Packages/DockerClient/Sources/DockerClient/DockerClient/DockerClient+Inspect.swift
+++ b/Packages/DockerClient/Sources/DockerClient/DockerClient/DockerClient+Inspect.swift
@@ -100,12 +100,14 @@ private struct ImageInspectDTO: Decodable {
     let config: ImageConfigDTO?
     let containerConfig: ImageConfigDTO?
     let graphDriver: GraphDriverDTO?
+    let rootFS: RootFSDTO?
 
     var snapshot: ImageInspectSnapshot {
         ImageInspectSnapshot(
             labels: config?.normalizedLabels ?? containerConfig?.normalizedLabels ?? [:],
             rootfsMountPath: graphDriver?.imageRootfsMountPath,
-            overlayUpperDir: graphDriver?.overlayUpperDir
+            overlayUpperDir: graphDriver?.overlayUpperDir,
+            rootfsLayers: rootFS?.layers ?? []
         )
     }
 
@@ -113,6 +115,7 @@ private struct ImageInspectDTO: Decodable {
         case config = "Config"
         case containerConfig = "ContainerConfig"
         case graphDriver = "GraphDriver"
+        case rootFS = "RootFS"
     }
 
     init(from decoder: Decoder) throws {
@@ -120,6 +123,15 @@ private struct ImageInspectDTO: Decodable {
         config = try? container.decodeIfPresent(ImageConfigDTO.self, forKey: .config)
         containerConfig = try? container.decodeIfPresent(ImageConfigDTO.self, forKey: .containerConfig)
         graphDriver = try? container.decodeIfPresent(GraphDriverDTO.self, forKey: .graphDriver)
+        rootFS = try? container.decodeIfPresent(RootFSDTO.self, forKey: .rootFS)
+    }
+}
+
+private struct RootFSDTO: Decodable {
+    let layers: [String]?
+
+    private enum CodingKeys: String, CodingKey {
+        case layers = "Layers"
     }
 }
 

--- a/Packages/DockerClient/Sources/DockerClient/DockerClient/DockerModels.swift
+++ b/Packages/DockerClient/Sources/DockerClient/DockerClient/DockerModels.swift
@@ -53,14 +53,21 @@ public struct ImageInspectSnapshot: Sendable {
         return overlayUpperDir
     }
 
+    /// `RootFS.Layers` diff IDs, bottom-most first. Present under every
+    /// image store; under the containerd store the layer chain IDs derive
+    /// from these when GraphDriver carries no paths.
+    public let rootfsLayers: [String]
+
     public init(
         labels: [String: String],
         rootfsMountPath: String? = nil,
-        overlayUpperDir: String? = nil
+        overlayUpperDir: String? = nil,
+        rootfsLayers: [String] = []
     ) {
         self.labels = labels
         self.rootfsMountPath = rootfsMountPath
         self.overlayUpperDir = overlayUpperDir
+        self.rootfsLayers = rootfsLayers
     }
 }
 


### PR DESCRIPTION
Companion to arcboxlabs/arcbox#433 — restores the **Images** Files tab under the containerd image store (Containers/Volumes shipped in #295).

- `ImageInspectSnapshot` gains `RootFS.Layers` (diff IDs).
- New `ImageLayerChain.topChainID` computes the top layer chain ID per the OCI formula (test vectors pinned independently via `shasum`; the single-layer vector matches a live containerd committed-snapshot key from the arcbox e2e).
- `ImageFilesTab` falls back to `SystemService.ResolveImageFs` when inspect has no path and browses the top layer directory through `~/ArcBox/containerd`; the resolve task id keys on docker/arcbox client availability (same fix class as the #295 review finding).

**Draft until** arcbox#433 merges and ships in a release (`verify-arcbox-protobuf` pins to `arcbox.version`; the bump PR needs the proto regen, same as v0.4.21's #296).

Validated: Debug build + ArcBoxTests green locally (incl. new chain-ID tests), `swift-format lint --strict` clean, xcodegen-regenerated pbxproj carries only the two new files.