### PR TITLE
feat(machines): live list via MachineService.Events instead of polling

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		CCAF8E87C516B0ACE300BDCD /* PodsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A76C0B459745654F31B3B2 /* PodsListView.swift */; };
 		CCD9ABC3F69FE5DA233E85EC /* MachineModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0647CCB67160C2509345B5E /* MachineModelTests.swift */; };
 		D0518D07973520530916560B /* ServiceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F238F21169A97B94193454CF /* ServiceDetailView.swift */; };
+		D0A2395C0C2BC0A77B175840 /* MachineEventMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2021CE387B9546EE87FA4CD5 /* MachineEventMonitor.swift */; };
 		D2AB4B6BF0723EE12A0DBC83 /* GuestDataMountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27130DDA57D2645C7E81D75D /* GuestDataMountTests.swift */; };
 		D2F870759080FB9D1DF58A3A /* NewContainerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B011CA693D5A9EFCCF61AA2D /* NewContainerSheet.swift */; };
 		D32166A92BDA2FB6B6037D94 /* DeepLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C649765AA76CFCBFC3302DA /* DeepLinkRouter.swift */; };
@@ -259,6 +260,7 @@
 		1E17CF68FBBA9447E1B15371 /* ImageTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTypes.swift; sourceTree = "<group>"; };
 		1E6C27E068081F8D598F3D7A /* ImageViewModel+Docker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImageViewModel+Docker.swift"; sourceTree = "<group>"; };
 		200F15F29A3634EC779554D4 /* ContainerLogsTab+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContainerLogsTab+Actions.swift"; sourceTree = "<group>"; };
+		2021CE387B9546EE87FA4CD5 /* MachineEventMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachineEventMonitor.swift; sourceTree = "<group>"; };
 		2022AA30CA121A0876D0B9D5 /* ImagesViewModel+Docker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImagesViewModel+Docker.swift"; sourceTree = "<group>"; };
 		209E974D66F4B2D9B5CDA2D9 /* VolumesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumesListView.swift; sourceTree = "<group>"; };
 		21565AF3B3606525539AE506 /* SandboxesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxesListView.swift; sourceTree = "<group>"; };
@@ -759,6 +761,7 @@
 			children = (
 				9A04AFE137230F2CE0DD9DBB /* DiagnosticBundleExporter.swift */,
 				8DB22F8A7AA46286F186A73F /* DockerEventMonitor.swift */,
+				2021CE387B9546EE87FA4CD5 /* MachineEventMonitor.swift */,
 				B71D28721E41F8303DBF7232 /* MachineImageCatalog.swift */,
 				50C68609B67AC82FF386CB92 /* SandboxEventMonitor.swift */,
 			);
@@ -1272,6 +1275,7 @@
 				C12DED2A6B5168308D89BE15 /* MachineCreateSheet.swift in Sources */,
 				2C918E08295E3751C9FD1EC1 /* MachineDetailView.swift in Sources */,
 				6689ABCBDBD0055D07165D84 /* MachineEmptyState.swift in Sources */,
+				D0A2395C0C2BC0A77B175840 /* MachineEventMonitor.swift in Sources */,
 				C415E585DA749E8A19984650 /* MachineFilesTab.swift in Sources */,
 				B5E8D265254E1C224247214A /* MachineImageCatalog.swift in Sources */,
 				BFA2E94DC17244A06D187331 /* MachineInfoTab.swift in Sources */,

--- a/ArcBox/App/AppDelegate.swift
+++ b/ArcBox/App/AppDelegate.swift
@@ -7,6 +7,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var daemonManager: DaemonManager?
     var eventMonitor: DockerEventMonitor?
     var sandboxEventMonitor: SandboxEventMonitor?
+    var machineEventMonitor: MachineEventMonitor?
     var startupOrchestrator: StartupOrchestrator?
     var arcboxClient: ArcBoxClient?
     var connectionTask: Task<Void, Never>?
@@ -35,6 +36,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         eventMonitor?.stop()
         sandboxEventMonitor?.stop()
+        machineEventMonitor?.stop()
         DockerContextManager.restorePreviousContext()
         arcboxClient?.close()
         connectionTask?.cancel()

--- a/ArcBox/ArcBoxApp.swift
+++ b/ArcBox/ArcBoxApp.swift
@@ -21,6 +21,7 @@ struct ArcBoxDesktopApp: App {
     // Lightweight init — no network calls until view appears
     @State private var eventMonitor = DockerEventMonitor()
     @State private var sandboxEventMonitor = SandboxEventMonitor()
+    @State private var machineEventMonitor = MachineEventMonitor()
     @State private var sleepWakeManager = SleepWakeManager()
     @State private var startupOrchestrator: StartupOrchestrator?
     @AppStorage("showInMenuBar") private var showInMenuBar = false
@@ -94,6 +95,7 @@ struct ArcBoxDesktopApp: App {
                     appDelegate.daemonManager = daemonManager
                     appDelegate.eventMonitor = eventMonitor
                     appDelegate.sandboxEventMonitor = sandboxEventMonitor
+                    appDelegate.machineEventMonitor = machineEventMonitor
 
                     let startupStart = CFAbsoluteTimeGetCurrent()
                     let orchestrator = StartupOrchestrator(
@@ -138,11 +140,13 @@ struct ArcBoxDesktopApp: App {
                         if let arcboxClient {
                             sandboxEventMonitor.start(
                                 client: arcboxClient, machineID: "default")
+                            machineEventMonitor.start(client: arcboxClient)
                         }
                         DockerContextManager.switchToArcBox()
                     } else {
                         eventMonitor.stop()
                         sandboxEventMonitor.stop()
+                        machineEventMonitor.stop()
                         sleepWakeManager.stop()
                         DockerContextManager.restorePreviousContext()
                     }

--- a/ArcBox/Services/MachineEventMonitor.swift
+++ b/ArcBox/Services/MachineEventMonitor.swift
@@ -1,0 +1,80 @@
+import ArcBoxClient
+import Foundation
+import GRPCCore
+import OSLog
+
+// Machine notifications come from the arcbox.v1 MachineService event stream,
+// distinct from Docker events and the sandbox stream.
+extension Notification.Name {
+    static let machineChanged = Notification.Name("machineChanged")
+}
+
+/// Subscribes to machine lifecycle events via gRPC server-streaming and posts
+/// a debounced `.machineChanged` so the Machines list refreshes on create /
+/// start / idle / stop / remove without polling. Any event — including the
+/// server's `resync` signal after dropped events — triggers a reload, so the
+/// exact payload is irrelevant here.
+@MainActor
+@Observable
+final class MachineEventMonitor {
+    @ObservationIgnored private var task: Task<Void, Never>?
+    @ObservationIgnored private var isStopped = true
+    @ObservationIgnored private var debounceTask: Task<Void, Never>?
+    private static let debounceInterval: Duration = .milliseconds(300)
+
+    func start(client: ArcBoxClient) {
+        task?.cancel()
+        isStopped = false
+
+        let stoppedCheck = { @MainActor [weak self] in self?.isStopped ?? true }
+        task = Task.detached {
+            var backoffSeconds: UInt64 = 2
+            while !Task.isCancelled {
+                if await stoppedCheck() { break }
+                do {
+                    try await client.machines.events(Arcbox_V1_MachineEventsRequest()) { response in
+                        for try await _ in response.messages {
+                            guard !Task.isCancelled else { break }
+                            await MainActor.run { [weak self] in
+                                self?.debouncedPost()
+                            }
+                        }
+                    }
+                    // Stream ended cleanly — reset backoff.
+                    backoffSeconds = 2
+                } catch {
+                    if Task.isCancelled { break }
+                    if await stoppedCheck() { break }
+                    Log.machine.warning(
+                        "Machine event stream error, reconnecting in \(backoffSeconds)s: \(error.localizedDescription, privacy: .private)"
+                    )
+                }
+
+                if Task.isCancelled { break }
+                if await stoppedCheck() { break }
+                try? await Task.sleep(for: .seconds(backoffSeconds))
+                // Exponential backoff capped at 30 seconds.
+                backoffSeconds = min(backoffSeconds * 2, 30)
+            }
+            Log.machine.info("Machine event monitor stopped")
+        }
+        Log.machine.info("Machine event monitor started")
+    }
+
+    func stop() {
+        isStopped = true
+        task?.cancel()
+        task = nil
+        debounceTask?.cancel()
+        debounceTask = nil
+    }
+
+    private func debouncedPost() {
+        debounceTask?.cancel()
+        debounceTask = Task {
+            try? await Task.sleep(for: Self.debounceInterval)
+            guard !Task.isCancelled else { return }
+            NotificationCenter.default.post(name: .machineChanged, object: nil)
+        }
+    }
+}

--- a/ArcBox/Services/MachineEventMonitor.swift
+++ b/ArcBox/Services/MachineEventMonitor.swift
@@ -33,6 +33,13 @@ final class MachineEventMonitor {
                 if await stoppedCheck() { break }
                 do {
                     try await client.machines.events(Arcbox_V1_MachineEventsRequest()) { response in
+                        // Refresh on every (re)connect: events that occur while
+                        // the stream is down during backoff are not replayed
+                        // (the server only sends `resync` for its own drops), so
+                        // re-list once the stream re-establishes to catch up.
+                        await MainActor.run { [weak self] in
+                            self?.debouncedPost()
+                        }
                         for try await _ in response.messages {
                             guard !Task.isCancelled else { break }
                             await MainActor.run { [weak self] in

--- a/ArcBox/Views/Machines/MachinesView.swift
+++ b/ArcBox/Views/Machines/MachinesView.swift
@@ -47,16 +47,15 @@ struct MachinesView: View {
             MachineCreateSheet()
         }
         .task(id: client != nil) {
-            // Load immediately, then poll while the Machines tab is on screen so
-            // the list tracks out-of-band changes (external CLI, a VM that exits
-            // on its own, a machine reset to stopped after daemon recovery).
-            // MachineService has no event stream, so poll rather than watch.
-            // loadMachines preserves in-flight transition and detail state, so a
-            // poll never clobbers an action the user just triggered.
-            while !Task.isCancelled {
-                await vm.loadMachines(client: client)
-                try? await Task.sleep(for: .seconds(3))
-            }
+            await vm.loadMachines(client: client)
+        }
+        // MachineEventMonitor streams MachineService.Events and posts this on
+        // create/start/idle/stop/remove (and on the server's resync signal), so
+        // the list tracks out-of-band changes — external CLI, a VM that exits on
+        // its own, a machine reset to stopped after daemon recovery — without
+        // polling. loadMachines preserves in-flight transition and detail state.
+        .onReceive(NotificationCenter.default.publisher(for: .machineChanged)) { _ in
+            Task { await vm.loadMachines(client: client) }
         }
         .confirmationDialog(
             "Delete machine \(pendingDeleteID ?? "")?",


### PR DESCRIPTION
## Why

The Machines list refreshed on a **3 s timer** — the interim fix from when `MachineService` had no event stream. daemon v0.4.24 (bundled since 1.27.2) ships `MachineService.Events`, so we can push-update like Containers (Docker events) and Sandboxes (`sandboxes.events`) instead of polling.

## What

- **`MachineEventMonitor`** (mirrors `SandboxEventMonitor`): a `Task.detached` server-streaming subscription to `client.machines.events(...)` with exponential backoff reconnect, posting a debounced `.machineChanged`. Started/stopped with `daemonManager.state` in `ArcBoxApp`, stopped on terminate in `AppDelegate`.
- **`MachinesView`**: load once via `.task`, then reload on `.onReceive(.machineChanged)`; the 3 s poll is gone.

Any event triggers a reload — including the server's `resync` signal after dropped events — so out-of-band changes (external `abctl`, a VM that exits on its own, a machine reset after daemon recovery) surface promptly. `loadMachines` still preserves in-flight transition + inspect-detail state, so a refresh never clobbers a pending action.

## Test plan
- `xcodebuild test`: 116 pass; `xcodebuild build` clean; SwiftLint strict + swift-format clean.
- Requires daemon ≥ v0.4.24 (has the Events RPC); 1.27.2+ bundles it.