### PR TITLE
feat(updater): default new installs to auto-download and install updates

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		7910184754585B4CF647FA92 /* ContainerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C6B2F85E39321931CEC3ED /* ContainerDetailView.swift */; };
 		79C5F3DA19E7431F8B28B6F0 /* MenuBarView+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC010DD9F0AEC7E4EA778C59 /* MenuBarView+Actions.swift */; };
 		7DABE0FBDD17F88D47333964 /* CommandHint.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65698313C3204F5F23E099B /* CommandHint.swift */; };
+		7DFC19087BE929DDF207A677 /* UpdaterSettingsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93968609F8E058EAC838DD18 /* UpdaterSettingsModel.swift */; };
 		7F091F3F3F75F500937DC7BC /* ImageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8BD8A4B6EEE9722D54739D /* ImageModel.swift */; };
 		801AAF363A7901B7D17F5C55 /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA5247E3096D7A9D54A270A /* AccountSettingsView.swift */; };
 		807479D85C38FEE5E53218DD /* LocalRootFSService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85321B230A582D1C0AF76B5C /* LocalRootFSService.swift */; };
@@ -353,6 +354,7 @@
 		9101DCB26B0BB5B8DE4CAE70 /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		920C9CA81449FA23CEC17EF6 /* SandboxFilesTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxFilesTab.swift; sourceTree = "<group>"; };
 		9234FC5BCCDDCBF441A94880 /* UpdaterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterDelegate.swift; sourceTree = "<group>"; };
+		93968609F8E058EAC838DD18 /* UpdaterSettingsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterSettingsModel.swift; sourceTree = "<group>"; };
 		949DB8BB8139F8D3C37503E9 /* MachineRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachineRowView.swift; sourceTree = "<group>"; };
 		95F593FF4C1C56EBF378883E /* MachineLogsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachineLogsTab.swift; sourceTree = "<group>"; };
 		9730C66B6A04B33F7DA3448B /* NetworkEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkEmptyState.swift; sourceTree = "<group>"; };
@@ -827,6 +829,7 @@
 				C0BC46E06601AA9D330AF049 /* SystemVmBackendModel.swift */,
 				591B3B9F3D3A0B5C43EC7B55 /* TemplatesViewModel.swift */,
 				9234FC5BCCDDCBF441A94880 /* UpdaterDelegate.swift */,
+				93968609F8E058EAC838DD18 /* UpdaterSettingsModel.swift */,
 				3DCBC0E44C2DBB3064D4A759 /* Containers */,
 				7D89C26DD9B6BEB015B28923 /* Images */,
 				46C6E77D6FA08BC8D86F3C3B /* Sandboxes */,
@@ -1366,6 +1369,7 @@
 				ED5B6539D3909308DA1C4AE4 /* TerminalSessionBridge.swift in Sources */,
 				4113241C123BBBBDEC76E5B0 /* ToastView.swift in Sources */,
 				525ECDE24CB1E8ADC7AADB49 /* UpdaterDelegate.swift in Sources */,
+				7DFC19087BE929DDF207A677 /* UpdaterSettingsModel.swift in Sources */,
 				96C7FFF79579D1B999ABAF3F /* Utilities.swift in Sources */,
 				6F8362D2C8129F7BBF6E9635 /* VolumeDetailView.swift in Sources */,
 				33821C4E5444A595520CCCB0 /* VolumeEmptyState.swift in Sources */,

--- a/ArcBox/ArcBoxApp.swift
+++ b/ArcBox/ArcBoxApp.swift
@@ -25,7 +25,6 @@ struct ArcBoxDesktopApp: App {
     @State private var sleepWakeManager = SleepWakeManager()
     @State private var startupOrchestrator: StartupOrchestrator?
     @AppStorage("showInMenuBar") private var showInMenuBar = false
-    @AppStorage("autoUpdate") private var autoUpdate = false
     @AppStorage("updateChannel") private var updateChannel = "stable"
 
     // Shared ViewModels used by both main window and menu bar
@@ -42,6 +41,7 @@ struct ArcBoxDesktopApp: App {
 
     private let updaterDelegate = UpdaterDelegate()
     private let updaterController: SPUStandardUpdaterController
+    private let updaterSettings: UpdaterSettingsModel
 
     init() {
         Self.initSentry()
@@ -51,6 +51,7 @@ struct ArcBoxDesktopApp: App {
             updaterDelegate: updaterDelegate,
             userDriverDelegate: nil
         )
+        updaterSettings = UpdaterSettingsModel(updater: updaterController.updater)
     }
 
     var body: some Scene {
@@ -151,13 +152,6 @@ struct ArcBoxDesktopApp: App {
                         DockerContextManager.restorePreviousContext()
                     }
                 }
-                .onAppear {
-                    // Sync auto-update preference to Sparkle
-                    updaterController.updater.automaticallyChecksForUpdates = autoUpdate
-                }
-                .onChange(of: autoUpdate) { _, newValue in
-                    updaterController.updater.automaticallyChecksForUpdates = newValue
-                }
                 .onChange(of: updateChannel) { _, _ in
                     // Force Sparkle to re-fetch the feed URL (which reads updateChannel via UpdaterDelegate)
                     updaterController.updater.resetUpdateCycle()
@@ -191,6 +185,7 @@ struct ArcBoxDesktopApp: App {
                 .environment(imagesVM)
                 .environment(authSession)
                 .environment(systemVmBackendVM)
+                .environment(updaterSettings)
                 .environment(\.arcboxClient, arcboxClient)
                 .environment(\.dockerClient, dockerClient)
                 .environment(\.accessTokenProvider, authSession)

--- a/ArcBox/Info.plist
+++ b/ArcBox/Info.plist
@@ -37,5 +37,12 @@
 	<string>$(POSTHOG_API_KEY)</string>
 	<key>SentryDSN</key>
 	<string>$(SENTRY_DSN)</string>
+	<!-- Sparkle initial defaults: automatically check for and download+install
+	     updates out of the box. User changes persist to UserDefaults and take
+	     precedence over these Info.plist seeds. -->
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUAutomaticallyUpdate</key>
+	<true/>
 </dict>
 </plist>

--- a/ArcBox/ViewModels/UpdaterSettingsModel.swift
+++ b/ArcBox/ViewModels/UpdaterSettingsModel.swift
@@ -1,0 +1,65 @@
+import Combine
+import Sparkle
+
+/// Bridges Sparkle's auto-update settings to SwiftUI.
+///
+/// `SPUUpdater` is the single source of truth: it persists these settings in the
+/// app's user defaults, seeded by the `SUEnableAutomaticChecks` and
+/// `SUAutomaticallyUpdate` Info.plist defaults. This model mirrors the relevant
+/// properties observably so the settings toggles reflect changes made anywhere —
+/// including Sparkle's own update dialog — without a duplicate `@AppStorage` that
+/// could drift out of sync with Sparkle's persisted state.
+@MainActor
+@Observable
+final class UpdaterSettingsModel {
+    private(set) var automaticallyChecksForUpdates: Bool
+    private(set) var automaticallyDownloadsUpdates: Bool
+    /// Whether automatic downloading can be enabled. Sparkle gates this behind
+    /// automatic checks, so it drives the download toggle's enabled state.
+    private(set) var allowsAutomaticUpdates: Bool
+
+    @ObservationIgnored
+    private let updater: SPUUpdater
+    @ObservationIgnored
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(updater: SPUUpdater) {
+        self.updater = updater
+        automaticallyChecksForUpdates = updater.automaticallyChecksForUpdates
+        automaticallyDownloadsUpdates = updater.automaticallyDownloadsUpdates
+        allowsAutomaticUpdates = updater.allowsAutomaticUpdates
+
+        // Reflect changes made outside the settings UI (e.g. Sparkle's own update
+        // dialog). Setting `automaticallyChecksForUpdates` also re-derives the
+        // gated download/allows properties, so observing all three keeps the
+        // mirrors consistent.
+        let observedKeyPaths: [KeyPath<SPUUpdater, Bool>] = [
+            \.automaticallyChecksForUpdates,
+            \.automaticallyDownloadsUpdates,
+            \.allowsAutomaticUpdates,
+        ]
+        for keyPath in observedKeyPaths {
+            updater.publisher(for: keyPath)
+                .sink { [weak self] _ in
+                    Task { @MainActor in self?.refresh() }
+                }
+                .store(in: &cancellables)
+        }
+    }
+
+    func setAutomaticallyChecksForUpdates(_ enabled: Bool) {
+        updater.automaticallyChecksForUpdates = enabled
+        refresh()
+    }
+
+    func setAutomaticallyDownloadsUpdates(_ enabled: Bool) {
+        updater.automaticallyDownloadsUpdates = enabled
+        refresh()
+    }
+
+    private func refresh() {
+        automaticallyChecksForUpdates = updater.automaticallyChecksForUpdates
+        automaticallyDownloadsUpdates = updater.automaticallyDownloadsUpdates
+        allowsAutomaticUpdates = updater.allowsAutomaticUpdates
+    }
+}

--- a/ArcBox/ViewModels/UpdaterSettingsModel.swift
+++ b/ArcBox/ViewModels/UpdaterSettingsModel.swift
@@ -1,4 +1,5 @@
-import Combine
+import Foundation
+import Observation
 import Sparkle
 
 /// Bridges Sparkle's auto-update settings to SwiftUI.
@@ -21,7 +22,7 @@ final class UpdaterSettingsModel {
     @ObservationIgnored
     private let updater: SPUUpdater
     @ObservationIgnored
-    private var cancellables: Set<AnyCancellable> = []
+    private var observations: [NSKeyValueObservation] = []
 
     init(updater: SPUUpdater) {
         self.updater = updater
@@ -33,17 +34,15 @@ final class UpdaterSettingsModel {
         // dialog). Setting `automaticallyChecksForUpdates` also re-derives the
         // gated download/allows properties, so observing all three keeps the
         // mirrors consistent.
-        let observedKeyPaths: [KeyPath<SPUUpdater, Bool>] = [
+        let keyPaths: [KeyPath<SPUUpdater, Bool>] = [
             \.automaticallyChecksForUpdates,
             \.automaticallyDownloadsUpdates,
             \.allowsAutomaticUpdates,
         ]
-        for keyPath in observedKeyPaths {
-            updater.publisher(for: keyPath)
-                .sink { [weak self] _ in
-                    Task { @MainActor in self?.refresh() }
-                }
-                .store(in: &cancellables)
+        observations = keyPaths.map { keyPath in
+            updater.observe(keyPath, options: [.new]) { [weak self] _, _ in
+                Task { @MainActor in self?.refresh() }
+            }
         }
     }
 

--- a/ArcBox/Views/Settings/GeneralSettingsView.swift
+++ b/ArcBox/Views/Settings/GeneralSettingsView.swift
@@ -1,6 +1,7 @@
 import ArcBoxClient
 import PostHog
 import ServiceManagement
+import Sparkle
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -10,11 +11,11 @@ struct GeneralSettingsView: View {
     @Environment(DaemonManager.self) private var daemonManager
     @Environment(ContainersViewModel.self) private var containersVM
     @Environment(ImagesViewModel.self) private var imagesVM
+    @Environment(UpdaterSettingsModel.self) private var updaterSettings
 
     @AppStorage("startAtLogin") private var startAtLogin = false
     @AppStorage("showInMenuBar") private var showInMenuBar = false
     @AppStorage("keepRunning") private var keepRunning = false
-    @AppStorage("autoUpdate") private var autoUpdate = false
     @AppStorage("updateChannel") private var updateChannel = "stable"
     @AppStorage("terminalTheme") private var terminalTheme = "system"
     @AppStorage("externalTerminal") private var externalTerminal = ExternalTerminalApp.terminalBundleIdentifier
@@ -40,7 +41,22 @@ struct GeneralSettingsView: View {
             }
 
             Section("Updates") {
-                Toggle("Automatically check for updates", isOn: $autoUpdate)
+                Toggle(
+                    "Automatically check for updates",
+                    isOn: Binding(
+                        get: { updaterSettings.automaticallyChecksForUpdates },
+                        set: { updaterSettings.setAutomaticallyChecksForUpdates($0) }
+                    )
+                )
+                Toggle(
+                    "Automatically download and install updates",
+                    isOn: Binding(
+                        get: { updaterSettings.automaticallyDownloadsUpdates },
+                        set: { updaterSettings.setAutomaticallyDownloadsUpdates($0) }
+                    )
+                )
+                .disabled(!updaterSettings.allowsAutomaticUpdates)
+                .padding(.leading, 20)
                 Picker("Update channel", selection: $updateChannel) {
                     Text("Stable").tag("stable")
                     Text("Beta").tag("beta")
@@ -236,9 +252,13 @@ struct GeneralSettingsView: View {
 }
 
 #Preview {
-    GeneralSettingsView()
+    let updater = SPUStandardUpdaterController(
+        startingUpdater: false, updaterDelegate: nil, userDriverDelegate: nil
+    ).updater
+    return GeneralSettingsView()
         .environment(DaemonManager())
         .environment(ContainersViewModel())
         .environment(ImagesViewModel())
+        .environment(UpdaterSettingsModel(updater: updater))
         .frame(width: 500, height: 400)
 }


### PR DESCRIPTION
## What

New installs now automatically **check for and download+install updates** out of the box, seeded by `SUEnableAutomaticChecks` / `SUAutomaticallyUpdate` in `Info.plist`.

Also refactors the update settings to make Sparkle the single source of truth.

## Why

Previously the app kept an `@AppStorage("autoUpdate")` mirror and force-synced it to Sparkle on every launch. That defaulted auto-update **off** and could drift out of sync with Sparkle's own persisted state (e.g. the checkbox in Sparkle's update dialog), because we maintained a duplicate user default — something Sparkle's docs explicitly warn against.

## How

- **`Info.plist`** — add `SUEnableAutomaticChecks=YES` / `SUAutomaticallyUpdate=YES` as the initial defaults. Sparkle's user defaults take precedence, so this only affects fresh installs; it also suppresses Sparkle's first-run "check automatically?" prompt.
- **`UpdaterSettingsModel`** (new) — an `@Observable` that treats `SPUUpdater` as the single source of truth and mirrors the relevant properties via KVO (same pattern as `CheckForUpdatesViewModel`). No duplicate `@AppStorage`.
- **`GeneralSettingsView`** — the two toggles bind directly to the model; the new "Automatically download and install updates" toggle is gated behind Sparkle's `allowsAutomaticUpdates` (which is off when automatic checks are off).
- **`ArcBoxApp`** — drop the `@AppStorage` mirrors and the launch/onChange sync; construct the model and inject it into the Settings window.

## Behavior

| User | Result |
|---|---|
| Fresh install | auto-check + auto-download/install **ON** |
| Existing user | keeps their persisted preference (Sparkle user defaults win over the Info.plist seed) |

Existing users are intentionally **not** migrated — see the discussion that led to this scope. Both can toggle either setting in **Settings → Updates**; changes persist through Sparkle.

## Verification

- `xcodebuild` (rust-embed skipped, signing off): **BUILD SUCCEEDED**; all three edited files compiled.
- `swift-format` + `swiftlint --strict`: clean.
- `xcodegen` regenerated `project.pbxproj` (only adds the new file).
- No unit tests: the change is SwiftUI bindings + Sparkle wiring with no independently testable logic.