### PR TITLE
ci(release): update Homebrew latest cask

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -787,10 +787,10 @@ jobs:
           echo "arm=$(sha256sum "$dmg_path" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
       - name: Bump Homebrew cask
-        uses: arcboxlabs/homebrew-tap/.github/actions/bump-cask@19f97aa3ca8a15c3fdbbf018c1b79651bfdebb8d
+        uses: arcboxlabs/homebrew-tap/.github/actions/bump-cask@6ae026934e8dd30533bbbd73a3be6b7958fe2062
         with:
           token: ${{ steps.app-token.outputs.token }}
-          cask: arcbox
+          cask: arcbox@latest
           version: ${{ steps.cask-shas.outputs.version }}
           arm_sha256: ${{ steps.cask-shas.outputs.arm }}
 


### PR DESCRIPTION
## Summary

- pin the release workflow to the updated homebrew-tap bump action
- publish stable releases to `arcbox@latest` now that `arcbox` has migrated to `homebrew/cask`

## Validation

- `actionlint .github/workflows/release.yml`
- `yq eval '.' .github/workflows/release.yml`