### PR TITLE
fix(machines): live state polling, daemon-reason errors, idempotent start/stop

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		C78692742B1986F29532AA90 /* MachineLogsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95F593FF4C1C56EBF378883E /* MachineLogsTab.swift */; };
 		C8181916F2EBD889B0C8046B /* MachineTerminalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8632512053E9C750CAA97F9 /* MachineTerminalSession.swift */; };
 		C8C56406446AE0906E11100C /* InfoTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED1683EF0A3490B8B7B5CF6 /* InfoTableView.swift */; };
+		C94515858BC220B73B93EC5D /* ArcBoxClientErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC5F65FECB2F80BA3AF1D84 /* ArcBoxClientErrorTests.swift */; };
 		C9850114DD3E3F1B3C22E09D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 68009FEC4A2F0EB046ACCA4C /* Assets.xcassets */; };
 		CA35C83C2741D945EF23C5E3 /* VolumeViewModel+Docker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 867A6CA0B4DD07BE74610FCB /* VolumeViewModel+Docker.swift */; };
 		CC2502232C562D3167B2F3D2 /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = 9C709A3E8E1972F5BB841623 /* PostHog */; };
@@ -254,6 +255,7 @@
 		1B18FDEC4B5AE8513C98D7B4 /* SandboxDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxDetailView.swift; sourceTree = "<group>"; };
 		1B80964B0A136E03F5FDA0FE /* SandboxesViewModel+PortsFiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SandboxesViewModel+PortsFiles.swift"; sourceTree = "<group>"; };
 		1C649765AA76CFCBFC3302DA /* DeepLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkRouter.swift; sourceTree = "<group>"; };
+		1DC5F65FECB2F80BA3AF1D84 /* ArcBoxClientErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArcBoxClientErrorTests.swift; sourceTree = "<group>"; };
 		1E17CF68FBBA9447E1B15371 /* ImageTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTypes.swift; sourceTree = "<group>"; };
 		1E6C27E068081F8D598F3D7A /* ImageViewModel+Docker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImageViewModel+Docker.swift"; sourceTree = "<group>"; };
 		200F15F29A3634EC779554D4 /* ContainerLogsTab+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContainerLogsTab+Actions.swift"; sourceTree = "<group>"; };
@@ -1008,6 +1010,7 @@
 		F40F93A7C5C0CC3834C9D722 /* ArcBoxTests */ = {
 			isa = PBXGroup;
 			children = (
+				1DC5F65FECB2F80BA3AF1D84 /* ArcBoxClientErrorTests.swift */,
 				A10ED4BA65D6B9CC56B6B329 /* ChangelogParserTests.swift */,
 				E610512C9106BB92A47DC044 /* ContainersViewModelTests.swift */,
 				F5B3B3C54B6D49C6198E9E26 /* DeepLinkTests.swift */,
@@ -1370,6 +1373,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C94515858BC220B73B93EC5D /* ArcBoxClientErrorTests.swift in Sources */,
 				31474CB365691C57A5568D14 /* ChangelogParserTests.swift in Sources */,
 				4D2029E55A7979B8BD9EE89A /* ContainersViewModelTests.swift in Sources */,
 				EE2D38BC76500BF768EEE20F /* DeepLinkTests.swift in Sources */,

--- a/ArcBox/Models/MachineModel.swift
+++ b/ArcBox/Models/MachineModel.swift
@@ -85,6 +85,14 @@ struct MachineViewModel: Identifiable, Hashable {
 
     var isRunning: Bool { state.isRunning }
 
+    /// A lifecycle transition is under way — either an RPC this session issued
+    /// (`isTransitioning`) or a daemon-reported starting/stopping state. The
+    /// row shows a spinner instead of a start/stop button while busy, so the
+    /// user can't fire a second lifecycle RPC into a racing one.
+    var isBusy: Bool {
+        isTransitioning || state == .starting || state == .stopping
+    }
+
     var resourcesDisplay: String {
         "\(cpuCores) cores, \(memoryGB) GB RAM, \(diskGB) GB disk"
     }

--- a/ArcBox/ViewModels/MachinesViewModel+GRPC.swift
+++ b/ArcBox/ViewModels/MachinesViewModel+GRPC.swift
@@ -117,7 +117,10 @@ extension MachinesViewModel {
                 options: ArcBoxClient.systemVmRestartCallOptions
             )
         } catch {
-            reportError(error, operation: "start")
+            // Starting an already-running machine is a no-op, not a failure.
+            if !ArcBoxClient.rpcMessage(error, contains: "already running") {
+                reportError(error, operation: "start")
+            }
         }
         setTransitioning(id, false)
         await loadMachines(client: client)
@@ -135,7 +138,10 @@ extension MachinesViewModel {
                 options: ArcBoxClient.systemVmRestartCallOptions
             )
         } catch {
-            reportError(error, operation: "stop")
+            // Stopping a machine that is not running is a no-op, not a failure.
+            if !ArcBoxClient.rpcMessage(error, contains: "not running") {
+                reportError(error, operation: "stop")
+            }
         }
         setTransitioning(id, false)
         await loadMachines(client: client)

--- a/ArcBox/Views/Machines/MachineRowView.swift
+++ b/ArcBox/Views/Machines/MachineRowView.swift
@@ -71,7 +71,7 @@ struct MachineRowView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
 
             // Action buttons (show on hover or selection)
-            if machine.isTransitioning {
+            if machine.isBusy {
                 ProgressView()
                     .controlSize(.small)
                     .padding(.trailing, 4)

--- a/ArcBox/Views/Machines/MachinesView.swift
+++ b/ArcBox/Views/Machines/MachinesView.swift
@@ -47,7 +47,16 @@ struct MachinesView: View {
             MachineCreateSheet()
         }
         .task(id: client != nil) {
-            await vm.loadMachines(client: client)
+            // Load immediately, then poll while the Machines tab is on screen so
+            // the list tracks out-of-band changes (external CLI, a VM that exits
+            // on its own, a machine reset to stopped after daemon recovery).
+            // MachineService has no event stream, so poll rather than watch.
+            // loadMachines preserves in-flight transition and detail state, so a
+            // poll never clobbers an action the user just triggered.
+            while !Task.isCancelled {
+                await vm.loadMachines(client: client)
+                try? await Task.sleep(for: .seconds(3))
+            }
         }
         .confirmationDialog(
             "Delete machine \(pendingDeleteID ?? "")?",

--- a/ArcBoxTests/ArcBoxClientErrorTests.swift
+++ b/ArcBoxTests/ArcBoxClientErrorTests.swift
@@ -1,0 +1,49 @@
+import GRPCCore
+import XCTest
+
+@testable import ArcBoxClient
+
+final class ArcBoxClientErrorTests: XCTestCase {
+
+    // MARK: - userMessage
+
+    func testSurfacesDaemonReasonForInternalError() {
+        let error = RPCError(
+            code: .internalError,
+            message: "invalid state: machine 'ubuntu' is already running"
+        )
+        XCTAssertEqual(
+            ArcBoxClient.userMessage(for: error),
+            "invalid state: machine 'ubuntu' is already running"
+        )
+    }
+
+    func testCannedCopyForConnectivityCodes() {
+        XCTAssertEqual(
+            ArcBoxClient.userMessage(for: RPCError(code: .unavailable, message: "broken pipe")),
+            "Cannot reach ArcBox daemon. Is it running?"
+        )
+        XCTAssertEqual(
+            ArcBoxClient.userMessage(for: RPCError(code: .deadlineExceeded, message: "")),
+            "Operation timed out. The daemon may be busy."
+        )
+    }
+
+    func testFallsBackToCodeWhenMessageEmpty() {
+        let error = RPCError(code: .unknown, message: "   ")
+        XCTAssertTrue(ArcBoxClient.userMessage(for: error).contains("daemon reported"))
+    }
+
+    // MARK: - rpcMessage
+
+    func testRPCMessageMatchesReasonCaseInsensitively() {
+        let error = RPCError(code: .internalError, message: "machine 'x' is Already Running")
+        XCTAssertTrue(ArcBoxClient.rpcMessage(error, contains: "already running"))
+        XCTAssertFalse(ArcBoxClient.rpcMessage(error, contains: "not running"))
+    }
+
+    func testRPCMessageIgnoresNonGRPCErrors() {
+        struct Other: Error {}
+        XCTAssertFalse(ArcBoxClient.rpcMessage(Other(), contains: "already running"))
+    }
+}

--- a/ArcBoxTests/MachineModelTests.swift
+++ b/ArcBoxTests/MachineModelTests.swift
@@ -65,6 +65,20 @@ final class MachineModelTests: XCTestCase {
         XCTAssertEqual(MachineViewModel(from: summary).distro.displayName, "Linux")
     }
 
+    // MARK: - Busy state
+
+    func testTransitionStatesAndInFlightRPCAreBusy() {
+        for state in ["starting", "stopping"] {
+            var summary = makeSummary()
+            summary.state = state
+            XCTAssertTrue(MachineViewModel(from: summary).isBusy, "\(state) should be busy")
+        }
+        var running = MachineViewModel(from: makeSummary())
+        XCTAssertFalse(running.isBusy)
+        running.isTransitioning = true
+        XCTAssertTrue(running.isBusy, "an in-flight RPC should mark the row busy")
+    }
+
     func testByteSizesRoundToNearestGB() {
         var summary = makeSummary()
         // 4096 MiB - 512 MiB rounds down; + 512 MiB rounds up.

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/ArcBoxClient.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/ArcBoxClient.swift
@@ -199,27 +199,38 @@ public final class ArcBoxClient: Sendable {
 
     /// Map a gRPC or transport error to a user-friendly message.
     public static func userMessage(for error: Error) -> String {
-        let desc = String(describing: error)
+        // gRPC errors carry a status code plus the daemon's own reason string.
+        // Prefer that reason: it is the most specific, human-readable text
+        // available (e.g. "machine 'foo' is already running"). Reserve canned
+        // copy for connectivity codes, whose raw message is transport noise.
+        if let rpcError = error as? RPCError {
+            switch rpcError.code {
+            case .unavailable:
+                return "Cannot reach ArcBox daemon. Is it running?"
+            case .deadlineExceeded:
+                return "Operation timed out. The daemon may be busy."
+            default:
+                let message = rpcError.message.trimmingCharacters(in: .whitespacesAndNewlines)
+                return message.isEmpty
+                    ? "The daemon reported an error (\(rpcError.code))." : message
+            }
+        }
 
-        if desc.contains("unavailable") || desc.contains("UNAVAILABLE") {
-            return "Cannot reach ArcBox daemon. Is it running?"
-        }
-        if desc.contains("deadline") || desc.contains("DEADLINE_EXCEEDED") {
-            return "Operation timed out. The daemon may be busy."
-        }
-        if desc.contains("not found") || desc.contains("NOT_FOUND") {
-            return "Resource not found. It may have been removed."
-        }
-        if desc.contains("already exists") || desc.contains("ALREADY_EXISTS") {
-            return "A resource with that name already exists."
-        }
-        if desc.contains("permission") || desc.contains("PERMISSION_DENIED") {
-            return "Permission denied. Check daemon privileges."
-        }
+        // Non-gRPC (transport/URL) errors: fall back to substring heuristics.
+        let desc = String(describing: error)
         if desc.contains("ECONNREFUSED") || desc.contains("Connection refused") {
             return "Connection refused. Is the ArcBox daemon running?"
         }
-
         return error.localizedDescription
+    }
+
+    /// True when `error` is a gRPC error whose reason contains `phrase`.
+    ///
+    /// Lets callers recognize a specific daemon rejection (e.g. an idempotent
+    /// "already running") without matching against the opaque bridged
+    /// `localizedDescription`.
+    public static func rpcMessage(_ error: Error, contains phrase: String) -> Bool {
+        guard let rpcError = error as? RPCError else { return false }
+        return rpcError.message.range(of: phrase, options: .caseInsensitive) != nil
     }
 }


### PR DESCRIPTION
## Symptom

Creating a machine, then clicking Run (start), showed:

> The operation couldn't be completed. (GRPCCore.RPCError error 1.)

## Root cause — state management, not just the message

The daemon correctly rejected starting an already-running machine (`invalid state: … is already running`). Three desktop-side issues turned that into a confusing dead-end:

1. **No live state.** The Machines list loaded once via `.task(id: client != nil)` and thereafter refreshed only as a side effect of a lifecycle action. Any out-of-band change — an external `abctl` start/stop, a VM that exits on its own, a machine reset to stopped after daemon recovery — left the row showing **stale state**, so a machine's displayed state could diverge from the daemon's truth. Containers (Docker events) and Sandboxes (`sandboxes.events`) both subscribe to a stream; MachineService has none.
2. **Opaque errors.** `ArcBoxClient.userMessage(for:)` matched `String(describing:)` against six substrings and fell through to the bridged `localizedDescription` for everything else — which for a `GRPCCore.RPCError` is `"(GRPCCore.RPCError error 1.)"`. *Every* daemon error outside those six showed as "error 1".
3. **Racey affordances.** A machine in `starting`/`stopping` was drawn with a clickable start/stop button that could fire a second lifecycle RPC into the in-flight one.

(The daemon's recovery path is **correct** — `PersistedState::Running` maps to in-memory `Stopped` on reload — so this is desktop-only.)

## Fix

- **Poll the machine list every 3s while the tab is on screen** so the UI tracks daemon truth. `loadMachines` preserves in-flight transition + inspect-detail state, so a poll never clobbers a pending action.
- **Unwrap `RPCError`** in `userMessage(for:)` and surface the daemon's own reason (canned copy reserved for `.unavailable`/`.deadlineExceeded`). Fixes error reporting for **all** RPCs app-wide.
- **Idempotent start/stop**: treat the daemon's `already running` / `not running` rejection as a no-op (new `ArcBoxClient.rpcMessage(_:contains:)` predicate).
- **`MachineViewModel.isBusy`** (in-flight RPC **or** daemon `starting`/`stopping`) → the row shows a spinner, not an action button, while busy.

## Follow-up (not in this PR)

The proper fix for #1 is a `MachineService` **events/watch stream** daemon-side (like `sandboxes.events`), so the desktop can push-update instead of poll. Polling is the pragmatic interim.

## Test plan

- `xcodebuild test`: 116 pass (+6). New `ArcBoxClientErrorTests` (RPCError→reason mapping, connectivity canned copy, empty-message fallback, `rpcMessage` predicate); `MachineModelTests` covers `isBusy`.
- Reproduced the daemon rejection with `abctl machine start <running>` → `invalid state: … already running`; confirmed the new mapping surfaces that text and start/stop no-op on it.
- SwiftLint strict + Homebrew swift-format 603 clean.