### PR TITLE
fix(ui): stop NavigationSplitView content column collapsing to vertical text

### DIFF
--- a/ArcBox/Views/ContentView.swift
+++ b/ArcBox/Views/ContentView.swift
@@ -27,21 +27,19 @@ struct ContentView: View {
         NavigationSplitView {
             sidebar
         } content: {
-            if isTemplatesSection {
-                Color.clear
-                    .navigationSplitViewColumnWidth(0)
-                    .navigationTitle("Templates")
-            } else if appVM.currentNav == .activity {
-                // Activity is a single full-width dashboard rendered in the
-                // detail column; collapse the content column.
-                Color.clear
-                    .navigationSplitViewColumnWidth(0)
-                    .navigationTitle("Activity")
-            } else {
-                contentColumn
-                    .background(AppColors.background)
-                    .navigationSplitViewColumnWidth(min: 150, ideal: 320, max: 600)
-            }
+            // Always render `contentColumn` and vary only the numeric width
+            // through the SAME flexible overload. Mixing the fixed
+            // `navigationSplitViewColumnWidth(0)` overload with the flexible
+            // `(min:ideal:max:)` one across sibling branches makes the column
+            // width latch near 0 on navigation, collapsing the list content to
+            // one-character-per-line text (Activity/Templates collapse to 0).
+            contentColumn
+                .background(AppColors.background)
+                .navigationSplitViewColumnWidth(
+                    min: isContentColumnCollapsed ? 0 : 150,
+                    ideal: isContentColumnCollapsed ? 0 : 320,
+                    max: isContentColumnCollapsed ? 0 : 600
+                )
         } detail: {
             detailPanel
                 .background(AppColors.sidebar)
@@ -101,8 +99,10 @@ struct ContentView: View {
         .navigationSplitViewColumnWidth(180)
     }
 
-    private var isTemplatesSection: Bool {
-        appVM.currentNav == .templates
+    /// Sections rendered full-width in the detail column collapse the content
+    /// column to zero width instead of showing a list.
+    private var isContentColumnCollapsed: Bool {
+        appVM.currentNav == .activity || appVM.currentNav == .templates
     }
 
     // MARK: - Content column
@@ -111,8 +111,9 @@ struct ContentView: View {
     private var contentColumn: some View {
         switch appVM.currentNav {
         case .activity:
-            // Rendered full-width in the detail column.
+            // Rendered full-width in the detail column; content column collapses.
             Color.clear
+                .navigationTitle("Activity")
         case .containers:
             ContainersListView()
                 .environment(containersVM)
@@ -140,8 +141,9 @@ struct ContentView: View {
             SandboxesListView()
                 .environment(sandboxesVM)
         case .templates:
-            // Handled in detail column
+            // Rendered full-width in the detail column; content column collapses.
             Color.clear
+                .navigationTitle("Templates")
         case nil:
             ContainersListView()
                 .environment(containersVM)


### PR DESCRIPTION
## Symptom

After switching between navigation sections a few times, the content column collapses to near-zero width and its text renders **one character per line** (vertical): the Sandboxes `List` / `Monitoring` switcher and the empty-state command hints (`abctl sandbox create …`) all stack vertically, and other list sections show the same squash. It's intermittent and clears on the next resize/nav switch.

## Root cause

`ContentView`'s `content:` closure mixed the **two different overloads** of `navigationSplitViewColumnWidth` across sibling `if/else` branches on the *same* column:

- `.navigationSplitViewColumnWidth(0)` (fixed) for Activity and Templates, which collapse the content column;
- `.navigationSplitViewColumnWidth(min: 150, ideal: 320, max: 600)` (flexible) for the list sections.

Switching the *overload type* on one column makes `NavigationSplitView` latch the resolved width near 0 on navigation — the `min: 150` floor stops being honored, so a ~0-width proposal reaches the content view. `Text` without `.lineLimit(1)`/`.fixedSize()` resolves a 0-width proposal by wrapping per character, producing the vertical text. This was introduced when the Activity dashboard added the fixed-`0` collapse (`75322cf`).

## Fix

Always render `contentColumn` and vary **only the numeric width** through the single flexible overload (`0/0/0` when collapsed, `150/320/600` otherwise). Staying within one overload lets the column re-resolve width normally, so the latch is gone. Activity/Templates still collapse to 0 and their nav titles are preserved (moved onto the collapsed `Color.clear` inside `contentColumn`). No behavior change beyond removing the collapse bug.

## Testing

- `swift-format lint -r --strict` — clean.
- `xcodebuild build -scheme ArcBox` (Debug) — **BUILD SUCCEEDED**.
- Manual: switch Activity/Templates ↔ Sandboxes/Containers repeatedly; content column keeps its width, no vertical text.