### PR TITLE
fix(settings): withhold the HV backend until the capacity fix ships

### DIFF
--- a/ArcBox/Views/Settings/SystemSettingsView.swift
+++ b/ArcBox/Views/Settings/SystemSettingsView.swift
@@ -99,7 +99,7 @@ struct SystemSettingsView: View {
             Section {
                 LabeledContent {
                     Picker("Virtual machine backend", selection: $selectedBackend) {
-                        ForEach(SystemVmBackend.allCases) { backend in
+                        ForEach(availableBackends) { backend in
                             Text(backend.label).tag(backend)
                         }
                     }
@@ -209,8 +209,22 @@ struct SystemSettingsView: View {
 
     // MARK: - System VM Backend
 
-    private static let backendCaption =
-        "Intel (amd64) code runs via Rosetta on Virtualization.framework, or via FEX on Hypervisor.framework. Switching restarts the System VM."
+    private static let backendCaption = """
+        Intel (amd64) code runs via Rosetta on Virtualization.framework, or via FEX on \
+        Hypervisor.framework. Switching restarts the System VM. Hypervisor.framework is \
+        temporarily unavailable pending a data-disk capacity fix.
+        """
+
+    /// Backends the user may switch *to*. Hypervisor.framework is withheld
+    /// because switching to it shrinks the data disk the guest sees and
+    /// permanently breaks Docker until a fixed guest kernel ships (arcbox #453 /
+    /// kernel #13). It stays listed only when the daemon is already on it, so an
+    /// affected user can still switch back to Virtualization.framework.
+    private var availableBackends: [SystemVmBackend] {
+        SystemVmBackend.allCases.filter {
+            $0 != .hv || backendModel.currentBackend == .hv
+        }
+    }
 
     private func syncBackendSelection() {
         if let current = backendModel.currentBackend {


### PR DESCRIPTION
## Why

Switching the System VM engine to **Hypervisor.framework (HV)** permanently breaks Docker for any existing user. The guest's HVC block driver hardcodes a 512 GiB disk while `docker.img`'s Btrfs metadata was grown to 8 TiB under VZ, so under HV the data disk fails to mount (`open_ctree failed`), dockerd never starts, and `backend=hv` is persisted so restart/reboot never recovers. 100% reproducible; data is intact but Docker is dead until the engine is switched back.

Root fix is in the guest kernel + host (kernel #13 / arcbox #453). This is the desktop stop-bleeding so users can't fall into the trap before a fixed boot bundle ships.

## What

- Drop HV from the backend picker (`availableBackends`), so it can't be selected.
- Keep HV listed **only** when the daemon already reports HV, so a currently-affected user can still switch back to VZ to recover.
- Caption notes HV is temporarily unavailable pending the capacity fix.

No new gRPC surface; purely a Settings guard. Revert this once a daemon + boot bundle carrying the capacity query is the minimum supported version.

## Test plan

- `xcodebuild build` succeeds; SwiftLint strict + swift-format 603 clean.
- Manual: on a VZ daemon the picker shows only Virtualization.framework; the switch-to-HV path is unreachable. (Recovery path — HV shown when daemon is on HV — needs a daemon already on HV.)