### PR TITLE
fix(startup): reliable helper install + independent semver compare

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,7 +396,17 @@ jobs:
 
       - name: Verify release artifact contracts
         run: |
-          APP_BINARY="${{ github.workspace }}/arcbox-core/target/dmg-build/ArcBox.app/Contents/MacOS/ArcBox"
+          DMG_PATH="${{ steps.dmg.outputs.dmg_path }}"
+          MOUNT_POINT="$RUNNER_TEMP/arcbox-release-verify"
+          mkdir -p "$MOUNT_POINT"
+          hdiutil attach -nobrowse -readonly -mountpoint "$MOUNT_POINT" "$DMG_PATH"
+          cleanup() {
+            hdiutil detach "$MOUNT_POINT" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          APP="$MOUNT_POINT/ArcBox.app"
+          APP_BINARY="$APP/Contents/MacOS/ArcBox"
           ARCHITECTURES=$(lipo -archs "$APP_BINARY")
           file "$APP_BINARY"
           echo "Architectures: $ARCHITECTURES"
@@ -406,7 +416,7 @@ jobs:
           fi
           # Confirm packaging embedded the required prebuilt host binaries.
           for bin in abctl arcbox-helper; do
-            path="${{ github.workspace }}/arcbox-core/target/dmg-build/ArcBox.app/Contents/MacOS/bin/$bin"
+            path="$APP/Contents/MacOS/bin/$bin"
             test -f "$path"
             file "$path"
           done
@@ -428,7 +438,6 @@ jobs:
             fi
           }
 
-          APP="${{ github.workspace }}/arcbox-core/target/dmg-build/ArcBox.app"
           HELPER_VERSION=$("$APP/Contents/MacOS/bin/arcbox-helper" --version)
           if [[ ! "$HELPER_VERSION" =~ ^arcbox-helper[[:space:]][0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::arcbox-helper --version did not return semver on stdout: '$HELPER_VERSION'"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -394,7 +394,7 @@ jobs:
             echo "build_number=$(git rev-list --count HEAD)" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Verify release architecture
+      - name: Verify release artifact contracts
         run: |
           APP_BINARY="${{ github.workspace }}/arcbox-core/target/dmg-build/ArcBox.app/Contents/MacOS/ArcBox"
           ARCHITECTURES=$(lipo -archs "$APP_BINARY")
@@ -404,16 +404,36 @@ jobs:
             echo "::error::Expected ARM64-only app binary, found: $ARCHITECTURES"
             exit 1
           fi
-          # Confirm packaging embedded the prebuilt host binaries.
+          # Confirm packaging embedded the required prebuilt host binaries.
           for bin in abctl arcbox-helper; do
             path="${{ github.workspace }}/arcbox-core/target/dmg-build/ArcBox.app/Contents/MacOS/bin/$bin"
-            if [ -f "$path" ]; then
-              file "$path"
-            else
-              echo "::warning::$bin missing from packaged app (optional for older arcbox releases)"
-            fi
+            test -f "$path"
+            file "$path"
           done
-          test -f "${{ github.workspace }}/arcbox-core/target/dmg-build/ArcBox.app/Contents/MacOS/bin/abctl"
+
+          verify_code_identity() {
+            local path="$1"
+            local expected_identifier="$2"
+            local details identifier team
+            details=$(codesign -dvv "$path" 2>&1)
+            identifier=$(printf '%s\n' "$details" | sed -n 's/^Identifier=//p')
+            team=$(printf '%s\n' "$details" | sed -n 's/^TeamIdentifier=//p')
+            if [ "$identifier" != "$expected_identifier" ]; then
+              echo "::error::$path identifier is '$identifier', expected '$expected_identifier'"
+              exit 1
+            fi
+            if [ "$team" != "422ACSY6Y5" ]; then
+              echo "::error::$path TeamIdentifier is '$team', expected '422ACSY6Y5'"
+              exit 1
+            fi
+          }
+
+          APP="${{ github.workspace }}/arcbox-core/target/dmg-build/ArcBox.app"
+          verify_code_identity "$APP/Contents/MacOS/bin/abctl" "com.arcboxlabs.desktop.cli"
+          verify_code_identity "$APP/Contents/MacOS/bin/arcbox-helper" "com.arcboxlabs.desktop.helper"
+          verify_code_identity \
+            "$APP/Contents/Frameworks/com.arcboxlabs.desktop.daemon.app/Contents/MacOS/com.arcboxlabs.desktop.daemon" \
+            "com.arcboxlabs.desktop.daemon"
 
       - name: Report build cache sizes
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,22 +189,18 @@ jobs:
           AGENT_BIN=$(find "$DOWNLOAD_DIR" -type f -name "arcbox-agent" | head -1)
           VM_AGENT_BIN=$(find "$DOWNLOAD_DIR" -type f -name "vm-agent" | head -1)
 
-          if [ -z "$CLI_BIN" ] || [ -z "$DAEMON_BIN" ]; then
-            echo "Could not find pre-built binaries in release assets"
+          if [ -z "$CLI_BIN" ] || [ -z "$DAEMON_BIN" ] || [ -z "$HELPER_BIN" ]; then
+            echo "Could not find required pre-built host binaries (abctl, arcbox-daemon, arcbox-helper) in release assets"
             exit 1
           fi
 
           cp "$CLI_BIN" arcbox-core/target/release/abctl
           cp "$DAEMON_BIN" arcbox-core/target/release/arcbox-daemon
-          chmod +x arcbox-core/target/release/abctl arcbox-core/target/release/arcbox-daemon
-
-          if [ -n "$HELPER_BIN" ]; then
-            cp "$HELPER_BIN" arcbox-core/target/release/arcbox-helper
-            chmod +x arcbox-core/target/release/arcbox-helper
-            echo "Found arcbox-helper in release assets"
-          else
-            echo "::warning::arcbox-helper not found in release assets"
-          fi
+          cp "$HELPER_BIN" arcbox-core/target/release/arcbox-helper
+          chmod +x \
+            arcbox-core/target/release/abctl \
+            arcbox-core/target/release/arcbox-daemon \
+            arcbox-core/target/release/arcbox-helper
 
           if [ -n "$AGENT_BIN" ]; then
             cp "$AGENT_BIN" arcbox-core/target/aarch64-unknown-linux-musl/release/arcbox-agent
@@ -439,7 +435,7 @@ jobs:
           }
 
           HELPER_VERSION=$("$APP/Contents/MacOS/bin/arcbox-helper" --version)
-          if [[ ! "$HELPER_VERSION" =~ ^arcbox-helper[[:space:]][0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+          if [[ ! "$HELPER_VERSION" =~ ^arcbox-helper[[:space:]][0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::arcbox-helper --version did not return semver on stdout: '$HELPER_VERSION'"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -429,6 +429,11 @@ jobs:
           }
 
           APP="${{ github.workspace }}/arcbox-core/target/dmg-build/ArcBox.app"
+          HELPER_VERSION=$("$APP/Contents/MacOS/bin/arcbox-helper" --version)
+          if [[ ! "$HELPER_VERSION" =~ ^arcbox-helper[[:space:]][0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::arcbox-helper --version did not return semver on stdout: '$HELPER_VERSION'"
+            exit 1
+          fi
           verify_code_identity "$APP/Contents/MacOS/bin/abctl" "com.arcboxlabs.desktop.cli"
           verify_code_identity "$APP/Contents/MacOS/bin/arcbox-helper" "com.arcboxlabs.desktop.helper"
           verify_code_identity \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,9 +93,9 @@ jobs:
           fi
 
           # create-dmg: UDZO packaging (homebrew-core).
-          # musl-cross: aarch64-linux-musl-strip for guest ELF payloads (dockerd
-          # etc.). Apple's /usr/bin/strip fails on some static Go ELFs. The
-          # formula lives in a third-party tap, not homebrew-core — bare
+          # musl-cross: aarch64-linux-musl-strip for bundled guest agents.
+          # Apple's /usr/bin/strip is not a reliable ELF stripper. The formula
+          # lives in a third-party tap, not homebrew-core — bare
           # `brew install musl-cross` fails with "No available formula".
           brew tap filosottile/musl-cross
           # Homebrew 5.x requires explicit trust for non-official taps.
@@ -443,6 +443,31 @@ jobs:
             echo "::error::arcbox-helper --version did not return semver on stdout: '$HELPER_VERSION'"
             exit 1
           fi
+
+          MANIFEST=$(find "$APP/Contents/Resources/assets" -name manifest.json -print -quit)
+          test -n "$MANIFEST"
+          python3 - "$MANIFEST" "$APP/Contents/Resources/runtime" <<'PY'
+          import hashlib
+          import json
+          import pathlib
+          import sys
+
+          manifest_path = pathlib.Path(sys.argv[1])
+          runtime_root = pathlib.Path(sys.argv[2])
+          manifest = json.loads(manifest_path.read_text())
+          for binary in manifest["binaries"]:
+              target = binary["targets"]["arm64"]
+              install_dir = binary.get("install_dir") or "bin"
+              path = runtime_root / install_dir / binary["name"]
+              if not path.is_file():
+                  raise SystemExit(f"missing manifest runtime binary: {path}")
+              actual = hashlib.sha256(path.read_bytes()).hexdigest()
+              if actual != target["sha256"]:
+                  raise SystemExit(
+                      f"runtime hash mismatch for {path}: expected {target['sha256']}, got {actual}"
+                  )
+          PY
+
           verify_code_identity "$APP/Contents/MacOS/bin/abctl" "com.arcboxlabs.desktop.cli"
           verify_code_identity "$APP/Contents/MacOS/bin/arcbox-helper" "com.arcboxlabs.desktop.helper"
           verify_code_identity \

--- a/ArcBox/Views/Shared/StartupProgressView.swift
+++ b/ArcBox/Views/Shared/StartupProgressView.swift
@@ -74,13 +74,21 @@ struct StartupProgressView: View {
     private func stepRow(_ step: StartupStep) -> some View {
         let status = orchestrator.stepStatuses[step] ?? .pending
 
-        HStack(spacing: 8) {
+        HStack(alignment: .top, spacing: 8) {
             statusIcon(status)
                 .frame(width: 14, height: 14)
+                .padding(.top, 1)
 
-            Text(step.label)
-                .font(.system(size: 12))
-                .foregroundStyle(textColor(for: status))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(step.label)
+                    .font(.system(size: 12))
+                    .foregroundStyle(textColor(for: status))
+                if let detail = step.detail, case .failed = status {
+                    Text(detail)
+                        .font(.system(size: 11))
+                        .foregroundStyle(AppColors.textMuted)
+                }
+            }
         }
     }
 

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Helper.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Helper.swift
@@ -13,37 +13,86 @@ extension DaemonManager {
     /// standard macOS "wants to make changes" password dialog, the same
     /// approach used by Docker Desktop and OrbStack.
     ///
-    /// Skips silently if the installed helper version matches the bundled one.
-    /// Only prompts for password on first install or upgrade.
+    /// Skips the password prompt when the installed helper version already
+    /// matches the bundled one. Always refreshes user-space shell integration
+    /// (`~/.arcbox/bin` Docker CLI links + PATH) so terminals keep working even
+    /// when the privileged helper path is deferred or fails.
+    ///
+    /// - Throws: when the helper is missing/outdated and the privileged install
+    ///   fails or does not leave a matching binary on disk. Callers surface this
+    ///   in the startup UI so the user can retry (password cancel used to be
+    ///   silent, leaving `/usr/local/bin/docker*` unlinked forever).
+    ///
     /// Installed helper binary path (must match arcbox-constants privileged::HELPER_BINARY).
     nonisolated static let installedHelperPath = "/usr/local/libexec/arcbox-helper"
 
-    public func installHelper() async {
+    public func installHelper() async throws {
         // Find abctl and helper in the app bundle.
         let bundle = Bundle.main.bundleURL
         let abctl = bundle.appendingPathComponent("Contents/MacOS/bin/abctl").path
         let helper = bundle.appendingPathComponent("Contents/MacOS/bin/arcbox-helper").path
         guard FileManager.default.isExecutableFile(atPath: abctl) else {
-            ClientLog.daemon.warning("abctl not found in bundle, skipping helper install")
-            return
+            throw HelperInstallError.bundledBinaryMissing("abctl")
         }
         guard FileManager.default.isExecutableFile(atPath: helper) else {
-            ClientLog.daemon.warning("arcbox-helper not found in bundle, skipping helper install")
-            return
+            throw HelperInstallError.bundledBinaryMissing("arcbox-helper")
         }
 
-        // Skip if installed helper is the same version as the bundled one.
         let installedVersion = binaryVersion(Self.installedHelperPath)
         let bundledVersion = binaryVersion(helper)
-        if let iv = installedVersion, let bv = bundledVersion, iv == bv {
+        let needsInstall =
+            installedVersion == nil
+            || bundledVersion == nil
+            || installedVersion != bundledVersion
+
+        if !needsInstall, let version = installedVersion {
             helperInstalled = true
-            ClientLog.daemon.info("Helper \(iv, privacy: .public) already installed")
+            ClientLog.daemon.info("Helper \(version, privacy: .public) already installed")
             await installShellIntegration(abctl: abctl)
             return
         }
 
-        ClientLog.daemon.info("Installing helper via abctl _install")
+        ClientLog.daemon.info(
+            """
+            Installing helper via abctl _install \
+            (installed=\(installedVersion ?? "none", privacy: .public), \
+            bundled=\(bundledVersion ?? "unknown", privacy: .public))
+            """
+        )
 
+        let installError = await runPrivilegedHelperInstall(abctl: abctl, helper: helper)
+        if let installError {
+            helperInstalled = false
+            // Still refresh user-space PATH/CLI links — these do not need root
+            // and keep `docker` available via ~/.arcbox/bin when the user has
+            // shell integration sourced.
+            await installShellIntegration(abctl: abctl)
+            throw installError
+        }
+
+        // Verify the on-disk helper actually matches the bundle. AppleScript can
+        // report success while the copy/bootstrap silently no-ops (or an older
+        // launchd-managed binary is still what --version reports).
+        let postInstallVersion = binaryVersion(Self.installedHelperPath)
+        if let bundledVersion, let postInstallVersion, postInstallVersion == bundledVersion {
+            helperInstalled = true
+            ClientLog.daemon.info(
+                "Helper installed successfully (\(postInstallVersion, privacy: .public))")
+            await installShellIntegration(abctl: abctl)
+            return
+        }
+
+        helperInstalled = false
+        await installShellIntegration(abctl: abctl)
+        throw HelperInstallError.versionMismatch(
+            installed: postInstallVersion,
+            expected: bundledVersion
+        )
+    }
+
+    /// Run the elevated `abctl _install` AppleScript. Returns `nil` on success
+    /// or a typed error describing the failure.
+    private func runPrivilegedHelperInstall(abctl: String, helper: String) async -> HelperInstallError? {
         func shellQuote(_ s: String) -> String {
             "'\(s.replacingOccurrences(of: "'", with: "'\\''"))'"
         }
@@ -52,24 +101,31 @@ extension DaemonManager {
             "\(shellQuote(abctl)) \(profileArgs) _install --no-daemon --no-shell --helper-path \(shellQuote(helper))"
         let script = "do shell script \"\(cmd)\" with administrator privileges"
 
-        let result = await Task.detached { () -> Bool in
+        return await Task.detached { () -> HelperInstallError? in
             var error: NSDictionary?
-            if let appleScript = NSAppleScript(source: script) {
-                appleScript.executeAndReturnError(&error)
-                if let error {
-                    ClientLog.daemon.warning("Helper install failed: \(error, privacy: .private)")
-                    return false
-                }
-                return true
+            guard let appleScript = NSAppleScript(source: script) else {
+                return .appleScriptUnavailable
             }
-            return false
+            appleScript.executeAndReturnError(&error)
+            if let error {
+                // NSAppleScript error dictionary keys (Foundation string constants).
+                let message =
+                    (error["NSAppleScriptErrorMessage"] as? String)
+                    ?? String(describing: error)
+                let code = error["NSAppleScriptErrorNumber"] as? Int
+                ClientLog.daemon.warning(
+                    "Helper install failed (code=\(code.map(String.init) ?? "?", privacy: .public)): \(message, privacy: .private)"
+                )
+                // -128 is userCanceledErr from Authorization Services / AppleScript.
+                if code == -128 || message.localizedCaseInsensitiveContains("user canceled")
+                    || message.localizedCaseInsensitiveContains("user cancelled")
+                {
+                    return .userCanceled
+                }
+                return .installFailed(message)
+            }
+            return nil
         }.value
-
-        helperInstalled = result
-        if result {
-            ClientLog.daemon.info("Helper installed successfully")
-            await installShellIntegration(abctl: abctl)
-        }
     }
 
     /// Run `abctl setup install` as the current user to set up shell
@@ -130,7 +186,8 @@ extension DaemonManager {
                     try fm.createDirectory(at: destDir, withIntermediateDirectories: true)
                 } catch {
                     ClientLog.daemon.warning(
-                        "Failed to create completions dir \(destDir.path): \(error, privacy: .public)")
+                        "Failed to create completions dir \(destDir.path): \(error, privacy: .public)"
+                    )
                     continue
                 }
                 for file in files {
@@ -152,6 +209,41 @@ extension DaemonManager {
         }.value
     }
 
+}
+
+// MARK: - Errors
+
+/// Failures while installing or verifying the privileged helper.
+public enum HelperInstallError: LocalizedError, Sendable, Equatable {
+    case bundledBinaryMissing(String)
+    case appleScriptUnavailable
+    case userCanceled
+    case installFailed(String)
+    case versionMismatch(installed: String?, expected: String?)
+
+    public var errorDescription: String? {
+        switch self {
+        case .bundledBinaryMissing(let name):
+            return "Bundled \(name) is missing from the app. Reinstall ArcBox."
+        case .appleScriptUnavailable:
+            return "Could not start the administrator prompt to install the helper service."
+        case .userCanceled:
+            return """
+                Administrator approval is required to install the helper service \
+                (needed for /usr/local/bin/docker and DNS). Click Retry and enter your password.
+                """
+        case .installFailed(let message):
+            return "Helper install failed: \(message)"
+        case .versionMismatch(let installed, let expected):
+            let have = installed ?? "none"
+            let want = expected ?? "unknown"
+            return """
+                Helper service is outdated (\(have); expected \(want)). \
+                Click Retry and approve the administrator prompt, or run: \
+                sudo abctl _install --no-daemon --no-shell
+                """
+        }
+    }
 }
 
 /// Runs `<binary> --version` and returns the trimmed stdout (e.g. "arcbox-helper 0.3.1").

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Helper.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Helper.swift
@@ -106,7 +106,8 @@ extension DaemonManager {
 
     /// Run the elevated `abctl _install` AppleScript. Returns `nil` on success
     /// or a typed error describing the failure.
-    private func runPrivilegedHelperInstall(abctl: String, helper: String) async -> HelperInstallError?
+    private func runPrivilegedHelperInstall(abctl: String, helper: String) async
+        -> HelperInstallError?
     {
         func shellQuote(_ s: String) -> String {
             "'\(s.replacingOccurrences(of: "'", with: "'\\''"))'"

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Helper.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Helper.swift
@@ -296,12 +296,15 @@ enum HelperVersion {
     ///
     /// - Missing install → reinstall
     /// - Unknown bundled version → reinstall (safe default)
-    /// - Installed < bundled → reinstall
-    /// - Installed ≥ bundled → keep (no password)
+    /// - **Major differs** either way → reinstall (tarpc / error wire break)
+    /// - Same major and installed < bundled → reinstall
+    /// - Same major and installed ≥ bundled → keep (no password on app downgrade)
     static func needsReinstall(installed: Triple?, bundled: Triple?) -> Bool {
         guard let bundled else { return true }
         guard let installed else { return true }
-        if installed.major != bundled.major { return installed.major < bundled.major }
+        // Wire major must match. A leftover 2.x helper after downgrading the
+        // app to 1.x is not "newer is fine" — force replace.
+        if installed.major != bundled.major { return true }
         if installed.minor != bundled.minor { return installed.minor < bundled.minor }
         return installed.patch < bundled.patch
     }

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Helper.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Helper.swift
@@ -288,17 +288,53 @@ public enum HelperInstallError: LocalizedError, Sendable, Equatable {
 
 // MARK: - Helper version parsing
 
-/// Parses `arcbox-helper --version` / RPC output into a comparable semver triple.
+/// Parses `arcbox-helper --version` / RPC output into a comparable semantic version.
 ///
 /// Formats:
 /// - Independent helper: `arcbox-helper 1.0.0`
 /// - Legacy workspace-tied: `arcbox-helper 0.4.12`
 struct HelperVersion: Comparable, Sendable {
+    private enum PrereleaseIdentifier: Comparable, Sendable {
+        case numeric(String)
+        case alphanumeric(String)
+
+        static func < (lhs: Self, rhs: Self) -> Bool {
+            switch (lhs, rhs) {
+            case (.numeric(let lhs), .numeric(let rhs)):
+                if lhs.count != rhs.count { return lhs.count < rhs.count }
+                return lhs < rhs
+            case (.numeric, .alphanumeric):
+                return true
+            case (.alphanumeric, .numeric):
+                return false
+            case (.alphanumeric(let lhs), .alphanumeric(let rhs)):
+                return lhs < rhs
+            }
+        }
+    }
+
     let major: UInt64
     let minor: UInt64
     let patch: UInt64
+    private let prerelease: [PrereleaseIdentifier]
 
-    /// Extract major.minor.patch from a version line.
+    init(major: UInt64, minor: UInt64, patch: UInt64) {
+        self.init(major: major, minor: minor, patch: patch, prerelease: [])
+    }
+
+    private init(
+        major: UInt64,
+        minor: UInt64,
+        patch: UInt64,
+        prerelease: [PrereleaseIdentifier]
+    ) {
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+        self.prerelease = prerelease
+    }
+
+    /// Extract a semantic version from a version line.
     static func parse(_ versionOutput: String?) -> Self? {
         guard var raw = versionOutput?.trimmingCharacters(in: .whitespacesAndNewlines),
             !raw.isEmpty
@@ -308,25 +344,77 @@ struct HelperVersion: Comparable, Sendable {
         if raw.hasPrefix("arcbox-helper") {
             raw = raw.dropFirst("arcbox-helper".count).trimmingCharacters(in: .whitespaces)
         }
-        // Drop pre-release / build metadata.
-        if let cut = raw.firstIndex(where: { $0 == "-" || $0 == "+" }) {
-            raw = String(raw[..<cut])
+
+        let buildParts = raw.split(separator: "+", maxSplits: 1, omittingEmptySubsequences: false)
+        if buildParts.count == 2, !validIdentifiers(buildParts[1], allowLeadingZeroes: true) {
+            return nil
         }
-        let parts = raw.split(separator: ".", omittingEmptySubsequences: false)
+
+        let versionParts = buildParts[0].split(
+            separator: "-", maxSplits: 1, omittingEmptySubsequences: false)
+        let parts = versionParts[0].split(separator: ".", omittingEmptySubsequences: false)
         guard parts.count == 3,
-            let major = UInt64(parts[0]),
-            let minor = UInt64(parts[1]),
-            let patch = UInt64(parts[2])
+            let major = parseCoreIdentifier(parts[0]),
+            let minor = parseCoreIdentifier(parts[1]),
+            let patch = parseCoreIdentifier(parts[2])
         else {
             return nil
         }
-        return Self(major: major, minor: minor, patch: patch)
+
+        var prerelease: [PrereleaseIdentifier] = []
+        if versionParts.count == 2 {
+            let rawPrerelease = versionParts[1]
+            guard validIdentifiers(rawPrerelease, allowLeadingZeroes: false) else { return nil }
+            prerelease = rawPrerelease.split(separator: ".").map { identifier in
+                if identifier.utf8.allSatisfy(Self.isASCIIDigit) {
+                    return .numeric(String(identifier))
+                }
+                return .alphanumeric(String(identifier))
+            }
+        }
+
+        return Self(major: major, minor: minor, patch: patch, prerelease: prerelease)
     }
 
     static func < (lhs: Self, rhs: Self) -> Bool {
         if lhs.major != rhs.major { return lhs.major < rhs.major }
         if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
-        return lhs.patch < rhs.patch
+        if lhs.patch != rhs.patch { return lhs.patch < rhs.patch }
+        if lhs.prerelease.isEmpty { return false }
+        if rhs.prerelease.isEmpty { return true }
+        return lhs.prerelease.lexicographicallyPrecedes(rhs.prerelease)
+    }
+
+    private static func parseCoreIdentifier(_ value: Substring) -> UInt64? {
+        guard value.utf8.allSatisfy(isASCIIDigit),
+            value.count == 1 || value.first != "0"
+        else {
+            return nil
+        }
+        return UInt64(value)
+    }
+
+    private static func validIdentifiers(
+        _ value: Substring,
+        allowLeadingZeroes: Bool
+    ) -> Bool {
+        let identifiers = value.split(separator: ".", omittingEmptySubsequences: false)
+        return !identifiers.isEmpty
+            && identifiers.allSatisfy { identifier in
+                guard !identifier.isEmpty,
+                    identifier.utf8.allSatisfy({
+                        isASCIIDigit($0) || (65...90).contains($0) || (97...122).contains($0) || $0 == 45
+                    })
+                else {
+                    return false
+                }
+                return allowLeadingZeroes || !identifier.utf8.allSatisfy(isASCIIDigit)
+                    || identifier.count == 1 || identifier.first != "0"
+            }
+    }
+
+    private static func isASCIIDigit(_ byte: UInt8) -> Bool {
+        (48...57).contains(byte)
     }
 
     /// Whether the on-disk helper should be replaced by the bundled one.

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Helper.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Helper.swift
@@ -13,8 +13,10 @@ extension DaemonManager {
     /// standard macOS "wants to make changes" password dialog, the same
     /// approach used by Docker Desktop and OrbStack.
     ///
-    /// Skips the password prompt when the installed helper version already
-    /// matches the bundled one. Always refreshes user-space shell integration
+    /// Skips the password prompt when the installed helper's **own crate
+    /// version** is already ≥ the bundled one. That version is independent of
+    /// the arcbox workspace version, so ordinary runtime bumps do not force an
+    /// admin reinstall. Always refreshes user-space shell integration
     /// (`~/.arcbox/bin` Docker CLI links + PATH) so terminals keep working even
     /// when the privileged helper path is deferred or fails.
     ///
@@ -40,14 +42,25 @@ extension DaemonManager {
 
         let installedVersion = binaryVersion(Self.installedHelperPath)
         let bundledVersion = binaryVersion(helper)
-        let needsInstall =
-            installedVersion == nil
-            || bundledVersion == nil
-            || installedVersion != bundledVersion
+        let installedSemver = HelperVersion.parse(installedVersion)
+        let bundledSemver = HelperVersion.parse(bundledVersion)
 
-        if !needsInstall, let version = installedVersion {
+        // Reinstall only when installed is missing or strictly older than the
+        // bundle. Equal/newer keeps the on-disk binary (no password).
+        let needsInstall = HelperVersion.needsReinstall(
+            installed: installedSemver,
+            bundled: bundledSemver
+        )
+
+        if !needsInstall {
             helperInstalled = true
-            ClientLog.daemon.info("Helper \(version, privacy: .public) already installed")
+            ClientLog.daemon.info(
+                """
+                Helper already sufficient \
+                (installed=\(installedVersion ?? "none", privacy: .public), \
+                bundled=\(bundledVersion ?? "unknown", privacy: .public))
+                """
+            )
             await installShellIntegration(abctl: abctl)
             return
         }
@@ -70,14 +83,15 @@ extension DaemonManager {
             throw installError
         }
 
-        // Verify the on-disk helper actually matches the bundle. AppleScript can
-        // report success while the copy/bootstrap silently no-ops (or an older
-        // launchd-managed binary is still what --version reports).
+        // Verify the on-disk helper version is now ≥ the bundle. AppleScript
+        // can report success while the copy/bootstrap silently no-ops.
         let postInstallVersion = binaryVersion(Self.installedHelperPath)
-        if let bundledVersion, let postInstallVersion, postInstallVersion == bundledVersion {
+        let postInstallSemver = HelperVersion.parse(postInstallVersion)
+        if !HelperVersion.needsReinstall(installed: postInstallSemver, bundled: bundledSemver) {
             helperInstalled = true
             ClientLog.daemon.info(
-                "Helper installed successfully (\(postInstallVersion, privacy: .public))")
+                "Helper installed successfully (\(postInstallVersion ?? "unknown", privacy: .public))"
+            )
             await installShellIntegration(abctl: abctl)
             return
         }
@@ -92,7 +106,8 @@ extension DaemonManager {
 
     /// Run the elevated `abctl _install` AppleScript. Returns `nil` on success
     /// or a typed error describing the failure.
-    private func runPrivilegedHelperInstall(abctl: String, helper: String) async -> HelperInstallError? {
+    private func runPrivilegedHelperInstall(abctl: String, helper: String) async -> HelperInstallError?
+    {
         func shellQuote(_ s: String) -> String {
             "'\(s.replacingOccurrences(of: "'", with: "'\\''"))'"
         }
@@ -238,7 +253,7 @@ public enum HelperInstallError: LocalizedError, Sendable, Equatable {
             let have = installed ?? "none"
             let want = expected ?? "unknown"
             return """
-                Helper service is outdated (\(have); expected \(want)). \
+                Helper service is outdated (\(have); need \(want)). \
                 Click Retry and approve the administrator prompt, or run: \
                 sudo abctl _install --no-daemon --no-shell
                 """
@@ -246,9 +261,56 @@ public enum HelperInstallError: LocalizedError, Sendable, Equatable {
     }
 }
 
-/// Runs `<binary> --version` and returns the trimmed stdout (e.g. "arcbox-helper 0.3.1").
+// MARK: - Helper version parsing
+
+/// Parses `arcbox-helper --version` / RPC output into a comparable semver triple.
+///
+/// Formats:
+/// - Independent helper: `arcbox-helper 1.0.0`
+/// - Legacy workspace-tied: `arcbox-helper 0.4.12`
+enum HelperVersion {
+    typealias Triple = (major: UInt64, minor: UInt64, patch: UInt64)
+
+    /// Extract major.minor.patch from a version line.
+    static func parse(_ versionOutput: String?) -> Triple? {
+        guard var raw = versionOutput?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !raw.isEmpty
+        else {
+            return nil
+        }
+        if raw.hasPrefix("arcbox-helper") {
+            raw = raw.dropFirst("arcbox-helper".count).trimmingCharacters(in: .whitespaces)
+        }
+        // Drop pre-release / build metadata.
+        if let cut = raw.firstIndex(where: { $0 == "-" || $0 == "+" }) {
+            raw = String(raw[..<cut])
+        }
+        let parts = raw.split(separator: ".", maxSplits: 2, omittingEmptySubsequences: false)
+        guard let major = parts.first.flatMap({ UInt64($0) }) else { return nil }
+        let minor = parts.count > 1 ? UInt64(parts[1]) ?? 0 : 0
+        let patch = parts.count > 2 ? UInt64(parts[2]) ?? 0 : 0
+        return (major, minor, patch)
+    }
+
+    /// Whether the on-disk helper should be replaced by the bundled one.
+    ///
+    /// - Missing install → reinstall
+    /// - Unknown bundled version → reinstall (safe default)
+    /// - Installed < bundled → reinstall
+    /// - Installed ≥ bundled → keep (no password)
+    static func needsReinstall(installed: Triple?, bundled: Triple?) -> Bool {
+        guard let bundled else { return true }
+        guard let installed else { return true }
+        if installed.major != bundled.major { return installed.major < bundled.major }
+        if installed.minor != bundled.minor { return installed.minor < bundled.minor }
+        return installed.patch < bundled.patch
+    }
+}
+
+/// Runs `<binary> --version` and returns the trimmed stdout
+/// (e.g. "arcbox-helper 1.0.0").
 /// Returns nil if the binary doesn't exist or the command fails.
-private func binaryVersion(_ path: String) -> String? {
+func binaryVersion(_ path: String) -> String? {
     guard FileManager.default.isExecutableFile(atPath: path) else { return nil }
     let process = Process()
     process.executableURL = URL(fileURLWithPath: path)

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Helper.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Helper.swift
@@ -117,7 +117,8 @@ extension DaemonManager {
         let profileArgs = Self.profileArguments.map(shellQuote).joined(separator: " ")
         let cmd =
             "\(shellQuote(abctl)) \(profileArgs) _install --no-daemon --no-shell --helper-path \(shellQuote(helper))"
-        let script = "do shell script \"\(cmd)\" with administrator privileges"
+        let script =
+            "do shell script \(appleScriptStringLiteral(cmd)) with administrator privileges"
 
         return await Task.detached { () -> HelperInstallError? in
             var error: NSDictionary?
@@ -231,6 +232,27 @@ extension DaemonManager {
 
 // MARK: - Errors
 
+/// Encodes an arbitrary string as one AppleScript string literal.
+///
+/// Shell quoting alone is insufficient because the shell command is first
+/// parsed as AppleScript source. App bundle paths may contain every escaped
+/// character handled here, including quotes and newlines.
+func appleScriptStringLiteral(_ value: String) -> String {
+    var literal = "\""
+    for character in value {
+        switch character {
+        case "\\": literal += "\\\\"
+        case "\"": literal += "\\\""
+        case "\n": literal += "\\n"
+        case "\r": literal += "\\r"
+        case "\t": literal += "\\t"
+        default: literal.append(character)
+        }
+    }
+    literal.append("\"")
+    return literal
+}
+
 /// Failures while installing or verifying the privileged helper.
 public enum HelperInstallError: LocalizedError, Sendable, Equatable {
     case bundledBinaryMissing(String)
@@ -271,11 +293,13 @@ public enum HelperInstallError: LocalizedError, Sendable, Equatable {
 /// Formats:
 /// - Independent helper: `arcbox-helper 1.0.0`
 /// - Legacy workspace-tied: `arcbox-helper 0.4.12`
-enum HelperVersion {
-    typealias Triple = (major: UInt64, minor: UInt64, patch: UInt64)
+struct HelperVersion: Comparable, Sendable {
+    let major: UInt64
+    let minor: UInt64
+    let patch: UInt64
 
     /// Extract major.minor.patch from a version line.
-    static func parse(_ versionOutput: String?) -> Triple? {
+    static func parse(_ versionOutput: String?) -> Self? {
         guard var raw = versionOutput?.trimmingCharacters(in: .whitespacesAndNewlines),
             !raw.isEmpty
         else {
@@ -288,11 +312,21 @@ enum HelperVersion {
         if let cut = raw.firstIndex(where: { $0 == "-" || $0 == "+" }) {
             raw = String(raw[..<cut])
         }
-        let parts = raw.split(separator: ".", maxSplits: 2, omittingEmptySubsequences: false)
-        guard let major = parts.first.flatMap({ UInt64($0) }) else { return nil }
-        let minor = parts.count > 1 ? UInt64(parts[1]) ?? 0 : 0
-        let patch = parts.count > 2 ? UInt64(parts[2]) ?? 0 : 0
-        return (major, minor, patch)
+        let parts = raw.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 3,
+            let major = UInt64(parts[0]),
+            let minor = UInt64(parts[1]),
+            let patch = UInt64(parts[2])
+        else {
+            return nil
+        }
+        return Self(major: major, minor: minor, patch: patch)
+    }
+
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        if lhs.major != rhs.major { return lhs.major < rhs.major }
+        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
+        return lhs.patch < rhs.patch
     }
 
     /// Whether the on-disk helper should be replaced by the bundled one.
@@ -302,14 +336,13 @@ enum HelperVersion {
     /// - **Major differs** either way → reinstall (tarpc / error wire break)
     /// - Same major and installed < bundled → reinstall
     /// - Same major and installed ≥ bundled → keep (no password on app downgrade)
-    static func needsReinstall(installed: Triple?, bundled: Triple?) -> Bool {
+    static func needsReinstall(installed: Self?, bundled: Self?) -> Bool {
         guard let bundled else { return true }
         guard let installed else { return true }
         // Wire major must match. A leftover 2.x helper after downgrading the
         // app to 1.x is not "newer is fine" — force replace.
         if installed.major != bundled.major { return true }
-        if installed.minor != bundled.minor { return installed.minor < bundled.minor }
-        return installed.patch < bundled.patch
+        return installed < bundled
     }
 }
 

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Helper.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Helper.swift
@@ -106,7 +106,9 @@ extension DaemonManager {
 
     /// Run the elevated `abctl _install` AppleScript. Returns `nil` on success
     /// or a typed error describing the failure.
-    private func runPrivilegedHelperInstall(abctl: String, helper: String) async
+    private func runPrivilegedHelperInstall(
+        abctl: String, helper: String
+    ) async
         -> HelperInstallError?
     {
         func shellQuote(_ s: String) -> String {

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/StartupOrchestrator/StartupOrchestrator.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/StartupOrchestrator/StartupOrchestrator.swift
@@ -94,10 +94,18 @@ public final class StartupOrchestrator {
             stepStatuses[step] = .pending
         }
 
-        // Step 1: Install privileged helper (one-time, macOS prompts for admin).
-        // Non-critical: daemon works without it, just no DNS/socket integration.
-        await runStep(.installHelper) {
-            await self.daemonManager.installHelper()
+        // Step 1: Install / upgrade the privileged helper (macOS prompts for admin).
+        // Critical for /usr/local/bin/docker* symlinks, DNS resolver, and the
+        // docker.sock convenience link. Failures used to be swallowed, leaving
+        // an ancient helper on disk and no CLI tools on PATH.
+        let helperOK = await runStep(.installHelper) {
+            try await self.daemonManager.installHelper()
+        }
+
+        guard helperOK else {
+            stepStatuses[.enableDaemon] = .skipped
+            stepStatuses[.connectAndWatch] = .skipped
+            return
         }
 
         // Pre-check: verify daemon binary signature and entitlements.

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/StartupOrchestrator/StartupTypes.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/StartupOrchestrator/StartupTypes.swift
@@ -34,6 +34,16 @@ public enum StartupStep: Int, CaseIterable, Sendable, Identifiable {
         case .connectAndWatch: return "Connecting to daemon"
         }
     }
+
+    /// Short explanation shown under the step label in the startup UI.
+    public var detail: String? {
+        switch self {
+        case .installHelper:
+            return "Required for /usr/local/bin/docker and DNS integration"
+        case .enableDaemon, .connectAndWatch:
+            return nil
+        }
+    }
 }
 
 // MARK: - Step Status

--- a/Packages/ArcBoxClient/Tests/ArcBoxClientTests/HelperInstallErrorTests.swift
+++ b/Packages/ArcBoxClient/Tests/ArcBoxClientTests/HelperInstallErrorTests.swift
@@ -13,15 +13,49 @@ struct HelperInstallErrorTests {
         let message =
             HelperInstallError.versionMismatch(
                 installed: "arcbox-helper 0.4.12",
-                expected: "arcbox-helper 0.4.24"
+                expected: "arcbox-helper 1.0.0"
             ).errorDescription ?? ""
         #expect(message.contains("0.4.12"))
-        #expect(message.contains("0.4.24"))
+        #expect(message.contains("1.0.0"))
         #expect(message.contains("sudo abctl _install"))
     }
 
     @Test func missingBinaryMessageNamesTheBinary() {
         let message = HelperInstallError.bundledBinaryMissing("arcbox-helper").errorDescription ?? ""
         #expect(message.contains("arcbox-helper"))
+    }
+}
+
+struct HelperVersionTests {
+    @Test func parsesIndependentHelperVersion() {
+        let v = HelperVersion.parse("arcbox-helper 1.0.0")
+        #expect(v?.major == 1)
+        #expect(v?.minor == 0)
+        #expect(v?.patch == 0)
+    }
+
+    @Test func parsesLegacyWorkspaceTiedVersion() {
+        let v = HelperVersion.parse("arcbox-helper 0.4.12")
+        #expect(v?.major == 0)
+        #expect(v?.minor == 4)
+        #expect(v?.patch == 12)
+    }
+
+    @Test func rejectsGarbageAndNil() {
+        #expect(HelperVersion.parse(nil) == nil)
+        #expect(HelperVersion.parse("") == nil)
+        #expect(HelperVersion.parse("not-a-helper") == nil)
+    }
+
+    @Test func reinstallOnlyWhenStrictlyOlder() {
+        let v100: HelperVersion.Triple = (1, 0, 0)
+        let v012: HelperVersion.Triple = (0, 4, 12)
+        let v101: HelperVersion.Triple = (1, 0, 1)
+
+        #expect(HelperVersion.needsReinstall(installed: nil, bundled: v100))
+        #expect(HelperVersion.needsReinstall(installed: v012, bundled: v100))
+        #expect(!HelperVersion.needsReinstall(installed: v100, bundled: v100))
+        #expect(!HelperVersion.needsReinstall(installed: v101, bundled: v100))
+        #expect(HelperVersion.needsReinstall(installed: v100, bundled: nil))
     }
 }

--- a/Packages/ArcBoxClient/Tests/ArcBoxClientTests/HelperInstallErrorTests.swift
+++ b/Packages/ArcBoxClient/Tests/ArcBoxClientTests/HelperInstallErrorTests.swift
@@ -53,6 +53,9 @@ struct HelperVersionTests {
         #expect(HelperVersion.parse("arcbox-helper 1.2.garbage") == nil)
         #expect(HelperVersion.parse("arcbox-helper 1.2") == nil)
         #expect(HelperVersion.parse("arcbox-helper 1.2.3.4") == nil)
+        #expect(HelperVersion.parse("arcbox-helper 1.0.0-01") == nil)
+        #expect(HelperVersion.parse("arcbox-helper 1.0.0-beta..1") == nil)
+        #expect(HelperVersion.parse("arcbox-helper 1.0.0+") == nil)
     }
 
     @Test func reinstallOnlyWhenStrictlyOlder() {
@@ -69,6 +72,41 @@ struct HelperVersionTests {
         // Major mismatch either way is a wire break — always reinstall.
         #expect(HelperVersion.needsReinstall(installed: v200, bundled: v100))
         #expect(HelperVersion.needsReinstall(installed: v100, bundled: v200))
+    }
+
+    @Test func stableBundleReplacesPrereleaseInstall() throws {
+        let prerelease = try #require(HelperVersion.parse("arcbox-helper 1.0.0-beta"))
+        let stable = try #require(HelperVersion.parse("arcbox-helper 1.0.0"))
+
+        #expect(HelperVersion.needsReinstall(installed: prerelease, bundled: stable))
+        #expect(!HelperVersion.needsReinstall(installed: stable, bundled: prerelease))
+    }
+
+    @Test func prereleaseIdentifiersFollowSemverPrecedence() throws {
+        let alpha = try #require(HelperVersion.parse("arcbox-helper 1.0.0-alpha"))
+        let alphaOne = try #require(HelperVersion.parse("arcbox-helper 1.0.0-alpha.1"))
+        let alphaBeta = try #require(HelperVersion.parse("arcbox-helper 1.0.0-alpha.beta"))
+        let beta = try #require(HelperVersion.parse("arcbox-helper 1.0.0-beta"))
+        let betaTwo = try #require(HelperVersion.parse("arcbox-helper 1.0.0-beta.2"))
+        let betaEleven = try #require(HelperVersion.parse("arcbox-helper 1.0.0-beta.11"))
+        let releaseCandidate = try #require(HelperVersion.parse("arcbox-helper 1.0.0-rc.1"))
+
+        #expect(alpha < alphaOne)
+        #expect(alphaOne < alphaBeta)
+        #expect(alphaBeta < beta)
+        #expect(beta < betaTwo)
+        #expect(betaTwo < betaEleven)
+        #expect(betaEleven < releaseCandidate)
+    }
+
+    @Test func buildMetadataDoesNotAffectPrecedence() throws {
+        let plain = try #require(HelperVersion.parse("arcbox-helper 1.0.0-beta.1"))
+        let withMetadata = try #require(
+            HelperVersion.parse("arcbox-helper 1.0.0-beta.1+build.007")
+        )
+
+        #expect(plain == withMetadata)
+        #expect(!HelperVersion.needsReinstall(installed: withMetadata, bundled: plain))
     }
 }
 

--- a/Packages/ArcBoxClient/Tests/ArcBoxClientTests/HelperInstallErrorTests.swift
+++ b/Packages/ArcBoxClient/Tests/ArcBoxClientTests/HelperInstallErrorTests.swift
@@ -1,0 +1,27 @@
+import Testing
+
+@testable import ArcBoxClient
+
+struct HelperInstallErrorTests {
+    @Test func userCanceledMessageMentionsRetryAndDocker() {
+        let message = HelperInstallError.userCanceled.errorDescription ?? ""
+        #expect(message.contains("Retry"))
+        #expect(message.contains("/usr/local/bin/docker"))
+    }
+
+    @Test func versionMismatchMessageIncludesBothVersions() {
+        let message =
+            HelperInstallError.versionMismatch(
+                installed: "arcbox-helper 0.4.12",
+                expected: "arcbox-helper 0.4.24"
+            ).errorDescription ?? ""
+        #expect(message.contains("0.4.12"))
+        #expect(message.contains("0.4.24"))
+        #expect(message.contains("sudo abctl _install"))
+    }
+
+    @Test func missingBinaryMessageNamesTheBinary() {
+        let message = HelperInstallError.bundledBinaryMissing("arcbox-helper").errorDescription ?? ""
+        #expect(message.contains("arcbox-helper"))
+    }
+}

--- a/Packages/ArcBoxClient/Tests/ArcBoxClientTests/HelperInstallErrorTests.swift
+++ b/Packages/ArcBoxClient/Tests/ArcBoxClientTests/HelperInstallErrorTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import ArcBoxClient
@@ -47,11 +48,18 @@ struct HelperVersionTests {
         #expect(HelperVersion.parse("not-a-helper") == nil)
     }
 
+    @Test func rejectsMalformedSemverComponents() {
+        #expect(HelperVersion.parse("arcbox-helper 1.garbage.9") == nil)
+        #expect(HelperVersion.parse("arcbox-helper 1.2.garbage") == nil)
+        #expect(HelperVersion.parse("arcbox-helper 1.2") == nil)
+        #expect(HelperVersion.parse("arcbox-helper 1.2.3.4") == nil)
+    }
+
     @Test func reinstallOnlyWhenStrictlyOlder() {
-        let v100: HelperVersion.Triple = (1, 0, 0)
-        let v012: HelperVersion.Triple = (0, 4, 12)
-        let v101: HelperVersion.Triple = (1, 0, 1)
-        let v200: HelperVersion.Triple = (2, 0, 0)
+        let v100 = HelperVersion(major: 1, minor: 0, patch: 0)
+        let v012 = HelperVersion(major: 0, minor: 4, patch: 12)
+        let v101 = HelperVersion(major: 1, minor: 0, patch: 1)
+        let v200 = HelperVersion(major: 2, minor: 0, patch: 0)
 
         #expect(HelperVersion.needsReinstall(installed: nil, bundled: v100))
         #expect(HelperVersion.needsReinstall(installed: v012, bundled: v100))
@@ -61,5 +69,19 @@ struct HelperVersionTests {
         // Major mismatch either way is a wire break — always reinstall.
         #expect(HelperVersion.needsReinstall(installed: v200, bundled: v100))
         #expect(HelperVersion.needsReinstall(installed: v100, bundled: v200))
+    }
+}
+
+struct AppleScriptStringLiteralTests {
+    @Test func untrustedPathCharactersRoundTripAsData() throws {
+        let value = "ArcBox\" & (do shell script \"printf injected\") & \\.app\nnext\rline\ttab"
+        let source = "return \(appleScriptStringLiteral(value))"
+        var error: NSDictionary?
+
+        let script = try #require(NSAppleScript(source: source))
+        let result = script.executeAndReturnError(&error)
+
+        #expect(error == nil)
+        #expect(result.stringValue == value)
     }
 }

--- a/Packages/ArcBoxClient/Tests/ArcBoxClientTests/HelperInstallErrorTests.swift
+++ b/Packages/ArcBoxClient/Tests/ArcBoxClientTests/HelperInstallErrorTests.swift
@@ -51,11 +51,15 @@ struct HelperVersionTests {
         let v100: HelperVersion.Triple = (1, 0, 0)
         let v012: HelperVersion.Triple = (0, 4, 12)
         let v101: HelperVersion.Triple = (1, 0, 1)
+        let v200: HelperVersion.Triple = (2, 0, 0)
 
         #expect(HelperVersion.needsReinstall(installed: nil, bundled: v100))
         #expect(HelperVersion.needsReinstall(installed: v012, bundled: v100))
         #expect(!HelperVersion.needsReinstall(installed: v100, bundled: v100))
         #expect(!HelperVersion.needsReinstall(installed: v101, bundled: v100))
         #expect(HelperVersion.needsReinstall(installed: v100, bundled: nil))
+        // Major mismatch either way is a wire break — always reinstall.
+        #expect(HelperVersion.needsReinstall(installed: v200, bundled: v100))
+        #expect(HelperVersion.needsReinstall(installed: v100, bundled: v200))
     }
 }

--- a/xtask/src/commands/macos.rs
+++ b/xtask/src/commands/macos.rs
@@ -3,6 +3,11 @@ use anyhow::Result;
 use crate::MacosArgs;
 
 #[cfg(target_os = "macos")]
+pub(super) const ABCTL_CODE_SIGN_IDENTIFIER: &str = "com.arcboxlabs.desktop.cli";
+#[cfg(target_os = "macos")]
+pub(super) const HELPER_CODE_SIGN_IDENTIFIER: &str = "com.arcboxlabs.desktop.helper";
+
+#[cfg(target_os = "macos")]
 pub mod bundle;
 #[cfg(target_os = "macos")]
 pub mod dmg;

--- a/xtask/src/commands/macos/dmg.rs
+++ b/xtask/src/commands/macos/dmg.rs
@@ -22,6 +22,9 @@ use super::{ABCTL_CODE_SIGN_IDENTIFIER, HELPER_CODE_SIGN_IDENTIFIER};
 use crate::support::fs as xfs;
 use crate::{MacosDmgArgs, MacosPrepareResourcesArgs};
 
+#[cfg(test)]
+mod tests;
+
 const SCHEME_NAME: &str = "ArcBox";
 const PRODUCTION_DAEMON_NAME: &str = "com.arcboxlabs.desktop.daemon";
 const DOCKER_TOOLS: [&str; 4] = [
@@ -665,9 +668,8 @@ fn embed_runtime(app_bundle: &Path, sign_identity: &str, profile: BundleProfile)
             }
             std::fs::copy(entry.path(), &dest)
                 .with_context(|| format!("copying runtime file {}", rel.display()))?;
-            // Drop DWARF / symbol tables from guest ELFs before codesign.
-            // Upstream dockerd/runc/firecracker releases often ship unstripped.
-            strip_binary_best_effort(&dest);
+            // Runtime binaries are pinned by the boot manifest. Preserve their
+            // exact bytes so the bundled seed still matches its declared hash.
             sign_binary(&dest, sign_identity)?;
             println!("  Embedded {}", rel.display());
             count += 1;
@@ -701,9 +703,8 @@ fn command_exists(name: &str) -> bool {
 /// Candidate strip tools for `path`, ordered by preference for its format.
 ///
 /// - Mach-O: Apple `/usr/bin/strip` first.
-/// - ELF (Linux guest): prefer ELF-capable cross/LLVM strippers. Apple's
-///   cctools `strip` handles some simple ELFs but fails on others (e.g.
-///   statically-linked Go `dockerd` with a broken `.rela.plt` link field).
+/// - ELF (Linux guest agents): prefer ELF-capable cross/LLVM strippers because
+///   Apple's cctools `strip` only handles some simple ELFs.
 fn strip_tool_candidates(path: &Path) -> Vec<&'static str> {
     let candidates: &[&str] = if xfs::is_macho(path) {
         &["/usr/bin/strip", "strip"]
@@ -733,6 +734,8 @@ fn strip_tool_candidates(path: &Path) -> Vec<&'static str> {
 /// - Tries each candidate tool on a temp copy; keeps the first result that is
 ///   strictly smaller than the original (so tools that grow under strip, or
 ///   that fail on a particular binary, are skipped).
+/// - Uses an RAII-managed unique temp file beside the destination so every
+///   preparation, execution, and installation failure cleans itself up.
 /// - Failures are logged and ignored — a larger binary beats a broken pack.
 fn strip_binary_best_effort(path: &Path) {
     let tools = strip_tool_candidates(path);
@@ -743,21 +746,24 @@ fn strip_binary_best_effort(path: &Path) {
         Ok(m) => m.len(),
         Err(_) => return,
     };
-    let tmp = path.with_extension("strip-tmp");
     let mut last_err: Option<String> = None;
 
     for tool in tools {
-        if let Err(e) = std::fs::copy(path, &tmp) {
-            println!("  Warning: strip prepare {}: {e}", path.display());
-            return;
-        }
-        match Command::new(tool).arg(&tmp).status() {
+        let tmp = match prepare_strip_copy(path) {
+            Ok(tmp) => tmp,
+            Err(e) => {
+                println!("  Warning: strip prepare {}: {e}", path.display());
+                return;
+            }
+        };
+        match Command::new(tool).arg(tmp.path()).status() {
             Ok(s) if s.success() => {
-                let after = std::fs::metadata(&tmp).map(|m| m.len()).unwrap_or(before);
+                let after = std::fs::metadata(tmp.path())
+                    .map(|m| m.len())
+                    .unwrap_or(before);
                 if after < before {
-                    if let Err(e) = std::fs::rename(&tmp, path) {
-                        println!("  Warning: strip install {}: {e}", path.display());
-                        let _ = std::fs::remove_file(&tmp);
+                    if let Err(e) = tmp.persist(path) {
+                        println!("  Warning: strip install {}: {}", path.display(), e.error);
                         return;
                     }
                     println!(
@@ -769,14 +775,11 @@ fn strip_binary_best_effort(path: &Path) {
                     return;
                 }
                 // Tool ran but did not shrink — try the next candidate.
-                let _ = std::fs::remove_file(&tmp);
             }
             Ok(s) => {
-                let _ = std::fs::remove_file(&tmp);
                 last_err = Some(format!("{tool} exited {}", s.code().unwrap_or(-1)));
             }
             Err(e) => {
-                let _ = std::fs::remove_file(&tmp);
                 last_err = Some(format!("{tool}: {e}"));
             }
         }
@@ -785,6 +788,15 @@ fn strip_binary_best_effort(path: &Path) {
     if let Some(err) = last_err {
         println!("  Warning: could not strip {}: {err}", path.display());
     }
+}
+
+fn prepare_strip_copy(path: &Path) -> std::io::Result<tempfile::NamedTempFile> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let tmp = tempfile::Builder::new()
+        .prefix(".strip-")
+        .tempfile_in(parent)?;
+    std::fs::copy(path, tmp.path())?;
+    Ok(tmp)
 }
 
 /// Strip the main app executable if Xcode left local symbols in place.

--- a/xtask/src/commands/macos/dmg.rs
+++ b/xtask/src/commands/macos/dmg.rs
@@ -18,6 +18,7 @@ use xtask_kit::dmg::{self, CreateDmgOptions};
 use xtask_kit::{github_actions, process, repo};
 
 use super::bundle::{self, BundleOptions, BundleProfile};
+use super::{ABCTL_CODE_SIGN_IDENTIFIER, HELPER_CODE_SIGN_IDENTIFIER};
 use crate::support::fs as xfs;
 use crate::{MacosDmgArgs, MacosPrepareResourcesArgs};
 
@@ -53,6 +54,16 @@ fn sign_binary(target: &Path, identity: &str) -> Result<()> {
         return Ok(());
     }
     apple::codesign(&CodesignOptions::runtime(identity, target))
+}
+
+/// Sign a binary with the stable identifier expected by helper peer auth.
+fn sign_binary_with_identifier(target: &Path, identity: &str, identifier: &str) -> Result<()> {
+    if identity.is_empty() {
+        return Ok(());
+    }
+    let mut options = CodesignOptions::runtime(identity, target);
+    options.identifier = Some(identifier);
+    apple::codesign(&options)
 }
 
 fn desktop_repo() -> Result<PathBuf> {
@@ -533,22 +544,22 @@ fn embed_host_cli_binaries(
     println!("--- Embedding host CLI binaries ---");
     let abctl_dst = bin_dir.join("abctl");
     std::fs::copy(&abctl_src, &abctl_dst).context("copying abctl")?;
-    sign_binary(&abctl_dst, sign_identity)?;
+    sign_binary_with_identifier(&abctl_dst, sign_identity, ABCTL_CODE_SIGN_IDENTIFIER)?;
     println!("  Copied abctl → MacOS/bin/abctl");
 
-    // arcbox-helper is optional in older release tarballs.
+    // Desktop startup requires the bundled helper for installation and version
+    // verification, so release packaging must fail rather than ship without it.
     let helper_src = src_dir.join("arcbox-helper");
-    if helper_src.is_file() {
-        let helper_dst = bin_dir.join("arcbox-helper");
-        std::fs::copy(&helper_src, &helper_dst).context("copying arcbox-helper")?;
-        sign_binary(&helper_dst, sign_identity)?;
-        println!("  Copied arcbox-helper → MacOS/bin/arcbox-helper");
-    } else {
-        println!(
-            "  Warning: arcbox-helper not found at {}, skipping",
+    if !helper_src.is_file() {
+        bail!(
+            "required arcbox-helper not found at {}; Desktop startup cannot continue without it",
             helper_src.display()
         );
     }
+    let helper_dst = bin_dir.join("arcbox-helper");
+    std::fs::copy(&helper_src, &helper_dst).context("copying arcbox-helper")?;
+    sign_binary_with_identifier(&helper_dst, sign_identity, HELPER_CODE_SIGN_IDENTIFIER)?;
+    println!("  Copied arcbox-helper → MacOS/bin/arcbox-helper");
     Ok(())
 }
 
@@ -976,6 +987,21 @@ fn sign_app_bundle(
         println!("  Restored pre-signed daemon bundle");
     }
 
+    // `codesign --deep` derives standalone executable identifiers from their
+    // basenames. Restore the stable identifiers that helper peer auth checks.
+    let host_bin_dir = app_bundle.join("Contents").join("MacOS").join("bin");
+    for (name, identifier) in [
+        ("abctl", ABCTL_CODE_SIGN_IDENTIFIER),
+        ("arcbox-helper", HELPER_CODE_SIGN_IDENTIFIER),
+    ] {
+        let binary = host_bin_dir.join(name);
+        if !binary.is_file() {
+            bail!("required bundled binary missing at {}", binary.display());
+        }
+        sign_binary_with_identifier(&binary, sign_identity, identifier)?;
+        println!("  Re-signed {name} as {identifier}");
+    }
+
     // Re-sign ArcBoxHelper.
     let helper = app_bundle
         .join("Contents")
@@ -987,7 +1013,7 @@ fn sign_app_bundle(
             .join("ArcBoxHelper")
             .join("ArcBoxHelper.entitlements");
         let mut options = CodesignOptions::runtime(sign_identity, &helper);
-        options.identifier = Some("com.arcboxlabs.desktop.helper");
+        options.identifier = Some(HELPER_CODE_SIGN_IDENTIFIER);
         options.entitlements = Some(&entitlements);
         apple::codesign(&options)?;
         println!("  Signed ArcBoxHelper with hardened runtime");

--- a/xtask/src/commands/macos/dmg/tests.rs
+++ b/xtask/src/commands/macos/dmg/tests.rs
@@ -1,0 +1,16 @@
+use super::prepare_strip_copy;
+
+#[test]
+fn failed_strip_preparation_leaves_no_temporary_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = dir.path().join("binary");
+    std::fs::create_dir(&source).unwrap();
+
+    assert!(prepare_strip_copy(&source).is_err());
+
+    let entries = std::fs::read_dir(dir.path())
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect::<Vec<_>>();
+    assert_eq!(entries, ["binary"]);
+}

--- a/xtask/src/commands/macos/embed.rs
+++ b/xtask/src/commands/macos/embed.rs
@@ -14,6 +14,7 @@ use regex::Regex;
 use xtask_kit::apple::{self, CodesignOptions};
 
 use super::bundle::{self, BundleOptions, BundleProfile};
+use super::{ABCTL_CODE_SIGN_IDENTIFIER, HELPER_CODE_SIGN_IDENTIFIER};
 use crate::MacosEmbedArgs;
 use crate::support::fs as xfs;
 
@@ -316,27 +317,24 @@ pub fn run(_args: MacosEmbedArgs) -> Result<()> {
     embed_signed_cli(
         &src_dir.join("abctl"),
         &cli_dir.join("abctl"),
-        "com.arcboxlabs.desktop.abctl",
+        ABCTL_CODE_SIGN_IDENTIFIER,
         "abctl",
-        true,
     )?;
 
     // ── Embed arcbox-helper → Contents/MacOS/bin/ ─────────────────────────────
     let helper_src = src_dir.join("arcbox-helper");
-    if helper_src.is_file() {
-        embed_signed_cli(
-            &helper_src,
-            &cli_dir.join("arcbox-helper"),
-            "com.arcboxlabs.desktop.helper",
-            "arcbox-helper",
-            false,
-        )?;
-    } else {
-        warn(&format!(
-            "arcbox-helper not found at {}, skipping",
+    if !helper_src.is_file() {
+        bail!(
+            "required arcbox-helper not found at {}; Desktop startup cannot continue without it",
             helper_src.display()
-        ));
+        );
     }
+    embed_signed_cli(
+        &helper_src,
+        &cli_dir.join("arcbox-helper"),
+        HELPER_CODE_SIGN_IDENTIFIER,
+        "arcbox-helper",
+    )?;
 
     // ── Embed guest binaries → Contents/Resources/bin/ ────────────────────────
     // arcbox-agent (System VM agent) and vm-agent (sandbox microVM init); the
@@ -365,13 +363,7 @@ pub fn run(_args: MacosEmbedArgs) -> Result<()> {
     Ok(())
 }
 
-fn embed_signed_cli(
-    src: &Path,
-    dst: &Path,
-    identifier: &str,
-    label: &str,
-    required: bool,
-) -> Result<()> {
+fn embed_signed_cli(src: &Path, dst: &Path, identifier: &str, label: &str) -> Result<()> {
     if sync_binary(src, dst)? {
         sign_with_xcode_identity(dst, identifier)?;
         note(&format!("Embedded and signed {label} → MacOS/bin/{label}"));
@@ -383,7 +375,6 @@ fn embed_signed_cli(
         }
         note(&format!("{label} unchanged, skipping copy"));
     }
-    let _ = required;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Hardens privileged helper upgrades and the release artifact contract behind `/usr/local/bin/docker*` availability.

### Install reliability
- surface typed helper install failures instead of continuing silently
- compare strict independent helper semver and reinstall on malformed or incompatible major versions
- verify the installed version after authorization
- quote shell and AppleScript strings independently, including special paths and injection payloads
- refresh `abctl setup install` after helper setup

### Release reliability
- preserve stable `abctl`, helper, and daemon code-sign identifiers through final packaging
- require the bundled helper and verify its stdout version contract
- verify architecture, identifiers, Team ID, and helper version inside the mounted final DMG
- preserve manifest-pinned runtime bytes and verify their SHA-256 values inside the final DMG
- use RAII-managed unique files for the remaining best-effort strip staging

## ArcBox dependency

- arcbox#458 introduced independent helper version `1.0.0` and is merged
- arcbox#463 contains the reviewed compatibility/release follow-ups

Ship order: merge arcbox#463 → release ArcBox v0.5.0 → bump `arcbox.version` to v0.5.0 → release Desktop v1.29.0.

## Automated validation

- [x] ArcBoxClient Swift package tests
- [x] strict SwiftLint and swift-format
- [x] xtask tests and Clippy with `-D warnings`
- [x] release workflow `actionlint` and YAML parse
- [x] final-DMG contract changes reviewed with no blocking finding

## Upgrade test plan

- [ ] Cancel admin prompt → failed helper step + Retry, not silent continue
- [ ] Fresh install → one password → `/usr/local/bin/docker` exists
- [ ] Stale 0.4.24 helper + new app → one password upgrade to 1.0.0
- [ ] Second launch with helper 1.0.0 → no password
- [ ] `/usr/local/libexec/arcbox-helper --version` reports `arcbox-helper 1.0.0` on stdout