### PR TITLE
fix(ci): install musl-cross from FiloSottile tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,17 +83,28 @@ jobs:
           fetch-depth: 1
 
       - name: Install dependencies
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: |
+          set -euo pipefail
           # macos runners sometimes ship untrusted third-party taps (e.g. aws/tap)
           # which brew now warns about on every invocation. Drop them before install.
           if brew tap | grep -qx 'aws/tap'; then
             brew untap aws/tap || true
           fi
-          # create-dmg: UDZO packaging.
+
+          # create-dmg: UDZO packaging (homebrew-core).
           # musl-cross: aarch64-linux-musl-strip for guest ELF payloads (dockerd
-          # etc.). Apple's /usr/bin/strip fails on some static Go ELFs.
-          brew install create-dmg musl-cross
+          # etc.). Apple's /usr/bin/strip fails on some static Go ELFs. The
+          # formula lives in a third-party tap, not homebrew-core — bare
+          # `brew install musl-cross` fails with "No available formula".
+          brew tap filosottile/musl-cross
+          # Homebrew 5.x requires explicit trust for non-official taps.
+          brew trust --tap filosottile/musl-cross 2>/dev/null \
+            || brew trust filosottile/musl-cross 2>/dev/null \
+            || true
+          brew install create-dmg filosottile/musl-cross/musl-cross
+          command -v create-dmg
+          command -v aarch64-linux-musl-strip
 
       - name: Import signing certificate
         uses: apple-actions/import-codesign-certs@v6


### PR DESCRIPTION
## Summary

v1.28.0 Release DMG failed in **1m3s** at `Install dependencies`:

```
No available formula with the name "musl-cross"
```

#313 added `brew install musl-cross` so packaging can strip guest ELFs with `aarch64-linux-musl-strip`, but that formula is **not** in homebrew-core — it lives at [`filosottile/musl-cross`](https://github.com/FiloSottile/homebrew-musl-cross).

### Fix

- `brew tap filosottile/musl-cross`
- `brew trust --tap` (Homebrew 5.x non-official tap requirement)
- `brew install create-dmg filosottile/musl-cross/musl-cross`
- Verify `create-dmg` and `aarch64-linux-musl-strip` are on PATH

## Test plan

- [ ] Merge
- [ ] Re-run Release DMG for `v1.28.0` (workflow_dispatch or re-push tag)
- [ ] Install dependencies succeeds; log shows strip using `aarch64-linux-musl-strip` where applicable
- [ ] DMG publishes successfully