### PR TITLE
feat(files): merge layers into one filesystem view

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		7F091F3F3F75F500937DC7BC /* ImageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8BD8A4B6EEE9722D54739D /* ImageModel.swift */; };
 		801AAF363A7901B7D17F5C55 /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA5247E3096D7A9D54A270A /* AccountSettingsView.swift */; };
 		807479D85C38FEE5E53218DD /* LocalRootFSService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85321B230A582D1C0AF76B5C /* LocalRootFSService.swift */; };
+		8127661373B4B0D6B1423F67 /* LayeredRootFSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3029D85CCC770F8C1801A392 /* LayeredRootFSTests.swift */; };
 		82ECF33C9637C7C65B527336 /* ArcBoxClient in Frameworks */ = {isa = PBXBuildFile; productRef = CFE468A82BAC1B4D9AE25368 /* ArcBoxClient */; };
 		8466B000B68A87CEECA6756F /* DockerEventMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06DFFB59D72F27F14A233B81 /* DockerEventMonitorTests.swift */; };
 		84DDB437165AE31AD63C30F9 /* MenuBarView+Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF57E2C2B0281B8CEA6132C /* MenuBarView+Metrics.swift */; };
@@ -203,6 +204,7 @@
 		F035F2D21380F9DD531E6B04 /* LocalRootFSOutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9EDD0CCB1C4698A31FC1ED1 /* LocalRootFSOutlineView.swift */; };
 		F07FF6E8891692D4D8807F3A /* LocalRootFSOutlineModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6C627A5BC34C783DAEAC31 /* LocalRootFSOutlineModels.swift */; };
 		F0B6CC9DB9992CE44F2A7F70 /* AppViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F707491EC9A47AE534822664 /* AppViewModel.swift */; };
+		F0B924B312EABA596C870505 /* LayeredRootFS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33250D1306B30B4E3D4C9B0E /* LayeredRootFS.swift */; };
 		F319F8722F145CCFA01650B6 /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F60CF8B8E81089BA2E8DC20 /* GeneralSettingsView.swift */; };
 		F40C3E6023452858EEEA893F /* K8sModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6FDB677AE01E62877A17AC /* K8sModelsTests.swift */; };
 		F5350A9E11B4C65AAE8BD569 /* ServiceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13203BD67479A8191C1A3BD6 /* ServiceModel.swift */; };
@@ -273,9 +275,11 @@
 		2D053B8542825698996A16FE /* ArcBoxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ArcBoxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E3E6C9D6EBE0D9358FB396A /* TemplateEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateEmptyState.swift; sourceTree = "<group>"; };
 		2E8FB9C9E3349126EF773522 /* DaemonLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaemonLoadingView.swift; sourceTree = "<group>"; };
+		3029D85CCC770F8C1801A392 /* LayeredRootFSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayeredRootFSTests.swift; sourceTree = "<group>"; };
 		312B3A0CBD47EB616127BBE5 /* TerminalSessionBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSessionBridge.swift; sourceTree = "<group>"; };
 		32115BE04C97CECA9C05A273 /* StartupProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupProgressView.swift; sourceTree = "<group>"; };
 		32C86546753C11A9E6CA8CB8 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
+		33250D1306B30B4E3D4C9B0E /* LayeredRootFS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayeredRootFS.swift; sourceTree = "<group>"; };
 		3DAC9EE4F067CB69F022C1E0 /* ActivityViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityViewModel.swift; sourceTree = "<group>"; };
 		3E30F5FC430804013B58C6F1 /* com.arcboxlabs.desktop.daemon.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = com.arcboxlabs.desktop.daemon.plist; sourceTree = "<group>"; };
 		3ED1683EF0A3490B8B7B5CF6 /* InfoTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoTableView.swift; sourceTree = "<group>"; };
@@ -786,6 +790,7 @@
 			children = (
 				83FBE0C82E0EB430C69EB944 /* GuestDataMount.swift */,
 				6218E84D6C2A8595FE308B5E /* ImageLayerChain.swift */,
+				33250D1306B30B4E3D4C9B0E /* LayeredRootFS.swift */,
 				85321B230A582D1C0AF76B5C /* LocalRootFSService.swift */,
 				7058C8975F3F2684714E24E2 /* SleepWakeManager.swift */,
 			);
@@ -1027,6 +1032,7 @@
 				C964312D5336EE55A8E4680B /* ImageLayerChainTests.swift */,
 				A2B6587D59B9EFA18E51A3F3 /* ImagesViewModelTests.swift */,
 				7B6FDB677AE01E62877A17AC /* K8sModelsTests.swift */,
+				3029D85CCC770F8C1801A392 /* LayeredRootFSTests.swift */,
 				F0647CCB67160C2509345B5E /* MachineModelTests.swift */,
 			);
 			path = ArcBoxTests;
@@ -1269,6 +1275,7 @@
 				9D6E13499CA3B4666836F0F1 /* InfoRow.swift in Sources */,
 				C8C56406446AE0906E11100C /* InfoTableView.swift in Sources */,
 				977632E34C7EC1E3FEEAA25E /* KubernetesState.swift in Sources */,
+				F0B924B312EABA596C870505 /* LayeredRootFS.swift in Sources */,
 				248D76E4E5597E56F48DA0F3 /* ListResizeHandle.swift in Sources */,
 				1CA50DB029E0C7A18CAF87A2 /* LocalRootFSOutlineCoordinator+Actions.swift in Sources */,
 				FFAB94A328F83148EC0ED794 /* LocalRootFSOutlineCoordinator+Columns.swift in Sources */,
@@ -1393,6 +1400,7 @@
 				8BBBA54130403D89D35986F7 /* ImageLayerChainTests.swift in Sources */,
 				0BCE503CC2BF6C2BEC9DC4EA /* ImagesViewModelTests.swift in Sources */,
 				F40C3E6023452858EEEA893F /* K8sModelsTests.swift in Sources */,
+				8127661373B4B0D6B1423F67 /* LayeredRootFSTests.swift in Sources */,
 				CCD9ABC3F69FE5DA233E85EC /* MachineModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		BB31DD543E7E07965B68C0A4 /* ContainerRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33B6873C4DDA948830B9EEC /* ContainerRowView.swift */; };
 		BB6DA9C1B509BF12CDA5A92E /* ImageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185A238D021D6C976574528C /* ImageDetailView.swift */; };
 		BBA87F361B8D0C6E8199DEEF /* ArcBoxDesktopApp+Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F21DD7BED5D64B93FF062D /* ArcBoxDesktopApp+Telemetry.swift */; };
+		BD0363ABBB77C56F049EE2E4 /* LayerMergeBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E1595F793A3AD5691E191D /* LayerMergeBadge.swift */; };
 		BD4DD5EF850AD2718803CB94 /* ContainerLoadErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC59662C0ED098CE14903C95 /* ContainerLoadErrorView.swift */; };
 		BD99D14EC5ED57BA1FF283CC /* DockerContextManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 064086AEC8C204E8224DF45A /* DockerContextManager.swift */; };
 		BDE44A1851827C2069778F08 /* ImageFilesTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE02225F61EF92333916B1 /* ImageFilesTab.swift */; };
@@ -442,6 +443,7 @@
 		F0647CCB67160C2509345B5E /* MachineModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachineModelTests.swift; sourceTree = "<group>"; };
 		F238F21169A97B94193454CF /* ServiceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceDetailView.swift; sourceTree = "<group>"; };
 		F4705819BA2C07E7EADAC37E /* MachineTerminalTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachineTerminalTab.swift; sourceTree = "<group>"; };
+		F4E1595F793A3AD5691E191D /* LayerMergeBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerMergeBadge.swift; sourceTree = "<group>"; };
 		F5B3B3C54B6D49C6198E9E26 /* DeepLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkTests.swift; sourceTree = "<group>"; };
 		F5F318A121B0C8EA1A05BFE5 /* InfoRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoRow.swift; sourceTree = "<group>"; };
 		F62FD6244C56EE8E45DF0EC7 /* AppColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppColors.swift; sourceTree = "<group>"; };
@@ -528,6 +530,7 @@
 				A80B0A0F4FC2E7ECA0B844DD /* ContainerFilesTab.swift */,
 				AE29B2F3FF7CFA3B0325CB97 /* ContainerInfoTab.swift */,
 				CE1AFAED2CB7429B714C8A06 /* ContainerTerminalTab.swift */,
+				F4E1595F793A3AD5691E191D /* LayerMergeBadge.swift */,
 				DE361CFCE48D16EF3A0F0085 /* ContainerLogsTab */,
 				1017F0D51C38B694100D248C /* LocalRootFSOutline */,
 			);
@@ -1275,6 +1278,7 @@
 				9D6E13499CA3B4666836F0F1 /* InfoRow.swift in Sources */,
 				C8C56406446AE0906E11100C /* InfoTableView.swift in Sources */,
 				977632E34C7EC1E3FEEAA25E /* KubernetesState.swift in Sources */,
+				BD0363ABBB77C56F049EE2E4 /* LayerMergeBadge.swift in Sources */,
 				F0B924B312EABA596C870505 /* LayeredRootFS.swift in Sources */,
 				248D76E4E5597E56F48DA0F3 /* ListResizeHandle.swift in Sources */,
 				1CA50DB029E0C7A18CAF87A2 /* LocalRootFSOutlineCoordinator+Actions.swift in Sources */,

--- a/ArcBox/Integrations/System/GuestDataMount.swift
+++ b/ArcBox/Integrations/System/GuestDataMount.swift
@@ -10,7 +10,7 @@ import Foundation
 /// browsed on the host via a prefix rewrite:
 /// `/var/lib/docker/<rest>` → `~/ArcBox/<rest>` and
 /// `/var/lib/containerd/<rest>` → `~/ArcBox/containerd/<rest>`.
-enum GuestDataMount {
+nonisolated enum GuestDataMount {
     /// Guest docker data root the export corresponds to.
     /// Mirrors `DOCKER_DATA_MOUNT_POINT` in the runtime.
     static let guestDataRoot = "/var/lib/docker"

--- a/ArcBox/Integrations/System/LayeredRootFS.swift
+++ b/ArcBox/Integrations/System/LayeredRootFS.swift
@@ -27,18 +27,41 @@ nonisolated struct LayeredRootFS {
     /// Whether composing is worth it at all: one layer merges to itself.
     var isComposed: Bool { layers.count > 1 }
 
+    /// The merged contents of one directory, plus how much of the stack the
+    /// merge could not actually read.
+    struct Listing {
+        let entries: [LocalFileEntry]
+        /// Layers that hold the path but failed to list it. Their files,
+        /// precedence and whiteouts are missing from `entries`, so a caller
+        /// showing this listing must be able to say it is incomplete.
+        let unreadableLayers: Int
+    }
+
     /// Lists the merged contents of a directory given relative to the stack
-    /// root. Layers that lack the directory contribute nothing; a layer that
-    /// cannot be read is skipped rather than failing the whole listing, so a
-    /// partially available export still browses.
-    func listDirectory(relativePath: String, showHiddenFiles: Bool) -> [LocalFileEntry] {
-        let listings = layers.map { layer -> [LocalRootFSService.LayerItem] in
+    /// root. A layer that cannot be read is skipped rather than failing the
+    /// whole listing, so a partially available export still browses — but the
+    /// skip is counted rather than hidden.
+    func listDirectory(relativePath: String, showHiddenFiles: Bool) -> Listing {
+        var listings: [[LocalRootFSService.LayerItem]] = []
+        var unreadable = 0
+
+        for layer in layers {
             let directory = Self.resolve(relativePath, in: layer)
-            return
-                (try? LocalRootFSService.listLayerItems(
-                    at: directory, showHiddenFiles: showHiddenFiles)) ?? []
+            do {
+                listings.append(
+                    try LocalRootFSService.listLayerItems(
+                        at: directory, showHiddenFiles: showHiddenFiles))
+            } catch {
+                // Most layers carry most paths not at all, which is normal and
+                // contributes nothing; a path that exists but will not open is
+                // a real gap in the merge.
+                if FileManager.default.fileExists(atPath: directory.path) {
+                    unreadable += 1
+                }
+            }
         }
-        return Self.merge(listings)
+
+        return Listing(entries: Self.merge(listings), unreadableLayers: unreadable)
     }
 
     /// Maps a host URL that came out of [`listDirectory`] back to its path

--- a/ArcBox/Integrations/System/LayeredRootFS.swift
+++ b/ArcBox/Integrations/System/LayeredRootFS.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Browses an overlay layer stack as one merged filesystem.
+///
+/// Containers and images under the containerd image store are not a single
+/// directory: the daemon resolves them to the same layer list the kernel
+/// would mount — a writable upper layer (containers only) followed by the
+/// image layers, highest first. The read-only `~/ArcBox` export serves each
+/// layer directory separately, so composing them here is what turns "the
+/// container's own writes" into "the container's filesystem".
+///
+/// This is a client-side union, not an overlayfs mount, and it reproduces
+/// overlay precedence and whiteouts but not opaque directories: those are
+/// recorded in a `trusted.overlay.*` xattr that does not survive the NFS
+/// export, so a directory the upper layer replaced wholesale still shows the
+/// entries it shadowed. A kernel-composed view (ABX-424) removes that caveat.
+nonisolated struct LayeredRootFS {
+    /// Layer directories, highest precedence first — the order overlayfs
+    /// encodes as `upperdir` then `lowerdir=A:B:C`.
+    let layers: [URL]
+
+    init?(layers: [URL]) {
+        guard !layers.isEmpty else { return nil }
+        self.layers = layers
+    }
+
+    /// Whether composing is worth it at all: one layer merges to itself.
+    var isComposed: Bool { layers.count > 1 }
+
+    /// Lists the merged contents of a directory given relative to the stack
+    /// root. Layers that lack the directory contribute nothing; a layer that
+    /// cannot be read is skipped rather than failing the whole listing, so a
+    /// partially available export still browses.
+    func listDirectory(relativePath: String, showHiddenFiles: Bool) -> [LocalFileEntry] {
+        let listings = layers.map { layer -> [LocalRootFSService.LayerItem] in
+            let directory = Self.resolve(relativePath, in: layer)
+            return
+                (try? LocalRootFSService.listLayerItems(
+                    at: directory, showHiddenFiles: showHiddenFiles)) ?? []
+        }
+        return Self.merge(listings)
+    }
+
+    /// Maps a host URL that came out of [`listDirectory`] back to its path
+    /// relative to the stack root, so expanding a node can re-merge across
+    /// every layer rather than only the one the node happened to come from.
+    func relativePath(forHostURL url: URL) -> String? {
+        let path = url.standardizedFileURL.path
+        for layer in layers {
+            let base = layer.standardizedFileURL.path
+            if path == base {
+                return ""
+            }
+            if path.hasPrefix(base + "/") {
+                return String(path.dropFirst(base.count + 1))
+            }
+        }
+        return nil
+    }
+
+    /// Merges per-layer listings, highest layer first.
+    ///
+    /// The first layer to name an entry decides it: a regular entry is taken
+    /// as-is, a whiteout deletes the name for every layer below (and is
+    /// itself hidden, being overlay bookkeeping rather than content).
+    static func merge(_ listings: [[LocalRootFSService.LayerItem]]) -> [LocalFileEntry] {
+        var decided: Set<String> = []
+        var merged: [LocalFileEntry] = []
+
+        for listing in listings {
+            for item in listing {
+                guard decided.insert(item.entry.name).inserted else { continue }
+                if !item.isWhiteout {
+                    merged.append(item.entry)
+                }
+            }
+        }
+
+        return merged.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+
+    private static func resolve(_ relativePath: String, in layer: URL) -> URL {
+        relativePath.isEmpty ? layer : layer.appendingPathComponent(relativePath)
+    }
+}

--- a/ArcBox/Integrations/System/LayeredRootFS.swift
+++ b/ArcBox/Integrations/System/LayeredRootFS.swift
@@ -61,16 +61,55 @@ nonisolated struct LayeredRootFS {
                     try LocalRootFSService.listLayerItems(
                         at: directory, showHiddenFiles: showHiddenFiles))
             } catch {
-                // A layer that simply lacks the path holds no opinion about
-                // it — a whiteout would have to live inside that very
-                // directory — so it is normal and the merge continues.
-                guard FileManager.default.fileExists(atPath: directory.path) else { continue }
+                // A layer that is present but simply lacks this path holds no
+                // opinion about it — a whiteout would have to live inside that
+                // very directory — so it is normal and the merge continues.
+                // A layer that is missing outright is unavailable, and its
+                // whiteouts are as unknowable as an unreadable one's.
+                let layerPresent = FileManager.default.fileExists(atPath: layer.path)
+                let pathPresent = FileManager.default.fileExists(atPath: directory.path)
+                if layerPresent && !pathPresent {
+                    continue
+                }
                 excluded.formUnion(index..<layers.count)
                 break
             }
         }
 
         return Listing(entries: Self.merge(listings), excludedLayers: excluded)
+    }
+
+    /// Layer paths mapped onto the export, and how many were left behind.
+    struct Resolution {
+        /// Host URLs for the layers that can be browsed, highest first.
+        let hostURLs: [URL]
+        /// Layers dropped from the tail, either unmappable or absent on the
+        /// host. Never represented in the merge, so a caller must count them
+        /// against the view's completeness.
+        let excludedCount: Int
+    }
+
+    /// Maps daemon-reported guest layer paths onto the `~/ArcBox` export,
+    /// stopping at the first layer the host cannot browse.
+    ///
+    /// Truncating rather than dropping matters for the same reason it does
+    /// inside [`listDirectory`]: a layer that cannot be browsed still decides
+    /// what the layers beneath it may show, so merging past it would surface
+    /// entries it may replace or delete.
+    static func resolveHostLayers(guestPaths: [String]) -> Resolution {
+        var hostURLs: [URL] = []
+        for guestPath in guestPaths {
+            guard let hostURL = GuestDataMount.hostURL(forGuestPath: guestPath),
+                (try? LocalRootFSService.resolveRootURL(path: hostURL.path)) != nil
+            else {
+                break
+            }
+            hostURLs.append(hostURL)
+        }
+        return Resolution(
+            hostURLs: hostURLs,
+            excludedCount: guestPaths.count - hostURLs.count
+        )
     }
 
     /// Maps a host URL that came out of [`listDirectory`] back to its path

--- a/ArcBox/Integrations/System/LayeredRootFS.swift
+++ b/ArcBox/Integrations/System/LayeredRootFS.swift
@@ -27,25 +27,32 @@ nonisolated struct LayeredRootFS {
     /// Whether composing is worth it at all: one layer merges to itself.
     var isComposed: Bool { layers.count > 1 }
 
-    /// The merged contents of one directory, plus which layers the merge
-    /// could not actually read.
+    /// The merged contents of one directory, plus which layers are missing
+    /// from it.
     struct Listing {
         let entries: [LocalFileEntry]
-        /// Indices into `layers` that hold the path but failed to list it.
-        /// Their files, precedence and whiteouts are missing from `entries`,
-        /// so a caller showing this listing must be able to say it is
-        /// incomplete — and identifying *which* layers lets callers union
+        /// Indices into `layers` whose content is not represented in
+        /// `entries`: the layer that failed to list, and — because its
+        /// whiteouts and replacements are unknowable — everything beneath
+        /// it. A caller showing this listing must be able to say it is
+        /// incomplete; identifying *which* layers lets callers union
         /// failures across directories instead of undercounting them.
-        let unreadableLayers: Set<Int>
+        let excludedLayers: Set<Int>
     }
 
     /// Lists the merged contents of a directory given relative to the stack
-    /// root. A layer that cannot be read is skipped rather than failing the
-    /// whole listing, so a partially available export still browses — but the
-    /// skip is reported rather than hidden.
+    /// root.
+    ///
+    /// A layer that cannot be read truncates the stack rather than being
+    /// skipped over. Skipping would let entries from lower layers surface
+    /// even though the unreadable layer may delete or replace them — showing
+    /// files the container or image does not actually have, which is worse
+    /// than showing fewer. Everything *above* the failure is unaffected:
+    /// lower layers can never override it. So the listing stays sound and
+    /// merely loses depth, and the loss is reported.
     func listDirectory(relativePath: String, showHiddenFiles: Bool) -> Listing {
         var listings: [[LocalRootFSService.LayerItem]] = []
-        var unreadable: Set<Int> = []
+        var excluded: Set<Int> = []
 
         for (index, layer) in layers.enumerated() {
             let directory = Self.resolve(relativePath, in: layer)
@@ -54,16 +61,16 @@ nonisolated struct LayeredRootFS {
                     try LocalRootFSService.listLayerItems(
                         at: directory, showHiddenFiles: showHiddenFiles))
             } catch {
-                // Most layers carry most paths not at all, which is normal and
-                // contributes nothing; a path that exists but will not open is
-                // a real gap in the merge.
-                if FileManager.default.fileExists(atPath: directory.path) {
-                    unreadable.insert(index)
-                }
+                // A layer that simply lacks the path holds no opinion about
+                // it — a whiteout would have to live inside that very
+                // directory — so it is normal and the merge continues.
+                guard FileManager.default.fileExists(atPath: directory.path) else { continue }
+                excluded.formUnion(index..<layers.count)
+                break
             }
         }
 
-        return Listing(entries: Self.merge(listings), unreadableLayers: unreadable)
+        return Listing(entries: Self.merge(listings), excludedLayers: excluded)
     }
 
     /// Maps a host URL that came out of [`listDirectory`] back to its path

--- a/ArcBox/Integrations/System/LayeredRootFS.swift
+++ b/ArcBox/Integrations/System/LayeredRootFS.swift
@@ -27,25 +27,27 @@ nonisolated struct LayeredRootFS {
     /// Whether composing is worth it at all: one layer merges to itself.
     var isComposed: Bool { layers.count > 1 }
 
-    /// The merged contents of one directory, plus how much of the stack the
-    /// merge could not actually read.
+    /// The merged contents of one directory, plus which layers the merge
+    /// could not actually read.
     struct Listing {
         let entries: [LocalFileEntry]
-        /// Layers that hold the path but failed to list it. Their files,
-        /// precedence and whiteouts are missing from `entries`, so a caller
-        /// showing this listing must be able to say it is incomplete.
-        let unreadableLayers: Int
+        /// Indices into `layers` that hold the path but failed to list it.
+        /// Their files, precedence and whiteouts are missing from `entries`,
+        /// so a caller showing this listing must be able to say it is
+        /// incomplete — and identifying *which* layers lets callers union
+        /// failures across directories instead of undercounting them.
+        let unreadableLayers: Set<Int>
     }
 
     /// Lists the merged contents of a directory given relative to the stack
     /// root. A layer that cannot be read is skipped rather than failing the
     /// whole listing, so a partially available export still browses — but the
-    /// skip is counted rather than hidden.
+    /// skip is reported rather than hidden.
     func listDirectory(relativePath: String, showHiddenFiles: Bool) -> Listing {
         var listings: [[LocalRootFSService.LayerItem]] = []
-        var unreadable = 0
+        var unreadable: Set<Int> = []
 
-        for layer in layers {
+        for (index, layer) in layers.enumerated() {
             let directory = Self.resolve(relativePath, in: layer)
             do {
                 listings.append(
@@ -56,7 +58,7 @@ nonisolated struct LayeredRootFS {
                 // contributes nothing; a path that exists but will not open is
                 // a real gap in the merge.
                 if FileManager.default.fileExists(atPath: directory.path) {
-                    unreadable += 1
+                    unreadable.insert(index)
                 }
             }
         }

--- a/ArcBox/Integrations/System/LocalRootFSService.swift
+++ b/ArcBox/Integrations/System/LocalRootFSService.swift
@@ -59,8 +59,18 @@ nonisolated struct LocalRootFSService {
         .fileSizeKey,
         .contentModificationDateKey,
         .localizedTypeDescriptionKey,
+        .fileResourceTypeKey,
         .nameKey,
     ]
+
+    /// One directory entry as read from a single layer, carrying the overlay
+    /// bookkeeping that [`LayeredRootFS`] needs but a plain listing does not.
+    struct LayerItem {
+        let entry: LocalFileEntry
+        /// Overlayfs marks a file deleted in an upper layer with a character
+        /// device of rdev 0:0 under the deleted name.
+        let isWhiteout: Bool
+    }
 
     static func resolveRootURL(path: String?) throws -> URL {
         guard let rawPath = path?.trimmingCharacters(in: .whitespacesAndNewlines), !rawPath.isEmpty else {
@@ -80,9 +90,15 @@ nonisolated struct LocalRootFSService {
     }
 
     static func listDirectory(at directoryURL: URL, showHiddenFiles: Bool) throws -> [LocalFileEntry] {
+        try listLayerItems(at: directoryURL, showHiddenFiles: showHiddenFiles).map(\.entry)
+    }
+
+    /// Lists a directory keeping the overlay whiteout marker, so a layered
+    /// browse can hide both the marker and whatever it deletes underneath.
+    static func listLayerItems(at directoryURL: URL, showHiddenFiles: Bool) throws -> [LayerItem] {
         var coordinatorError: NSError?
         var capturedError: Error?
-        var entries: [LocalFileEntry] = []
+        var entries: [LayerItem] = []
 
         let coordinator = NSFileCoordinator(filePresenter: nil)
         coordinator.coordinate(readingItemAt: directoryURL, options: .withoutChanges, error: &coordinatorError) {
@@ -114,7 +130,7 @@ nonisolated struct LocalRootFSService {
                         kind = values.localizedTypeDescription ?? "Document"
                     }
 
-                    return LocalFileEntry(
+                    let entry = LocalFileEntry(
                         url: entryURL,
                         name: values.name ?? entryURL.lastPathComponent,
                         isDirectory: isDirectory,
@@ -126,9 +142,13 @@ nonisolated struct LocalRootFSService {
                         children: nil,
                         loadError: nil
                     )
+                    return LayerItem(
+                        entry: entry,
+                        isWhiteout: values.fileResourceType == .characterSpecial
+                    )
                 }
                 .sorted {
-                    $0.name.localizedStandardCompare($1.name) == .orderedAscending
+                    $0.entry.name.localizedStandardCompare($1.entry.name) == .orderedAscending
                 }
             } catch {
                 capturedError = error

--- a/ArcBox/Integrations/System/LocalRootFSService.swift
+++ b/ArcBox/Integrations/System/LocalRootFSService.swift
@@ -72,6 +72,21 @@ nonisolated struct LocalRootFSService {
         let isWhiteout: Bool
     }
 
+    /// Whether an entry is an overlay whiteout — a character device of
+    /// rdev 0:0 standing in for a name deleted in a lower layer.
+    ///
+    /// The device number is what separates bookkeeping from content: layers
+    /// legitimately carry character devices (an image shipping `/dev/null`,
+    /// a privileged container's own nodes), and classifying those as
+    /// deletions would hide both the device and whatever it shadows below.
+    /// Only character devices are stat'd, so the common entry pays nothing.
+    static func isWhiteout(_ url: URL, resourceType: URLFileResourceType?) -> Bool {
+        guard resourceType == .characterSpecial else { return false }
+        var status = stat()
+        guard lstat(url.path, &status) == 0 else { return false }
+        return status.st_rdev == 0
+    }
+
     static func resolveRootURL(path: String?) throws -> URL {
         guard let rawPath = path?.trimmingCharacters(in: .whitespacesAndNewlines), !rawPath.isEmpty else {
             throw RootFSError.missingRootPath
@@ -144,7 +159,7 @@ nonisolated struct LocalRootFSService {
                     )
                     return LayerItem(
                         entry: entry,
-                        isWhiteout: values.fileResourceType == .characterSpecial
+                        isWhiteout: isWhiteout(entryURL, resourceType: values.fileResourceType)
                     )
                 }
                 .sorted {

--- a/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
@@ -12,7 +12,12 @@ struct ContainerFilesTab: View {
     @State private var selectedPath: String?
     @State private var rootURL: URL?
     @State private var layers: LayeredRootFS?
-    @State private var unavailableLayerCount = 0
+    /// Stack layers found unreadable, by index — a set so failures seen in
+    /// different directories union instead of collapsing to the worst one.
+    @State private var unreadableLayerIndices: Set<Int> = []
+    /// Layers whose guest path maps to no exported root: never in the stack,
+    /// so they have no index, but still missing from what the user sees.
+    @State private var unmappableLayerCount = 0
     @State private var totalLayerCount = 0
     @State private var errorMessage: String?
     @State private var isLoadingRoot = false
@@ -59,7 +64,7 @@ struct ContainerFilesTab: View {
             if let layers, layers.isComposed {
                 LayerMergeBadge(
                     total: max(totalLayerCount, layers.layers.count),
-                    unavailable: unavailableLayerCount
+                    unavailable: unreadableLayerIndices.count + unmappableLayerCount
                 )
             }
 
@@ -117,10 +122,11 @@ struct ContainerFilesTab: View {
                 onOpenURL: { url in
                     _ = NSWorkspace.shared.open(url)
                 },
-                onUnreadableLayers: { count in
-                    // Keep the worst seen: a layer that fails once has already
-                    // left holes in what the user browsed.
-                    unavailableLayerCount = max(unavailableLayerCount, count)
+                onUnreadableLayers: { indices in
+                    // Union, never replace: a layer that failed once has
+                    // already left holes in what the user browsed, and two
+                    // directories can fail on two different layers.
+                    unreadableLayerIndices.formUnion(indices)
                 }
             )
         } else {
@@ -171,7 +177,8 @@ struct ContainerFilesTab: View {
         isLoadingRoot = true
         selectedPath = nil
         layers = nil
-        unavailableLayerCount = 0
+        unreadableLayerIndices = []
+        unmappableLayerCount = 0
         totalLayerCount = 0
 
         // Inspect-provided path (classic graph drivers) is already a merged
@@ -209,11 +216,11 @@ struct ContainerFilesTab: View {
             // rather than passing a partial filesystem off as the whole one.
             // Listings report further failures as they happen (a layer can
             // die after this check), and the badge keeps the worst seen.
-            unavailableLayerCount =
-                unmappableCount
-                + hostURLs.filter {
-                    (try? LocalRootFSService.resolveRootURL(path: $0.path)) == nil
-                }.count
+            unmappableLayerCount = unmappableCount
+            unreadableLayerIndices = Set(
+                hostURLs.enumerated()
+                    .filter { (try? LocalRootFSService.resolveRootURL(path: $0.element.path)) == nil }
+                    .map(\.offset))
         } catch {
             rootURL = nil
             errorMessage = GuestDataMount.unavailableMessage(subject: "This container's filesystem")

--- a/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
@@ -193,12 +193,13 @@ struct ContainerFilesTab: View {
         }
 
         // The resolved paths are guest paths; browse them through ~/ArcBox.
-        // A layer whose path falls outside the exported roots cannot be
-        // browsed at all, so it counts against the view's completeness rather
-        // than quietly shrinking the stack.
-        let hostURLs = guestPaths.compactMap(GuestDataMount.hostURL(forGuestPath:))
+        // The stack stops at the first layer the host cannot browse: it still
+        // decides what lies beneath it, so merging past it would surface
+        // entries it may replace or delete.
+        let resolution = LayeredRootFS.resolveHostLayers(guestPaths: guestPaths)
+        let hostURLs = resolution.hostURLs
         totalLayerCount = guestPaths.count
-        let unmappableCount = guestPaths.count - hostURLs.count
+        unmappableLayerCount = resolution.excludedCount
         guard let rootHostURL = hostURLs.first else {
             rootURL = nil
             errorMessage =
@@ -212,16 +213,8 @@ struct ContainerFilesTab: View {
         do {
             rootURL = try LocalRootFSService.resolveRootURL(path: rootHostURL.path)
             layers = hostURLs.count > 1 ? LayeredRootFS(layers: hostURLs) : nil
-            // A layer the export cannot currently serve merges as empty, so
-            // the view would be quietly incomplete; count them and say so
-            // rather than passing a partial filesystem off as the whole one.
-            // Listings report further failures as they happen (a layer can
-            // die after this check), and the badge keeps the worst seen.
-            unmappableLayerCount = unmappableCount
-            excludedLayerIndices = Set(
-                hostURLs.enumerated()
-                    .filter { (try? LocalRootFSService.resolveRootURL(path: $0.element.path)) == nil }
-                    .map(\.offset))
+            // Listings report further exclusions as they happen — a layer can
+            // die after this point — and the badge unions them.
         } catch {
             rootURL = nil
             errorMessage = GuestDataMount.unavailableMessage(subject: "This container's filesystem")

--- a/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
@@ -12,9 +12,10 @@ struct ContainerFilesTab: View {
     @State private var selectedPath: String?
     @State private var rootURL: URL?
     @State private var layers: LayeredRootFS?
-    /// Stack layers found unreadable, by index — a set so failures seen in
-    /// different directories union instead of collapsing to the worst one.
-    @State private var unreadableLayerIndices: Set<Int> = []
+    /// Stack layers missing from what was browsed, by index — a set so
+    /// exclusions seen in different directories union instead of collapsing
+    /// to the worst one.
+    @State private var excludedLayerIndices: Set<Int> = []
     /// Layers whose guest path maps to no exported root: never in the stack,
     /// so they have no index, but still missing from what the user sees.
     @State private var unmappableLayerCount = 0
@@ -64,7 +65,7 @@ struct ContainerFilesTab: View {
             if let layers, layers.isComposed {
                 LayerMergeBadge(
                     total: max(totalLayerCount, layers.layers.count),
-                    unavailable: unreadableLayerIndices.count + unmappableLayerCount
+                    unavailable: excludedLayerIndices.count + unmappableLayerCount
                 )
             }
 
@@ -122,11 +123,11 @@ struct ContainerFilesTab: View {
                 onOpenURL: { url in
                     _ = NSWorkspace.shared.open(url)
                 },
-                onUnreadableLayers: { indices in
-                    // Union, never replace: a layer that failed once has
-                    // already left holes in what the user browsed, and two
+                onExcludedLayers: { indices in
+                    // Union, never replace: a layer dropped once has already
+                    // left holes in what the user browsed, and two
                     // directories can fail on two different layers.
-                    unreadableLayerIndices.formUnion(indices)
+                    excludedLayerIndices.formUnion(indices)
                 }
             )
         } else {
@@ -177,7 +178,7 @@ struct ContainerFilesTab: View {
         isLoadingRoot = true
         selectedPath = nil
         layers = nil
-        unreadableLayerIndices = []
+        excludedLayerIndices = []
         unmappableLayerCount = 0
         totalLayerCount = 0
 
@@ -217,7 +218,7 @@ struct ContainerFilesTab: View {
             // Listings report further failures as they happen (a layer can
             // die after this check), and the badge keeps the worst seen.
             unmappableLayerCount = unmappableCount
-            unreadableLayerIndices = Set(
+            excludedLayerIndices = Set(
                 hostURLs.enumerated()
                     .filter { (try? LocalRootFSService.resolveRootURL(path: $0.element.path)) == nil }
                     .map(\.offset))

--- a/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
@@ -13,6 +13,7 @@ struct ContainerFilesTab: View {
     @State private var rootURL: URL?
     @State private var layers: LayeredRootFS?
     @State private var unavailableLayerCount = 0
+    @State private var totalLayerCount = 0
     @State private var errorMessage: String?
     @State private var isLoadingRoot = false
     @State private var refreshToken = UUID()
@@ -57,7 +58,7 @@ struct ContainerFilesTab: View {
 
             if let layers, layers.isComposed {
                 LayerMergeBadge(
-                    total: layers.layers.count,
+                    total: max(totalLayerCount, layers.layers.count),
                     unavailable: unavailableLayerCount
                 )
             }
@@ -115,6 +116,11 @@ struct ContainerFilesTab: View {
                 selectedPath: $selectedPath,
                 onOpenURL: { url in
                     _ = NSWorkspace.shared.open(url)
+                },
+                onUnreadableLayers: { count in
+                    // Keep the worst seen: a layer that fails once has already
+                    // left holes in what the user browsed.
+                    unavailableLayerCount = max(unavailableLayerCount, count)
                 }
             )
         } else {
@@ -165,6 +171,8 @@ struct ContainerFilesTab: View {
         isLoadingRoot = true
         selectedPath = nil
         layers = nil
+        unavailableLayerCount = 0
+        totalLayerCount = 0
 
         // Inspect-provided path (classic graph drivers) is already a merged
         // rootfs; under the containerd image store inspect carries no paths,
@@ -177,7 +185,12 @@ struct ContainerFilesTab: View {
         }
 
         // The resolved paths are guest paths; browse them through ~/ArcBox.
+        // A layer whose path falls outside the exported roots cannot be
+        // browsed at all, so it counts against the view's completeness rather
+        // than quietly shrinking the stack.
         let hostURLs = guestPaths.compactMap(GuestDataMount.hostURL(forGuestPath:))
+        totalLayerCount = guestPaths.count
+        let unmappableCount = guestPaths.count - hostURLs.count
         guard let rootHostURL = hostURLs.first else {
             rootURL = nil
             errorMessage =
@@ -194,8 +207,11 @@ struct ContainerFilesTab: View {
             // A layer the export cannot currently serve merges as empty, so
             // the view would be quietly incomplete; count them and say so
             // rather than passing a partial filesystem off as the whole one.
+            // Listings report further failures as they happen (a layer can
+            // die after this check), and the badge keeps the worst seen.
             unavailableLayerCount =
-                hostURLs.filter {
+                unmappableCount
+                + hostURLs.filter {
                     (try? LocalRootFSService.resolveRootURL(path: $0.path)) == nil
                 }.count
         } catch {

--- a/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
@@ -12,6 +12,7 @@ struct ContainerFilesTab: View {
     @State private var selectedPath: String?
     @State private var rootURL: URL?
     @State private var layers: LayeredRootFS?
+    @State private var unavailableLayerCount = 0
     @State private var errorMessage: String?
     @State private var isLoadingRoot = false
     @State private var refreshToken = UUID()
@@ -55,10 +56,10 @@ struct ContainerFilesTab: View {
                 .truncationMode(.middle)
 
             if let layers, layers.isComposed {
-                Text("merged from \(layers.layers.count) layers")
-                    .font(.system(size: 11))
-                    .foregroundStyle(AppColors.textMuted)
-                    .fixedSize()
+                LayerMergeBadge(
+                    total: layers.layers.count,
+                    unavailable: unavailableLayerCount
+                )
             }
 
             Spacer()
@@ -189,12 +190,14 @@ struct ContainerFilesTab: View {
 
         do {
             rootURL = try LocalRootFSService.resolveRootURL(path: rootHostURL.path)
-            // Layers the export cannot currently serve would merge as empty
-            // and silently hide content, so compose only what is readable.
-            let readable = hostURLs.filter {
-                (try? LocalRootFSService.resolveRootURL(path: $0.path)) != nil
-            }
-            layers = readable.count > 1 ? LayeredRootFS(layers: readable) : nil
+            layers = hostURLs.count > 1 ? LayeredRootFS(layers: hostURLs) : nil
+            // A layer the export cannot currently serve merges as empty, so
+            // the view would be quietly incomplete; count them and say so
+            // rather than passing a partial filesystem off as the whole one.
+            unavailableLayerCount =
+                hostURLs.filter {
+                    (try? LocalRootFSService.resolveRootURL(path: $0.path)) == nil
+                }.count
         } catch {
             rootURL = nil
             errorMessage = GuestDataMount.unavailableMessage(subject: "This container's filesystem")

--- a/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
@@ -11,6 +11,7 @@ struct ContainerFilesTab: View {
 
     @State private var selectedPath: String?
     @State private var rootURL: URL?
+    @State private var layers: LayeredRootFS?
     @State private var errorMessage: String?
     @State private var isLoadingRoot = false
     @State private var refreshToken = UUID()
@@ -52,6 +53,13 @@ struct ContainerFilesTab: View {
                 .foregroundStyle(AppColors.textSecondary)
                 .lineLimit(1)
                 .truncationMode(.middle)
+
+            if let layers, layers.isComposed {
+                Text("merged from \(layers.layers.count) layers")
+                    .font(.system(size: 11))
+                    .foregroundStyle(AppColors.textMuted)
+                    .fixedSize()
+            }
 
             Spacer()
 
@@ -100,6 +108,7 @@ struct ContainerFilesTab: View {
         } else if let rootURL {
             LocalRootFSOutlineView(
                 rootURL: rootURL,
+                layers: layers,
                 showHiddenFiles: showHiddenFiles,
                 reloadID: outlineReloadID,
                 selectedPath: $selectedPath,
@@ -128,9 +137,8 @@ struct ContainerFilesTab: View {
                 .padding(.horizontal, 20)
 
             Text(
-                "Container filesystems are browsed through the read-only ~/ArcBox export. "
-                    + "The view shows the container's own writable layer; "
-                    + "image layers stay in their own snapshots."
+                "Container filesystems are browsed through the read-only ~/ArcBox export, "
+                    + "merging the container's writable layer over the image layers below it."
             )
             .font(.system(size: 12))
             .foregroundStyle(AppColors.textMuted)
@@ -155,22 +163,24 @@ struct ContainerFilesTab: View {
         errorMessage = nil
         isLoadingRoot = true
         selectedPath = nil
+        layers = nil
 
-        // Inspect-provided path (classic graph drivers), else ask the daemon
-        // to resolve the container's snapshot layers (containerd image store,
-        // where inspect carries no GraphDriver paths).
-        var guestPath = container.resolvedRootFSMountPath
-        if guestPath == nil {
-            guestPath = await resolveViaDaemon()
+        // Inspect-provided path (classic graph drivers) is already a merged
+        // rootfs; under the containerd image store inspect carries no paths,
+        // so the daemon resolves the layer stack and the tab merges it.
+        var guestPaths: [String] = []
+        if let mountPath = container.resolvedRootFSMountPath {
+            guestPaths = [mountPath]
+        } else {
+            guestPaths = await resolveViaDaemon()
         }
 
-        // The resolved path is a guest path; browse it through the ~/ArcBox export.
-        guard let guestPath,
-            let hostURL = GuestDataMount.hostURL(forGuestPath: guestPath)
-        else {
+        // The resolved paths are guest paths; browse them through ~/ArcBox.
+        let hostURLs = guestPaths.compactMap(GuestDataMount.hostURL(forGuestPath:))
+        guard let rootHostURL = hostURLs.first else {
             rootURL = nil
             errorMessage =
-                guestPath == nil
+                guestPaths.isEmpty
                 ? "Container has no resolvable filesystem path."
                 : "Container filesystem path is outside the guest data root."
             isLoadingRoot = false
@@ -178,7 +188,13 @@ struct ContainerFilesTab: View {
         }
 
         do {
-            rootURL = try LocalRootFSService.resolveRootURL(path: hostURL.path)
+            rootURL = try LocalRootFSService.resolveRootURL(path: rootHostURL.path)
+            // Layers the export cannot currently serve would merge as empty
+            // and silently hide content, so compose only what is readable.
+            let readable = hostURLs.filter {
+                (try? LocalRootFSService.resolveRootURL(path: $0.path)) != nil
+            }
+            layers = readable.count > 1 ? LayeredRootFS(layers: readable) : nil
         } catch {
             rootURL = nil
             errorMessage = GuestDataMount.unavailableMessage(subject: "This container's filesystem")
@@ -187,24 +203,29 @@ struct ContainerFilesTab: View {
         isLoadingRoot = false
     }
 
-    /// Resolves the container's writable snapshot layer via the daemon.
+    /// Resolves the container's snapshot layer stack via the daemon.
     ///
     /// Under the containerd image store the layer directories live in
     /// containerd's snapshotter, so the daemon queries the guest and returns
-    /// guest paths; the writable (upper) layer holds everything the container
-    /// itself wrote.
-    private func resolveViaDaemon() async -> String? {
-        guard let arcboxClient else { return nil }
+    /// guest paths: the writable (upper) layer the container wrote, followed
+    /// by the image layers below it — overlay precedence order.
+    private func resolveViaDaemon() async -> [String] {
+        guard let arcboxClient else { return [] }
         var request = Arcbox_V1_ResolveContainerFsRequest()
         request.containerID = container.id
         do {
             let response = try await arcboxClient.system.resolveContainerFs(
                 request, options: ArcBoxClient.defaultCallOptions)
-            return response.upperDir.isEmpty ? nil : response.upperDir
+            var paths: [String] = []
+            if !response.upperDir.isEmpty {
+                paths.append(response.upperDir)
+            }
+            paths.append(contentsOf: response.lowerDirs.filter { !$0.isEmpty })
+            return paths
         } catch {
             Log.daemon.error(
                 "Failed to resolve container fs: \(error.localizedDescription, privacy: .private)")
-            return nil
+            return []
         }
     }
 

--- a/ArcBox/Views/Containers/Tabs/LayerMergeBadge.swift
+++ b/ArcBox/Views/Containers/Tabs/LayerMergeBadge.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// Says how many layers a Files tab merged, and warns when some of them
+/// could not be read.
+///
+/// A layer the `~/ArcBox` export cannot serve contributes nothing to the
+/// merge, so the browser would otherwise present a partial filesystem as if
+/// it were complete — files unique to that layer, and the deletions it
+/// records, simply would not appear.
+struct LayerMergeBadge: View {
+    let total: Int
+    let unavailable: Int
+
+    private var isComplete: Bool { unavailable == 0 }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            if !isComplete {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 10))
+            }
+
+            Text(label)
+                .font(.system(size: 11))
+        }
+        .foregroundStyle(isComplete ? AppColors.textMuted : AppColors.warning)
+        .fixedSize()
+        .help(
+            isComplete
+                ? "Merged view of all \(total) filesystem layers."
+                : "\(unavailable) of \(total) layers are unavailable through the ~/ArcBox export; "
+                    + "files that only exist in them are missing from this view."
+        )
+    }
+
+    private var label: String {
+        isComplete
+            ? "merged from \(total) layers"
+            : "merged from \(total - unavailable) of \(total) layers"
+    }
+}

--- a/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineCoordinator+Loading.swift
+++ b/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineCoordinator+Loading.swift
@@ -14,7 +14,7 @@ extension LocalRootFSOutlineCoordinator {
 
         DispatchQueue.global(qos: .userInitiated).async {
             let entries: [LocalFileEntry]
-            var unreadableLayers = 0
+            var unreadableLayers: Set<Int> = []
             if let layers {
                 let listing = layers.listDirectory(relativePath: "", showHiddenFiles: showHidden)
                 entries = listing.entries
@@ -49,7 +49,7 @@ extension LocalRootFSOutlineCoordinator {
 
         DispatchQueue.global(qos: .userInitiated).async {
             let children: [LocalFileEntry]
-            var unreadableLayers = 0
+            var unreadableLayers: Set<Int> = []
             // The node carries the URL of whichever layer won it, so re-derive
             // its path relative to the stack: the merged children can come
             // from layers this node's own directory does not exist in.

--- a/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineCoordinator+Loading.swift
+++ b/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineCoordinator+Loading.swift
@@ -5,6 +5,7 @@ extension LocalRootFSOutlineCoordinator {
         generation += 1
         let currentGeneration = generation
         let rootURL = parent.rootURL
+        let layers = parent.layers
         let showHidden = parent.showHiddenFiles
 
         rootNodes = []
@@ -13,10 +14,12 @@ extension LocalRootFSOutlineCoordinator {
 
         DispatchQueue.global(qos: .userInitiated).async {
             let entries: [LocalFileEntry]
-            do {
-                entries = try FileSystemService.listDirectory(at: rootURL, showHiddenFiles: showHidden)
-            } catch {
-                entries = []
+            if let layers {
+                entries = layers.listDirectory(relativePath: "", showHiddenFiles: showHidden)
+            } else {
+                entries =
+                    (try? FileSystemService.listDirectory(
+                        at: rootURL, showHiddenFiles: showHidden)) ?? []
             }
 
             DispatchQueue.main.async {
@@ -36,14 +39,22 @@ extension LocalRootFSOutlineCoordinator {
 
         node.isLoading = true
         let currentGeneration = generation
+        let layers = parent.layers
         let showHidden = parent.showHiddenFiles
+        let url = node.entry.url
 
         DispatchQueue.global(qos: .userInitiated).async {
             let children: [LocalFileEntry]
-            do {
-                children = try FileSystemService.listDirectory(at: node.entry.url, showHiddenFiles: showHidden)
-            } catch {
-                children = []
+            // The node carries the URL of whichever layer won it, so re-derive
+            // its path relative to the stack: the merged children can come
+            // from layers this node's own directory does not exist in.
+            if let layers, let relativePath = layers.relativePath(forHostURL: url) {
+                children = layers.listDirectory(
+                    relativePath: relativePath, showHiddenFiles: showHidden)
+            } else {
+                children =
+                    (try? FileSystemService.listDirectory(at: url, showHiddenFiles: showHidden))
+                    ?? []
             }
 
             DispatchQueue.main.async {

--- a/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineCoordinator+Loading.swift
+++ b/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineCoordinator+Loading.swift
@@ -14,11 +14,11 @@ extension LocalRootFSOutlineCoordinator {
 
         DispatchQueue.global(qos: .userInitiated).async {
             let entries: [LocalFileEntry]
-            var unreadableLayers: Set<Int> = []
+            var excludedLayers: Set<Int> = []
             if let layers {
                 let listing = layers.listDirectory(relativePath: "", showHiddenFiles: showHidden)
                 entries = listing.entries
-                unreadableLayers = listing.unreadableLayers
+                excludedLayers = listing.excludedLayers
             } else {
                 entries =
                     (try? FileSystemService.listDirectory(
@@ -27,7 +27,7 @@ extension LocalRootFSOutlineCoordinator {
 
             DispatchQueue.main.async {
                 guard currentGeneration == self.generation else { return }
-                self.parent.onUnreadableLayers?(unreadableLayers)
+                self.parent.onExcludedLayers?(excludedLayers)
                 self.rootNodes = entries.map { LocalFileNode(entry: $0, parent: nil) }
                 self.outlineView?.reloadData()
                 self.adjustColumnWidths(force: true)
@@ -49,7 +49,7 @@ extension LocalRootFSOutlineCoordinator {
 
         DispatchQueue.global(qos: .userInitiated).async {
             let children: [LocalFileEntry]
-            var unreadableLayers: Set<Int> = []
+            var excludedLayers: Set<Int> = []
             // The node carries the URL of whichever layer won it, so re-derive
             // its path relative to the stack: the merged children can come
             // from layers this node's own directory does not exist in.
@@ -57,7 +57,7 @@ extension LocalRootFSOutlineCoordinator {
                 let listing = layers.listDirectory(
                     relativePath: relativePath, showHiddenFiles: showHidden)
                 children = listing.entries
-                unreadableLayers = listing.unreadableLayers
+                excludedLayers = listing.excludedLayers
             } else {
                 children =
                     (try? FileSystemService.listDirectory(at: url, showHiddenFiles: showHidden))
@@ -66,7 +66,7 @@ extension LocalRootFSOutlineCoordinator {
 
             DispatchQueue.main.async {
                 guard currentGeneration == self.generation else { return }
-                self.parent.onUnreadableLayers?(unreadableLayers)
+                self.parent.onExcludedLayers?(excludedLayers)
                 node.isLoading = false
                 node.children = children.map { LocalFileNode(entry: $0, parent: node) }
                 self.outlineView?.reloadItem(node, reloadChildren: true)

--- a/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineCoordinator+Loading.swift
+++ b/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineCoordinator+Loading.swift
@@ -14,8 +14,11 @@ extension LocalRootFSOutlineCoordinator {
 
         DispatchQueue.global(qos: .userInitiated).async {
             let entries: [LocalFileEntry]
+            var unreadableLayers = 0
             if let layers {
-                entries = layers.listDirectory(relativePath: "", showHiddenFiles: showHidden)
+                let listing = layers.listDirectory(relativePath: "", showHiddenFiles: showHidden)
+                entries = listing.entries
+                unreadableLayers = listing.unreadableLayers
             } else {
                 entries =
                     (try? FileSystemService.listDirectory(
@@ -24,6 +27,7 @@ extension LocalRootFSOutlineCoordinator {
 
             DispatchQueue.main.async {
                 guard currentGeneration == self.generation else { return }
+                self.parent.onUnreadableLayers?(unreadableLayers)
                 self.rootNodes = entries.map { LocalFileNode(entry: $0, parent: nil) }
                 self.outlineView?.reloadData()
                 self.adjustColumnWidths(force: true)
@@ -45,12 +49,15 @@ extension LocalRootFSOutlineCoordinator {
 
         DispatchQueue.global(qos: .userInitiated).async {
             let children: [LocalFileEntry]
+            var unreadableLayers = 0
             // The node carries the URL of whichever layer won it, so re-derive
             // its path relative to the stack: the merged children can come
             // from layers this node's own directory does not exist in.
             if let layers, let relativePath = layers.relativePath(forHostURL: url) {
-                children = layers.listDirectory(
+                let listing = layers.listDirectory(
                     relativePath: relativePath, showHiddenFiles: showHidden)
+                children = listing.entries
+                unreadableLayers = listing.unreadableLayers
             } else {
                 children =
                     (try? FileSystemService.listDirectory(at: url, showHiddenFiles: showHidden))
@@ -59,6 +66,7 @@ extension LocalRootFSOutlineCoordinator {
 
             DispatchQueue.main.async {
                 guard currentGeneration == self.generation else { return }
+                self.parent.onUnreadableLayers?(unreadableLayers)
                 node.isLoading = false
                 node.children = children.map { LocalFileNode(entry: $0, parent: node) }
                 self.outlineView?.reloadItem(node, reloadChildren: true)

--- a/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineView.swift
+++ b/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 struct LocalRootFSOutlineView: NSViewRepresentable {
     let rootURL: URL
+    /// Layer stack to merge while browsing. `nil` browses `rootURL` alone —
+    /// the plain single-directory case (volumes, machines, sandboxes).
+    var layers: LayeredRootFS?
     let showHiddenFiles: Bool
     let reloadID: String
     @Binding var selectedPath: String?

--- a/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineView.swift
+++ b/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineView.swift
@@ -9,10 +9,12 @@ struct LocalRootFSOutlineView: NSViewRepresentable {
     let reloadID: String
     @Binding var selectedPath: String?
     let onOpenURL: (URL) -> Void
-    /// Reports, per listing, how many layers held the directory but could not
+    /// Reports, per listing, which layers held the directory but could not
     /// be read — a layer that dies after the tab loaded shows up here and
     /// nowhere else, so the caller can keep its "incomplete" warning honest.
-    var onUnreadableLayers: ((Int) -> Void)?
+    /// Identifying the layers lets the caller union failures across
+    /// directories; a bare count would collapse distinct layers into one.
+    var onUnreadableLayers: ((Set<Int>) -> Void)?
 
     func makeCoordinator() -> LocalRootFSOutlineCoordinator {
         LocalRootFSOutlineCoordinator(parent: self)

--- a/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineView.swift
+++ b/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineView.swift
@@ -9,6 +9,10 @@ struct LocalRootFSOutlineView: NSViewRepresentable {
     let reloadID: String
     @Binding var selectedPath: String?
     let onOpenURL: (URL) -> Void
+    /// Reports, per listing, how many layers held the directory but could not
+    /// be read — a layer that dies after the tab loaded shows up here and
+    /// nowhere else, so the caller can keep its "incomplete" warning honest.
+    var onUnreadableLayers: ((Int) -> Void)?
 
     func makeCoordinator() -> LocalRootFSOutlineCoordinator {
         LocalRootFSOutlineCoordinator(parent: self)

--- a/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineView.swift
+++ b/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineView.swift
@@ -9,12 +9,12 @@ struct LocalRootFSOutlineView: NSViewRepresentable {
     let reloadID: String
     @Binding var selectedPath: String?
     let onOpenURL: (URL) -> Void
-    /// Reports, per listing, which layers held the directory but could not
-    /// be read — a layer that dies after the tab loaded shows up here and
-    /// nowhere else, so the caller can keep its "incomplete" warning honest.
-    /// Identifying the layers lets the caller union failures across
-    /// directories; a bare count would collapse distinct layers into one.
-    var onUnreadableLayers: ((Set<Int>) -> Void)?
+    /// Reports, per listing, which layers are missing from it — a layer that
+    /// dies after the tab loaded shows up here and nowhere else, so the
+    /// caller can keep its "incomplete" warning honest. Identifying the
+    /// layers lets the caller union failures across directories; a bare
+    /// count would collapse distinct layers into one.
+    var onExcludedLayers: ((Set<Int>) -> Void)?
 
     func makeCoordinator() -> LocalRootFSOutlineCoordinator {
         LocalRootFSOutlineCoordinator(parent: self)

--- a/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
+++ b/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
@@ -207,12 +207,13 @@ struct ImageFilesTab: View {
             // The layer directories are guest paths; browse them via ~/ArcBox.
             let mountPoints = try await resolveImageLayerPaths()
             resolvedRootFSMountPath = mountPoints.first
-            // A layer whose path falls outside the exported roots cannot be
-            // browsed at all, so it counts against the view's completeness
-            // rather than quietly shrinking the stack.
-            let hostURLs = mountPoints.compactMap(GuestDataMount.hostURL(forGuestPath:))
+            // The stack stops at the first layer the host cannot browse: it
+            // still decides what lies beneath it, so merging past it would
+            // surface entries it may replace or delete.
+            let resolution = LayeredRootFS.resolveHostLayers(guestPaths: mountPoints)
+            let hostURLs = resolution.hostURLs
             totalLayerCount = mountPoints.count
-            let unmappableCount = mountPoints.count - hostURLs.count
+            unmappableLayerCount = resolution.excludedCount
             guard let rootHostURL = hostURLs.first else {
                 errorMessage = "Image layer path is outside the guest data root."
                 isLoadingRoot = false
@@ -220,14 +221,8 @@ struct ImageFilesTab: View {
             }
             rootURL = try LocalRootFSService.resolveRootURL(path: rootHostURL.path)
             layers = hostURLs.count > 1 ? LayeredRootFS(layers: hostURLs) : nil
-            // A layer the export cannot currently serve merges as empty, so
-            // the view would be quietly incomplete; count them and say so
-            // rather than passing a partial filesystem off as the whole one.
-            unmappableLayerCount = unmappableCount
-            excludedLayerIndices = Set(
-                hostURLs.enumerated()
-                    .filter { (try? LocalRootFSService.resolveRootURL(path: $0.element.path)) == nil }
-                    .map(\.offset))
+            // Listings report further exclusions as they happen — a layer can
+            // die after this point — and the badge unions them.
         } catch let error as ImageFilesTabError {
             resolvedRootFSMountPath = nil
             errorMessage = error.localizedDescription

--- a/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
+++ b/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
@@ -31,6 +31,7 @@ struct ImageFilesTab: View {
     @State private var rootURL: URL?
     @State private var layers: LayeredRootFS?
     @State private var unavailableLayerCount = 0
+    @State private var totalLayerCount = 0
     @State private var resolvedRootFSMountPath: String?
     @State private var errorMessage: String?
     @State private var isLoadingRoot = false
@@ -80,7 +81,7 @@ struct ImageFilesTab: View {
 
             if let layers, layers.isComposed {
                 LayerMergeBadge(
-                    total: layers.layers.count,
+                    total: max(totalLayerCount, layers.layers.count),
                     unavailable: unavailableLayerCount
                 )
             }
@@ -138,6 +139,11 @@ struct ImageFilesTab: View {
                 selectedPath: $selectedPath,
                 onOpenURL: { url in
                     _ = NSWorkspace.shared.open(url)
+                },
+                onUnreadableLayers: { count in
+                    // Keep the worst seen: a layer that fails once has already
+                    // left holes in what the user browsed.
+                    unavailableLayerCount = max(unavailableLayerCount, count)
                 }
             )
         } else {
@@ -186,12 +192,19 @@ struct ImageFilesTab: View {
         selectedPath = nil
         rootURL = nil
         layers = nil
+        unavailableLayerCount = 0
+        totalLayerCount = 0
 
         do {
             // The layer directories are guest paths; browse them via ~/ArcBox.
             let mountPoints = try await resolveImageLayerPaths()
             resolvedRootFSMountPath = mountPoints.first
+            // A layer whose path falls outside the exported roots cannot be
+            // browsed at all, so it counts against the view's completeness
+            // rather than quietly shrinking the stack.
             let hostURLs = mountPoints.compactMap(GuestDataMount.hostURL(forGuestPath:))
+            totalLayerCount = mountPoints.count
+            let unmappableCount = mountPoints.count - hostURLs.count
             guard let rootHostURL = hostURLs.first else {
                 errorMessage = "Image layer path is outside the guest data root."
                 isLoadingRoot = false
@@ -203,7 +216,8 @@ struct ImageFilesTab: View {
             // the view would be quietly incomplete; count them and say so
             // rather than passing a partial filesystem off as the whole one.
             unavailableLayerCount =
-                hostURLs.filter {
+                unmappableCount
+                + hostURLs.filter {
                     (try? LocalRootFSService.resolveRootURL(path: $0.path)) == nil
                 }.count
         } catch let error as ImageFilesTabError {

--- a/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
+++ b/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
@@ -30,6 +30,7 @@ struct ImageFilesTab: View {
     @State private var selectedPath: String?
     @State private var rootURL: URL?
     @State private var layers: LayeredRootFS?
+    @State private var unavailableLayerCount = 0
     @State private var resolvedRootFSMountPath: String?
     @State private var errorMessage: String?
     @State private var isLoadingRoot = false
@@ -76,6 +77,13 @@ struct ImageFilesTab: View {
                 .foregroundStyle(AppColors.textSecondary)
                 .lineLimit(1)
                 .truncationMode(.middle)
+
+            if let layers, layers.isComposed {
+                LayerMergeBadge(
+                    total: layers.layers.count,
+                    unavailable: unavailableLayerCount
+                )
+            }
 
             Spacer()
 
@@ -190,12 +198,14 @@ struct ImageFilesTab: View {
                 return
             }
             rootURL = try LocalRootFSService.resolveRootURL(path: rootHostURL.path)
-            // Layers the export cannot currently serve would merge as empty
-            // and silently hide content, so compose only what is readable.
-            let readable = hostURLs.filter {
-                (try? LocalRootFSService.resolveRootURL(path: $0.path)) != nil
-            }
-            layers = readable.count > 1 ? LayeredRootFS(layers: readable) : nil
+            layers = hostURLs.count > 1 ? LayeredRootFS(layers: hostURLs) : nil
+            // A layer the export cannot currently serve merges as empty, so
+            // the view would be quietly incomplete; count them and say so
+            // rather than passing a partial filesystem off as the whole one.
+            unavailableLayerCount =
+                hostURLs.filter {
+                    (try? LocalRootFSService.resolveRootURL(path: $0.path)) == nil
+                }.count
         } catch let error as ImageFilesTabError {
             resolvedRootFSMountPath = nil
             errorMessage = error.localizedDescription

--- a/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
+++ b/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
@@ -30,9 +30,10 @@ struct ImageFilesTab: View {
     @State private var selectedPath: String?
     @State private var rootURL: URL?
     @State private var layers: LayeredRootFS?
-    /// Stack layers found unreadable, by index — a set so failures seen in
-    /// different directories union instead of collapsing to the worst one.
-    @State private var unreadableLayerIndices: Set<Int> = []
+    /// Stack layers missing from what was browsed, by index — a set so
+    /// exclusions seen in different directories union instead of collapsing
+    /// to the worst one.
+    @State private var excludedLayerIndices: Set<Int> = []
     /// Layers whose guest path maps to no exported root: never in the stack,
     /// so they have no index, but still missing from what the user sees.
     @State private var unmappableLayerCount = 0
@@ -87,7 +88,7 @@ struct ImageFilesTab: View {
             if let layers, layers.isComposed {
                 LayerMergeBadge(
                     total: max(totalLayerCount, layers.layers.count),
-                    unavailable: unreadableLayerIndices.count + unmappableLayerCount
+                    unavailable: excludedLayerIndices.count + unmappableLayerCount
                 )
             }
 
@@ -145,11 +146,11 @@ struct ImageFilesTab: View {
                 onOpenURL: { url in
                     _ = NSWorkspace.shared.open(url)
                 },
-                onUnreadableLayers: { indices in
-                    // Union, never replace: a layer that failed once has
-                    // already left holes in what the user browsed, and two
+                onExcludedLayers: { indices in
+                    // Union, never replace: a layer dropped once has already
+                    // left holes in what the user browsed, and two
                     // directories can fail on two different layers.
-                    unreadableLayerIndices.formUnion(indices)
+                    excludedLayerIndices.formUnion(indices)
                 }
             )
         } else {
@@ -198,7 +199,7 @@ struct ImageFilesTab: View {
         selectedPath = nil
         rootURL = nil
         layers = nil
-        unreadableLayerIndices = []
+        excludedLayerIndices = []
         unmappableLayerCount = 0
         totalLayerCount = 0
 
@@ -223,7 +224,7 @@ struct ImageFilesTab: View {
             // the view would be quietly incomplete; count them and say so
             // rather than passing a partial filesystem off as the whole one.
             unmappableLayerCount = unmappableCount
-            unreadableLayerIndices = Set(
+            excludedLayerIndices = Set(
                 hostURLs.enumerated()
                     .filter { (try? LocalRootFSService.resolveRootURL(path: $0.element.path)) == nil }
                     .map(\.offset))

--- a/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
+++ b/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
@@ -30,7 +30,12 @@ struct ImageFilesTab: View {
     @State private var selectedPath: String?
     @State private var rootURL: URL?
     @State private var layers: LayeredRootFS?
-    @State private var unavailableLayerCount = 0
+    /// Stack layers found unreadable, by index — a set so failures seen in
+    /// different directories union instead of collapsing to the worst one.
+    @State private var unreadableLayerIndices: Set<Int> = []
+    /// Layers whose guest path maps to no exported root: never in the stack,
+    /// so they have no index, but still missing from what the user sees.
+    @State private var unmappableLayerCount = 0
     @State private var totalLayerCount = 0
     @State private var resolvedRootFSMountPath: String?
     @State private var errorMessage: String?
@@ -82,7 +87,7 @@ struct ImageFilesTab: View {
             if let layers, layers.isComposed {
                 LayerMergeBadge(
                     total: max(totalLayerCount, layers.layers.count),
-                    unavailable: unavailableLayerCount
+                    unavailable: unreadableLayerIndices.count + unmappableLayerCount
                 )
             }
 
@@ -140,10 +145,11 @@ struct ImageFilesTab: View {
                 onOpenURL: { url in
                     _ = NSWorkspace.shared.open(url)
                 },
-                onUnreadableLayers: { count in
-                    // Keep the worst seen: a layer that fails once has already
-                    // left holes in what the user browsed.
-                    unavailableLayerCount = max(unavailableLayerCount, count)
+                onUnreadableLayers: { indices in
+                    // Union, never replace: a layer that failed once has
+                    // already left holes in what the user browsed, and two
+                    // directories can fail on two different layers.
+                    unreadableLayerIndices.formUnion(indices)
                 }
             )
         } else {
@@ -192,7 +198,8 @@ struct ImageFilesTab: View {
         selectedPath = nil
         rootURL = nil
         layers = nil
-        unavailableLayerCount = 0
+        unreadableLayerIndices = []
+        unmappableLayerCount = 0
         totalLayerCount = 0
 
         do {
@@ -215,11 +222,11 @@ struct ImageFilesTab: View {
             // A layer the export cannot currently serve merges as empty, so
             // the view would be quietly incomplete; count them and say so
             // rather than passing a partial filesystem off as the whole one.
-            unavailableLayerCount =
-                unmappableCount
-                + hostURLs.filter {
-                    (try? LocalRootFSService.resolveRootURL(path: $0.path)) == nil
-                }.count
+            unmappableLayerCount = unmappableCount
+            unreadableLayerIndices = Set(
+                hostURLs.enumerated()
+                    .filter { (try? LocalRootFSService.resolveRootURL(path: $0.element.path)) == nil }
+                    .map(\.offset))
         } catch let error as ImageFilesTabError {
             resolvedRootFSMountPath = nil
             errorMessage = error.localizedDescription

--- a/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
+++ b/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
@@ -29,6 +29,7 @@ struct ImageFilesTab: View {
 
     @State private var selectedPath: String?
     @State private var rootURL: URL?
+    @State private var layers: LayeredRootFS?
     @State private var resolvedRootFSMountPath: String?
     @State private var errorMessage: String?
     @State private var isLoadingRoot = false
@@ -123,6 +124,7 @@ struct ImageFilesTab: View {
         } else if let rootURL {
             LocalRootFSOutlineView(
                 rootURL: rootURL,
+                layers: layers,
                 showHiddenFiles: showHiddenFiles,
                 reloadID: outlineReloadID,
                 selectedPath: $selectedPath,
@@ -175,17 +177,25 @@ struct ImageFilesTab: View {
         isLoadingRoot = true
         selectedPath = nil
         rootURL = nil
+        layers = nil
 
         do {
-            // The layer directory is a guest path; browse it via ~/ArcBox.
-            let mountPoint = try await resolveImageRootFSMountPath()
-            resolvedRootFSMountPath = mountPoint
-            guard let hostURL = GuestDataMount.hostURL(forGuestPath: mountPoint) else {
+            // The layer directories are guest paths; browse them via ~/ArcBox.
+            let mountPoints = try await resolveImageLayerPaths()
+            resolvedRootFSMountPath = mountPoints.first
+            let hostURLs = mountPoints.compactMap(GuestDataMount.hostURL(forGuestPath:))
+            guard let rootHostURL = hostURLs.first else {
                 errorMessage = "Image layer path is outside the guest data root."
                 isLoadingRoot = false
                 return
             }
-            rootURL = try LocalRootFSService.resolveRootURL(path: hostURL.path)
+            rootURL = try LocalRootFSService.resolveRootURL(path: rootHostURL.path)
+            // Layers the export cannot currently serve would merge as empty
+            // and silently hide content, so compose only what is readable.
+            let readable = hostURLs.filter {
+                (try? LocalRootFSService.resolveRootURL(path: $0.path)) != nil
+            }
+            layers = readable.count > 1 ? LayeredRootFS(layers: readable) : nil
         } catch let error as ImageFilesTabError {
             resolvedRootFSMountPath = nil
             errorMessage = error.localizedDescription
@@ -196,7 +206,7 @@ struct ImageFilesTab: View {
         isLoadingRoot = false
     }
 
-    private func resolveImageRootFSMountPath() async throws -> String {
+    private func resolveImageLayerPaths() async throws -> [String] {
         guard let docker else {
             throw ImageFilesTabError.dockerUnavailable
         }
@@ -207,13 +217,14 @@ struct ImageFilesTab: View {
                 explicitPath: snapshot.rootfsMountPath,
                 labels: snapshot.labels
             ) {
-                return resolvedPath
+                return [resolvedPath]
             }
             // Containerd image store: inspect carries no layer paths; ask
-            // the daemon to resolve the layer chain and browse the top
-            // layer's directory.
-            if let resolvedPath = await resolveViaDaemon(diffIDs: snapshot.rootfsLayers) {
-                return resolvedPath
+            // the daemon to resolve the layer chain, then merge the layers
+            // into the filesystem the image would present when run.
+            let resolved = await resolveViaDaemon(diffIDs: snapshot.rootfsLayers)
+            if !resolved.isEmpty {
+                return resolved
             }
             throw ImageFilesTabError.missingRootPath
         } catch let error as ImageFilesTabError {
@@ -223,22 +234,23 @@ struct ImageFilesTab: View {
         }
     }
 
-    /// Resolves the image's top layer directory via the daemon, keyed by
-    /// the layer chain ID computed from the inspect diff IDs.
-    private func resolveViaDaemon(diffIDs: [String]) async -> String? {
+    /// Resolves the image's layer directories via the daemon, keyed by the
+    /// layer chain ID computed from the inspect diff IDs. The daemon returns
+    /// them in overlay precedence order, topmost layer first.
+    private func resolveViaDaemon(diffIDs: [String]) async -> [String] {
         guard let arcboxClient,
             let topChainID = ImageLayerChain.topChainID(diffIDs: diffIDs)
-        else { return nil }
+        else { return [] }
         var request = Arcbox_V1_ResolveImageFsRequest()
         request.topChainID = topChainID
         do {
             let response = try await arcboxClient.system.resolveImageFs(
                 request, options: ArcBoxClient.defaultCallOptions)
-            return response.lowerDirs.first
+            return response.lowerDirs.filter { !$0.isEmpty }
         } catch {
             Log.daemon.error(
                 "Failed to resolve image fs: \(error.localizedDescription, privacy: .private)")
-            return nil
+            return []
         }
     }
 

--- a/ArcBoxTests/LayeredRootFSTests.swift
+++ b/ArcBoxTests/LayeredRootFSTests.swift
@@ -139,7 +139,7 @@ final class LayeredRootFSTests: XCTestCase {
 
         XCTAssertEqual(listing.entries.map(\.name), ["hosts", "resolv.conf"])
         XCTAssertEqual(try String(contentsOf: listing.entries[0].url, encoding: .utf8), "container")
-        XCTAssertEqual(listing.unreadableLayers, [])
+        XCTAssertEqual(listing.excludedLayers, [])
     }
 
     func testListDirectorySkipsLayersMissingTheDirectory() throws {
@@ -166,7 +166,7 @@ final class LayeredRootFSTests: XCTestCase {
         XCTAssertEqual(listing.entries.map(\.name), ["tool"])
         // A layer that simply lacks the path is normal, not a read failure —
         // counting it would put a permanent warning on every browse.
-        XCTAssertEqual(listing.unreadableLayers, [])
+        XCTAssertEqual(listing.excludedLayers, [])
     }
 
     // MARK: whiteout classification
@@ -195,7 +195,7 @@ final class LayeredRootFSTests: XCTestCase {
         XCTAssertEqual(items.map(\.isWhiteout), [false])
     }
 
-    func testListDirectoryCountsUnreadableLayers() throws {
+    func testListDirectoryReportsExcludedLayers() throws {
         // A path that exists but will not list (here: a regular file where a
         // directory is expected) is a real hole in the merge — the caller has
         // to be able to tell the user the view is incomplete.
@@ -223,7 +223,7 @@ final class LayeredRootFSTests: XCTestCase {
         // Identify *which* layer failed: a caller browsing several
         // directories unions these, and a bare count would collapse
         // failures in different layers into one.
-        XCTAssertEqual(listing.unreadableLayers, [1])
+        XCTAssertEqual(listing.excludedLayers, [1])
     }
 
     func testDistinctDirectoriesReportDistinctFailingLayers() throws {
@@ -247,8 +247,65 @@ final class LayeredRootFSTests: XCTestCase {
         let stack = try XCTUnwrap(LayeredRootFS(layers: [a, b]))
 
         XCTAssertEqual(
-            stack.listDirectory(relativePath: "etc", showHiddenFiles: false).unreadableLayers, [0])
+            stack.listDirectory(relativePath: "etc", showHiddenFiles: false).excludedLayers, [0, 1])
         XCTAssertEqual(
-            stack.listDirectory(relativePath: "opt", showHiddenFiles: false).unreadableLayers, [1])
+            stack.listDirectory(relativePath: "opt", showHiddenFiles: false).excludedLayers, [1])
+    }
+
+    func testUnreadableUpperLayerHidesLowerEntriesRatherThanShowingStaleOnes() throws {
+        // The upper layer decides what the lower one is allowed to show: it
+        // can replace a file or whiteout it entirely. If it cannot be read,
+        // surfacing the lower layer's copy would show content the container
+        // does not actually have — worse than showing nothing. The stack
+        // truncates at the failure instead.
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let upper = root.appendingPathComponent("upper", isDirectory: true)
+        let lower = root.appendingPathComponent("lower/etc", isDirectory: true)
+        try FileManager.default.createDirectory(at: upper, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: lower, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // `etc` exists in the upper layer but will not list.
+        try "x".write(to: upper.appendingPathComponent("etc"), atomically: true, encoding: .utf8)
+        try "stale".write(
+            to: lower.appendingPathComponent("passwd"), atomically: true, encoding: .utf8)
+
+        let stack = try XCTUnwrap(
+            LayeredRootFS(layers: [upper, root.appendingPathComponent("lower", isDirectory: true)]))
+        let listing = stack.listDirectory(relativePath: "etc", showHiddenFiles: false)
+
+        XCTAssertEqual(listing.entries.map(\.name), [])
+        XCTAssertEqual(listing.excludedLayers, [0, 1])
+    }
+
+    func testLayersAboveAnUnreadableOneStillMerge() throws {
+        // Precedence runs downward, so nothing below can override what the
+        // readable top layers already decided — those entries stay sound.
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let top = root.appendingPathComponent("top/etc", isDirectory: true)
+        let mid = root.appendingPathComponent("mid", isDirectory: true)
+        let bottom = root.appendingPathComponent("bottom/etc", isDirectory: true)
+        for dir in [top, mid, bottom] {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try "top".write(to: top.appendingPathComponent("hosts"), atomically: true, encoding: .utf8)
+        try "x".write(to: mid.appendingPathComponent("etc"), atomically: true, encoding: .utf8)
+        try "bottom".write(
+            to: bottom.appendingPathComponent("resolv.conf"), atomically: true, encoding: .utf8)
+
+        let stack = try XCTUnwrap(
+            LayeredRootFS(layers: [
+                root.appendingPathComponent("top", isDirectory: true),
+                mid,
+                root.appendingPathComponent("bottom", isDirectory: true),
+            ]))
+        let listing = stack.listDirectory(relativePath: "etc", showHiddenFiles: false)
+
+        XCTAssertEqual(listing.entries.map(\.name), ["hosts"])
+        XCTAssertEqual(listing.excludedLayers, [1, 2])
     }
 }

--- a/ArcBoxTests/LayeredRootFSTests.swift
+++ b/ArcBoxTests/LayeredRootFSTests.swift
@@ -135,10 +135,11 @@ final class LayeredRootFSTests: XCTestCase {
                 root.appendingPathComponent("upper", isDirectory: true),
                 root.appendingPathComponent("lower", isDirectory: true),
             ]))
-        let merged = stack.listDirectory(relativePath: "etc", showHiddenFiles: false)
+        let listing = stack.listDirectory(relativePath: "etc", showHiddenFiles: false)
 
-        XCTAssertEqual(merged.map(\.name), ["hosts", "resolv.conf"])
-        XCTAssertEqual(try String(contentsOf: merged[0].url, encoding: .utf8), "container")
+        XCTAssertEqual(listing.entries.map(\.name), ["hosts", "resolv.conf"])
+        XCTAssertEqual(try String(contentsOf: listing.entries[0].url, encoding: .utf8), "container")
+        XCTAssertEqual(listing.unreadableLayers, 0)
     }
 
     func testListDirectorySkipsLayersMissingTheDirectory() throws {
@@ -161,10 +162,11 @@ final class LayeredRootFSTests: XCTestCase {
                 root.appendingPathComponent("lower", isDirectory: true),
             ]))
 
-        XCTAssertEqual(
-            stack.listDirectory(relativePath: "opt", showHiddenFiles: false).map(\.name),
-            ["tool"]
-        )
+        let listing = stack.listDirectory(relativePath: "opt", showHiddenFiles: false)
+        XCTAssertEqual(listing.entries.map(\.name), ["tool"])
+        // A layer that simply lacks the path is normal, not a read failure —
+        // counting it would put a permanent warning on every browse.
+        XCTAssertEqual(listing.unreadableLayers, 0)
     }
 
     // MARK: whiteout classification
@@ -191,5 +193,33 @@ final class LayeredRootFSTests: XCTestCase {
         let items = try LocalRootFSService.listLayerItems(at: root, showHiddenFiles: false)
 
         XCTAssertEqual(items.map(\.isWhiteout), [false])
+    }
+
+    func testListDirectoryCountsUnreadableLayers() throws {
+        // A path that exists but will not list (here: a regular file where a
+        // directory is expected) is a real hole in the merge — the caller has
+        // to be able to tell the user the view is incomplete.
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let good = root.appendingPathComponent("good/etc", isDirectory: true)
+        try FileManager.default.createDirectory(at: good, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("broken", isDirectory: true),
+            withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try "x".write(to: good.appendingPathComponent("hosts"), atomically: true, encoding: .utf8)
+        try "not a directory".write(
+            to: root.appendingPathComponent("broken/etc"), atomically: true, encoding: .utf8)
+
+        let stack = try XCTUnwrap(
+            LayeredRootFS(layers: [
+                root.appendingPathComponent("good", isDirectory: true),
+                root.appendingPathComponent("broken", isDirectory: true),
+            ]))
+        let listing = stack.listDirectory(relativePath: "etc", showHiddenFiles: false)
+
+        XCTAssertEqual(listing.entries.map(\.name), ["hosts"])
+        XCTAssertEqual(listing.unreadableLayers, 1)
     }
 }

--- a/ArcBoxTests/LayeredRootFSTests.swift
+++ b/ArcBoxTests/LayeredRootFSTests.swift
@@ -80,12 +80,12 @@ final class LayeredRootFSTests: XCTestCase {
 
     // MARK: relative path mapping
 
-    func testRelativePathResolvesAcrossLayers() {
-        let stack = LayeredRootFS(layers: [
-            URL(fileURLWithPath: "/mnt/upper"),
-            URL(fileURLWithPath: "/mnt/lower"),
-        ])
-        let unwrapped = try! XCTUnwrap(stack)
+    func testRelativePathResolvesAcrossLayers() throws {
+        let unwrapped = try XCTUnwrap(
+            LayeredRootFS(layers: [
+                URL(fileURLWithPath: "/mnt/upper"),
+                URL(fileURLWithPath: "/mnt/lower"),
+            ]))
 
         XCTAssertEqual(unwrapped.relativePath(forHostURL: URL(fileURLWithPath: "/mnt/upper")), "")
         XCTAssertEqual(
@@ -96,11 +96,11 @@ final class LayeredRootFSTests: XCTestCase {
         XCTAssertNil(unwrapped.relativePath(forHostURL: URL(fileURLWithPath: "/elsewhere/etc")))
     }
 
-    func testRelativePathDoesNotMatchSiblingPrefix() {
+    func testRelativePathDoesNotMatchSiblingPrefix() throws {
         // "/mnt/upper-backup" shares a string prefix with "/mnt/upper" but is
         // a different directory; treating it as layer content would browse
         // the wrong tree.
-        let stack = try! XCTUnwrap(LayeredRootFS(layers: [URL(fileURLWithPath: "/mnt/upper")]))
+        let stack = try XCTUnwrap(LayeredRootFS(layers: [URL(fileURLWithPath: "/mnt/upper")]))
 
         XCTAssertNil(
             stack.relativePath(forHostURL: URL(fileURLWithPath: "/mnt/upper-backup/etc")))
@@ -110,8 +110,8 @@ final class LayeredRootFSTests: XCTestCase {
         XCTAssertNil(LayeredRootFS(layers: []))
     }
 
-    func testSingleLayerIsNotComposed() {
-        let stack = try! XCTUnwrap(LayeredRootFS(layers: [URL(fileURLWithPath: "/mnt/only")]))
+    func testSingleLayerIsNotComposed() throws {
+        let stack = try XCTUnwrap(LayeredRootFS(layers: [URL(fileURLWithPath: "/mnt/only")]))
         XCTAssertFalse(stack.isComposed)
     }
 
@@ -165,5 +165,31 @@ final class LayeredRootFSTests: XCTestCase {
             stack.listDirectory(relativePath: "opt", showHiddenFiles: false).map(\.name),
             ["tool"]
         )
+    }
+
+    // MARK: whiteout classification
+
+    func testRealCharacterDeviceIsNotAWhiteout() throws {
+        // Overlay whiteouts are character devices of rdev 0:0. Layers also
+        // carry legitimate character devices (an image shipping /dev/null,
+        // a privileged container's nodes); classifying those as deletions
+        // would hide both the device and whatever it shadows below.
+        let devices = try LocalRootFSService.listLayerItems(
+            at: URL(fileURLWithPath: "/dev"), showHiddenFiles: true)
+        let null = try XCTUnwrap(devices.first { $0.entry.name == "null" })
+
+        XCTAssertFalse(null.isWhiteout)
+    }
+
+    func testRegularFileIsNotAWhiteout() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "x".write(to: root.appendingPathComponent("file"), atomically: true, encoding: .utf8)
+
+        let items = try LocalRootFSService.listLayerItems(at: root, showHiddenFiles: false)
+
+        XCTAssertEqual(items.map(\.isWhiteout), [false])
     }
 }

--- a/ArcBoxTests/LayeredRootFSTests.swift
+++ b/ArcBoxTests/LayeredRootFSTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+
+@testable import ArcBox
+
+final class LayeredRootFSTests: XCTestCase {
+    // MARK: merge precedence
+
+    private func item(
+        _ name: String, isWhiteout: Bool = false, layer: String = "l"
+    )
+        -> LocalRootFSService.LayerItem
+    {
+        let entry = LocalFileEntry(
+            url: URL(fileURLWithPath: "/\(layer)/\(name)"),
+            name: name,
+            isDirectory: false,
+            isPackage: false,
+            isSymbolicLink: false,
+            sizeBytes: 0,
+            modifiedDate: nil,
+            kind: "Document",
+            children: nil,
+            loadError: nil
+        )
+        return LocalRootFSService.LayerItem(entry: entry, isWhiteout: isWhiteout)
+    }
+
+    func testHigherLayerWinsSameName() {
+        let merged = LayeredRootFS.merge([
+            [item("app.conf", layer: "upper")],
+            [item("app.conf", layer: "lower")],
+        ])
+
+        XCTAssertEqual(merged.map(\.name), ["app.conf"])
+        // The container's own copy must win over the image's, or the tab
+        // would show pre-edit content for every modified file.
+        XCTAssertEqual(merged[0].url.path, "/upper/app.conf")
+    }
+
+    func testLayersUnionDistinctNames() {
+        let merged = LayeredRootFS.merge([
+            [item("written-by-container", layer: "upper")],
+            [item("from-image", layer: "lower")],
+        ])
+
+        XCTAssertEqual(merged.map(\.name), ["from-image", "written-by-container"])
+    }
+
+    func testWhiteoutHidesItselfAndLowerEntry() {
+        // Deleting an image file inside a container leaves a whiteout in the
+        // upper layer; both it and the file it deletes must disappear.
+        let merged = LayeredRootFS.merge([
+            [item("deleted", isWhiteout: true, layer: "upper")],
+            [item("deleted", layer: "lower"), item("kept", layer: "lower")],
+        ])
+
+        XCTAssertEqual(merged.map(\.name), ["kept"])
+    }
+
+    func testWhiteoutOnlyShadowsLowerLayers() {
+        // A whiteout in a middle layer must not hide a higher layer's file.
+        let merged = LayeredRootFS.merge([
+            [item("resurrected", layer: "upper")],
+            [item("resurrected", isWhiteout: true, layer: "mid")],
+            [item("resurrected", layer: "lower")],
+        ])
+
+        XCTAssertEqual(merged.map(\.name), ["resurrected"])
+        XCTAssertEqual(merged[0].url.path, "/upper/resurrected")
+    }
+
+    func testMergedEntriesAreSortedByName() {
+        let merged = LayeredRootFS.merge([
+            [item("zeta", layer: "upper")],
+            [item("alpha", layer: "lower")],
+        ])
+
+        XCTAssertEqual(merged.map(\.name), ["alpha", "zeta"])
+    }
+
+    // MARK: relative path mapping
+
+    func testRelativePathResolvesAcrossLayers() {
+        let stack = LayeredRootFS(layers: [
+            URL(fileURLWithPath: "/mnt/upper"),
+            URL(fileURLWithPath: "/mnt/lower"),
+        ])
+        let unwrapped = try! XCTUnwrap(stack)
+
+        XCTAssertEqual(unwrapped.relativePath(forHostURL: URL(fileURLWithPath: "/mnt/upper")), "")
+        XCTAssertEqual(
+            unwrapped.relativePath(forHostURL: URL(fileURLWithPath: "/mnt/lower/etc/nginx")),
+            "etc/nginx"
+        )
+        // A URL from outside the stack must not be mistaken for layer content.
+        XCTAssertNil(unwrapped.relativePath(forHostURL: URL(fileURLWithPath: "/elsewhere/etc")))
+    }
+
+    func testRelativePathDoesNotMatchSiblingPrefix() {
+        // "/mnt/upper-backup" shares a string prefix with "/mnt/upper" but is
+        // a different directory; treating it as layer content would browse
+        // the wrong tree.
+        let stack = try! XCTUnwrap(LayeredRootFS(layers: [URL(fileURLWithPath: "/mnt/upper")]))
+
+        XCTAssertNil(
+            stack.relativePath(forHostURL: URL(fileURLWithPath: "/mnt/upper-backup/etc")))
+    }
+
+    func testEmptyStackIsRejected() {
+        XCTAssertNil(LayeredRootFS(layers: []))
+    }
+
+    func testSingleLayerIsNotComposed() {
+        let stack = try! XCTUnwrap(LayeredRootFS(layers: [URL(fileURLWithPath: "/mnt/only")]))
+        XCTAssertFalse(stack.isComposed)
+    }
+
+    // MARK: on-disk merge
+
+    func testListDirectoryMergesRealDirectories() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let upper = root.appendingPathComponent("upper/etc", isDirectory: true)
+        let lower = root.appendingPathComponent("lower/etc", isDirectory: true)
+        try FileManager.default.createDirectory(at: upper, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: lower, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try "container".write(to: upper.appendingPathComponent("hosts"), atomically: true, encoding: .utf8)
+        try "image".write(to: lower.appendingPathComponent("hosts"), atomically: true, encoding: .utf8)
+        try "image".write(to: lower.appendingPathComponent("resolv.conf"), atomically: true, encoding: .utf8)
+
+        let stack = try XCTUnwrap(
+            LayeredRootFS(layers: [
+                root.appendingPathComponent("upper", isDirectory: true),
+                root.appendingPathComponent("lower", isDirectory: true),
+            ]))
+        let merged = stack.listDirectory(relativePath: "etc", showHiddenFiles: false)
+
+        XCTAssertEqual(merged.map(\.name), ["hosts", "resolv.conf"])
+        XCTAssertEqual(try String(contentsOf: merged[0].url, encoding: .utf8), "container")
+    }
+
+    func testListDirectorySkipsLayersMissingTheDirectory() throws {
+        // Most layers do not carry most directories; a layer without the path
+        // must contribute nothing rather than failing the whole listing.
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let lower = root.appendingPathComponent("lower/opt", isDirectory: true)
+        try FileManager.default.createDirectory(at: lower, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("upper", isDirectory: true),
+            withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try "x".write(to: lower.appendingPathComponent("tool"), atomically: true, encoding: .utf8)
+
+        let stack = try XCTUnwrap(
+            LayeredRootFS(layers: [
+                root.appendingPathComponent("upper", isDirectory: true),
+                root.appendingPathComponent("lower", isDirectory: true),
+            ]))
+
+        XCTAssertEqual(
+            stack.listDirectory(relativePath: "opt", showHiddenFiles: false).map(\.name),
+            ["tool"]
+        )
+    }
+}

--- a/ArcBoxTests/LayeredRootFSTests.swift
+++ b/ArcBoxTests/LayeredRootFSTests.swift
@@ -308,4 +308,56 @@ final class LayeredRootFSTests: XCTestCase {
         XCTAssertEqual(listing.entries.map(\.name), ["hosts"])
         XCTAssertEqual(listing.excludedLayers, [1, 2])
     }
+
+    // MARK: host-layer resolution
+
+    func testResolveHostLayersTruncatesAtAnUnmappableLayer() {
+        // An unmappable upper layer still decides what the layers beneath it
+        // may show, so dropping it and keeping the lower ones would surface
+        // files it may have replaced or deleted.
+        let resolution = LayeredRootFS.resolveHostLayers(guestPaths: [
+            "/somewhere/else/upper",
+            "/var/lib/docker/volumes",
+        ])
+
+        XCTAssertEqual(resolution.hostURLs, [])
+        XCTAssertEqual(resolution.excludedCount, 2)
+    }
+
+    func testResolveHostLayersTruncatesAtAMissingLayer() {
+        // Same rule when the path maps fine but is not on the host: the
+        // layer is unavailable, and what it deletes is unknowable.
+        let resolution = LayeredRootFS.resolveHostLayers(guestPaths: [
+            "/var/lib/docker/definitely-not-present-\(UUID().uuidString)",
+            "/var/lib/docker/volumes",
+        ])
+
+        XCTAssertEqual(resolution.hostURLs, [])
+        XCTAssertEqual(resolution.excludedCount, 2)
+    }
+
+    func testMissingLayerDirectoryTruncatesTheMerge() throws {
+        // A layer whose directory is gone entirely is unavailable — distinct
+        // from a present layer that merely lacks the path, which is normal
+        // and must keep merging.
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let present = root.appendingPathComponent("present/etc", isDirectory: true)
+        let lower = root.appendingPathComponent("lower/etc", isDirectory: true)
+        try FileManager.default.createDirectory(at: present, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: lower, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "x".write(to: lower.appendingPathComponent("passwd"), atomically: true, encoding: .utf8)
+
+        let stack = try XCTUnwrap(
+            LayeredRootFS(layers: [
+                root.appendingPathComponent("present", isDirectory: true),
+                root.appendingPathComponent("gone", isDirectory: true),
+                root.appendingPathComponent("lower", isDirectory: true),
+            ]))
+        let listing = stack.listDirectory(relativePath: "etc", showHiddenFiles: false)
+
+        XCTAssertEqual(listing.entries.map(\.name), [])
+        XCTAssertEqual(listing.excludedLayers, [1, 2])
+    }
 }

--- a/ArcBoxTests/LayeredRootFSTests.swift
+++ b/ArcBoxTests/LayeredRootFSTests.swift
@@ -139,7 +139,7 @@ final class LayeredRootFSTests: XCTestCase {
 
         XCTAssertEqual(listing.entries.map(\.name), ["hosts", "resolv.conf"])
         XCTAssertEqual(try String(contentsOf: listing.entries[0].url, encoding: .utf8), "container")
-        XCTAssertEqual(listing.unreadableLayers, 0)
+        XCTAssertEqual(listing.unreadableLayers, [])
     }
 
     func testListDirectorySkipsLayersMissingTheDirectory() throws {
@@ -166,7 +166,7 @@ final class LayeredRootFSTests: XCTestCase {
         XCTAssertEqual(listing.entries.map(\.name), ["tool"])
         // A layer that simply lacks the path is normal, not a read failure —
         // counting it would put a permanent warning on every browse.
-        XCTAssertEqual(listing.unreadableLayers, 0)
+        XCTAssertEqual(listing.unreadableLayers, [])
     }
 
     // MARK: whiteout classification
@@ -220,6 +220,35 @@ final class LayeredRootFSTests: XCTestCase {
         let listing = stack.listDirectory(relativePath: "etc", showHiddenFiles: false)
 
         XCTAssertEqual(listing.entries.map(\.name), ["hosts"])
-        XCTAssertEqual(listing.unreadableLayers, 1)
+        // Identify *which* layer failed: a caller browsing several
+        // directories unions these, and a bare count would collapse
+        // failures in different layers into one.
+        XCTAssertEqual(listing.unreadableLayers, [1])
+    }
+
+    func testDistinctDirectoriesReportDistinctFailingLayers() throws {
+        // The case a bare count loses: /etc fails on one layer and /opt on
+        // another, so a caller unioning these sees two layers with holes,
+        // not one.
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let a = root.appendingPathComponent("a", isDirectory: true)
+        let b = root.appendingPathComponent("b", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: a.appendingPathComponent("opt"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: b.appendingPathComponent("etc"), withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // Each layer has one path that exists but cannot be listed.
+        try "x".write(to: a.appendingPathComponent("etc"), atomically: true, encoding: .utf8)
+        try "x".write(to: b.appendingPathComponent("opt"), atomically: true, encoding: .utf8)
+
+        let stack = try XCTUnwrap(LayeredRootFS(layers: [a, b]))
+
+        XCTAssertEqual(
+            stack.listDirectory(relativePath: "etc", showHiddenFiles: false).unreadableLayers, [0])
+        XCTAssertEqual(
+            stack.listDirectory(relativePath: "opt", showHiddenFiles: false).unreadableLayers, [1])
     }
 }


### PR DESCRIPTION
## Problem

The Files tabs browse **one** directory. Under the containerd image store that means:

- a **container** shows only its writable layer — i.e. just the files it wrote itself. Open a running nginx and `/etc/nginx` is not there, because it belongs to the image;
- an **image** shows only its topmost layer — for most images a handful of files, not the filesystem the image actually presents.

The daemon has resolved the *whole* stack since #429/#433 and forwards it over gRPC (`upperDir` + `lowerDirs`, overlay precedence order). The tabs used `upperDir` / `lowerDirs.first` and dropped the rest.

## Change

Compose the layers client-side.

`LayeredRootFS` merges per-layer listings with overlay semantics:
- the highest layer to name an entry wins it (a file the container edited shadows the image's copy);
- a **whiteout** — the character device overlayfs writes under a deleted name — hides both itself and the entry it deletes in every layer below.

The outline re-derives each expanded node's path *relative to the stack* before listing, so children merge across all layers rather than only the layer the node happened to come from (a directory present in three layers lists the union of all three).

Single-layer cases (volumes, machines, sandboxes, classic graph drivers) pass `layers: nil` and keep the existing single-directory path — no behavior change.

## Known limitation

Opaque directories are **not** honoured: overlayfs records them in a `trusted.overlay.*` xattr, which does not survive the NFS export. A directory an upper layer replaced wholesale still shows the entries it shadowed. The kernel-composed export (ABX-424) removes this, but is blocked upstream on containerd's `index=off` behavior reaching a released bundle — this is the unblocked 95%, and the caveat is documented at the type.

## Validation

- 11 new unit tests: precedence, union, whiteout (both "hides lower" and "only shadows below"), sort order, relative-path mapping incl. the sibling-prefix trap (`/mnt/upper-backup` must not match `/mnt/upper`), and two on-disk merges against real temp directories.
- Full suite: **130 tests, 0 failures**; `swift-format lint -r --strict ArcBox/ Packages/` clean.

Refs ABX-425, ABX-424.