### PR TITLE
fix(settings): re-enable the HV backend now that the capacity fix ships

### DIFF
--- a/ArcBox/Views/Settings/SystemSettingsView.swift
+++ b/ArcBox/Views/Settings/SystemSettingsView.swift
@@ -99,7 +99,7 @@ struct SystemSettingsView: View {
             Section {
                 LabeledContent {
                     Picker("Virtual machine backend", selection: $selectedBackend) {
-                        ForEach(availableBackends) { backend in
+                        ForEach(SystemVmBackend.allCases) { backend in
                             Text(backend.label).tag(backend)
                         }
                     }
@@ -209,22 +209,8 @@ struct SystemSettingsView: View {
 
     // MARK: - System VM Backend
 
-    private static let backendCaption = """
-        Intel (amd64) code runs via Rosetta on Virtualization.framework, or via FEX on \
-        Hypervisor.framework. Switching restarts the System VM. Hypervisor.framework is \
-        temporarily unavailable pending a data-disk capacity fix.
-        """
-
-    /// Backends the user may switch *to*. Hypervisor.framework is withheld
-    /// because switching to it shrinks the data disk the guest sees and
-    /// permanently breaks Docker until a fixed guest kernel ships (arcbox #453 /
-    /// kernel #13). It stays listed only when the daemon is already on it, so an
-    /// affected user can still switch back to Virtualization.framework.
-    private var availableBackends: [SystemVmBackend] {
-        SystemVmBackend.allCases.filter {
-            $0 != .hv || backendModel.currentBackend == .hv
-        }
-    }
+    private static let backendCaption =
+        "Intel (amd64) code runs via Rosetta on Virtualization.framework, or via FEX on Hypervisor.framework. Switching restarts the System VM."
 
     private func syncBackendSelection() {
         if let current = backendModel.currentBackend {


### PR DESCRIPTION
## Why

1.27.2 shipped with the Hypervisor.framework option **removed** from Settings (the #306 stop-bleeding guard, "temporarily unavailable pending a data-disk capacity fix"). But 1.27.2 also bundles daemon **v0.4.24** (boot assets 0.6.9 / kernel **v0.0.20**), whose guest driver queries the real HVC block capacity — so the corruption that motivated #306 is already fixed in this very release. The guard is now redundant and contradictory (fix present, option hidden).

## Verified live before flipping

On a machine whose data disk's Btrfs metadata was grown to 8 TiB under VZ (the exact setup that used to corrupt on HV):

- `abctl system backend hv` → daemon brought the block device up at the real **17179869184 sectors (8 TiB)** (was hardcoded 512 GiB before), the System VM booted, Btrfs mounted, and Docker came up clean (`overlayfs / 29.6.1`).
- `abctl system backend vz` → switched back, still healthy.

So HV↔VZ round-trips no longer corrupt the data disk.

## Change

Revert #306: restore the full backend picker (`SystemVmBackend.allCases`) and the original caption; drop the `availableBackends` filter and the "temporarily unavailable" copy.

## Test plan
- `xcodebuild build` succeeds; SwiftLint strict + swift-format clean.
- Live HV↔VZ switch verified as above.