### PR TITLE
fix(files): post-merge review fixes for the layered Files view

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		3B38458299F141A08B8C7107 /* ImageTerminalTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB477EF803A15EDFF2685A23 /* ImageTerminalTab.swift */; };
 		3B6BCFE408976AA0CDD0A5F8 /* SandboxesViewModel+PortsFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B80964B0A136E03F5FDA0FE /* SandboxesViewModel+PortsFiles.swift */; };
 		3F0B1B3F51E1663A5BA7EA66 /* SystemSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F734677F8F8EFD08CB32E8B3 /* SystemSettingsView.swift */; };
+		3F5E421D1DA0E9C653BAEB70 /* LayerStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B589789A38796A969785F9 /* LayerStack.swift */; };
 		4113241C123BBBBDEC76E5B0 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB03A05EDADB4F1FA6E10A1 /* ToastView.swift */; };
 		41459C0A45497BA629B8C34D /* NetworksViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ED3EC883A488801DE03195 /* NetworksViewModel.swift */; };
 		415470083B7CD53FB22C4E88 /* MachineModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD5CF45B00B80D85A778AB4 /* MachineModel.swift */; };
@@ -79,6 +80,7 @@
 		632810E9B138C535A11E7EBF /* DiagnosticBundleExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A04AFE137230F2CE0DD9DBB /* DiagnosticBundleExporter.swift */; };
 		648A2CC2001B3BE05F6B7B4C /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5272B55436BFFB8D2021CA20 /* EmptyStateView.swift */; };
 		6689ABCBDBD0055D07165D84 /* MachineEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 727A1DD3E8D3B0BB875475A8 /* MachineEmptyState.swift */; };
+		6720D08CDB730C241017A457 /* LayerStackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F4E99670A28483DBAA6CC8 /* LayerStackTests.swift */; };
 		67924F4E35FF28F7412EEBBA /* NetworkDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B7685DAD23E5427C0F9911 /* NetworkDetailView.swift */; };
 		68D8583BAE183D23FFC10815 /* MenuBarHoverButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 789DE20DB0F3E106BFAC6E10 /* MenuBarHoverButton.swift */; };
 		6EE6805F5EC85742CC665575 /* DockerCLIResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDE93A683D2613C431BEBF2 /* DockerCLIResolver.swift */; };
@@ -412,11 +414,13 @@
 		BDF2337ED21F8382F7ABB29A /* VolumeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeModel.swift; sourceTree = "<group>"; };
 		BEA74DBE71D29DEB680F08E7 /* SwiftTermView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftTermView.swift; sourceTree = "<group>"; };
 		C0A093F9D88FA4D914DE6F45 /* Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
+		C0B589789A38796A969785F9 /* LayerStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerStack.swift; sourceTree = "<group>"; };
 		C0BC46E06601AA9D330AF049 /* SystemVmBackendModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemVmBackendModel.swift; sourceTree = "<group>"; };
 		C0DD79FCBCF65FAFFBBB61D0 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		C15C37C29F16DD4E28B30271 /* MenuBarView+Containers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MenuBarView+Containers.swift"; sourceTree = "<group>"; };
 		C33F6D43F3CE2C79F072C7F3 /* DockerClient */ = {isa = PBXFileReference; lastKnownFileType = folder; name = DockerClient; path = Packages/DockerClient; sourceTree = SOURCE_ROOT; };
 		C964312D5336EE55A8E4680B /* ImageLayerChainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLayerChainTests.swift; sourceTree = "<group>"; };
+		C9F4E99670A28483DBAA6CC8 /* LayerStackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerStackTests.swift; sourceTree = "<group>"; };
 		CC86E86A85E46B083853A9AA /* MachineFilesTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachineFilesTab.swift; sourceTree = "<group>"; };
 		CC98017408ED56AFF734125A /* AboutView+Sections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AboutView+Sections.swift"; sourceTree = "<group>"; };
 		CDF5B0B3EC77FB12D8B4EA6A /* PodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodsViewModel.swift; sourceTree = "<group>"; };
@@ -796,6 +800,7 @@
 				83FBE0C82E0EB430C69EB944 /* GuestDataMount.swift */,
 				6218E84D6C2A8595FE308B5E /* ImageLayerChain.swift */,
 				33250D1306B30B4E3D4C9B0E /* LayeredRootFS.swift */,
+				C0B589789A38796A969785F9 /* LayerStack.swift */,
 				85321B230A582D1C0AF76B5C /* LocalRootFSService.swift */,
 				7058C8975F3F2684714E24E2 /* SleepWakeManager.swift */,
 			);
@@ -1039,6 +1044,7 @@
 				A2B6587D59B9EFA18E51A3F3 /* ImagesViewModelTests.swift */,
 				7B6FDB677AE01E62877A17AC /* K8sModelsTests.swift */,
 				3029D85CCC770F8C1801A392 /* LayeredRootFSTests.swift */,
+				C9F4E99670A28483DBAA6CC8 /* LayerStackTests.swift */,
 				F0647CCB67160C2509345B5E /* MachineModelTests.swift */,
 			);
 			path = ArcBoxTests;
@@ -1282,6 +1288,7 @@
 				C8C56406446AE0906E11100C /* InfoTableView.swift in Sources */,
 				977632E34C7EC1E3FEEAA25E /* KubernetesState.swift in Sources */,
 				BD0363ABBB77C56F049EE2E4 /* LayerMergeBadge.swift in Sources */,
+				3F5E421D1DA0E9C653BAEB70 /* LayerStack.swift in Sources */,
 				F0B924B312EABA596C870505 /* LayeredRootFS.swift in Sources */,
 				248D76E4E5597E56F48DA0F3 /* ListResizeHandle.swift in Sources */,
 				1CA50DB029E0C7A18CAF87A2 /* LocalRootFSOutlineCoordinator+Actions.swift in Sources */,
@@ -1408,6 +1415,7 @@
 				8BBBA54130403D89D35986F7 /* ImageLayerChainTests.swift in Sources */,
 				0BCE503CC2BF6C2BEC9DC4EA /* ImagesViewModelTests.swift in Sources */,
 				F40C3E6023452858EEEA893F /* K8sModelsTests.swift in Sources */,
+				6720D08CDB730C241017A457 /* LayerStackTests.swift in Sources */,
 				8127661373B4B0D6B1423F67 /* LayeredRootFSTests.swift in Sources */,
 				CCD9ABC3F69FE5DA233E85EC /* MachineModelTests.swift in Sources */,
 			);

--- a/ArcBox/Integrations/System/LayerStack.swift
+++ b/ArcBox/Integrations/System/LayerStack.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// What a Files tab is browsing, and how much of it is missing.
+///
+/// Container and image tabs resolve different things — one asks the daemon
+/// about a container, the other computes a layer chain from an image — but
+/// from the resolved guest paths onward they behave identically, and that
+/// shared half is what this owns. Keeping it in one place is not only less
+/// code: the merge's soundness rules (truncate at the first layer that
+/// cannot be browsed, report what is missing) have to hold for both tabs,
+/// and two copies is how one of them silently stops holding.
+nonisolated struct LayerStack {
+    /// Merged browser for the stack, or `nil` when a single layer is browsed
+    /// directly and there is nothing to merge.
+    private(set) var layers: LayeredRootFS?
+    /// The directory the outline browses: the top layer of the stack.
+    private(set) var rootURL: URL?
+    /// How many layers the daemon reported, browsable or not.
+    private(set) var reportedLayers = 0
+    /// Stack indices whose content is absent from what was browsed. A set so
+    /// exclusions seen in different directories union rather than collapse.
+    private(set) var excludedIndices: Set<Int> = []
+    /// Layers dropped before the stack existed, having no index to record.
+    private(set) var unbrowsableLayers = 0
+
+    /// Layers whose content the user is not seeing.
+    var missingLayers: Int { excludedIndices.count + unbrowsableLayers }
+
+    /// Whether there is a stack worth describing. A subject with a single
+    /// layer has nothing to be incomplete about.
+    var describesAStack: Bool { reportedLayers > 1 }
+
+    /// Why a stack could not be browsed at all.
+    enum Unresolved: Equatable {
+        /// Nothing was reported to browse.
+        case noPaths
+        /// The top layer is not under an exported root — a path problem.
+        case outsideExport
+        /// The top layer maps fine but is not there — the export is not
+        /// mounted, which is a different problem with a different fix.
+        case exportUnavailable
+    }
+
+    /// Resolves daemon-reported guest layer paths into a browsable stack.
+    ///
+    /// Runs off the main actor: resolution stats every layer, and on a
+    /// wedged export each stat blocks until NFS gives up.
+    static func resolve(guestPaths: [String]) async -> LayerStack {
+        let resolution = await Task.detached {
+            LayeredRootFS.resolveHostLayers(guestPaths: guestPaths)
+        }.value
+
+        var stack = LayerStack()
+        stack.reportedLayers = guestPaths.count
+        stack.unbrowsableLayers = resolution.excludedCount
+        stack.rootURL = resolution.hostURLs.first
+        stack.layers =
+            resolution.hostURLs.count > 1 ? LayeredRootFS(layers: resolution.hostURLs) : nil
+        return stack
+    }
+
+    /// Classifies a stack with no browsable top layer, so callers can say
+    /// which problem the user actually has.
+    static func unresolved(guestPaths: [String]) -> Unresolved {
+        guard let first = guestPaths.first else { return .noPaths }
+        return GuestDataMount.hostURL(forGuestPath: first) == nil
+            ? .outsideExport
+            : .exportUnavailable
+    }
+
+    /// Records layers a listing could not represent. Unions rather than
+    /// replaces: a layer dropped once has already left holes in what the
+    /// user browsed, and two directories can fail on two different layers.
+    mutating func exclude(_ indices: Set<Int>) {
+        excludedIndices.formUnion(indices)
+    }
+}

--- a/ArcBox/Integrations/System/LayerStack.swift
+++ b/ArcBox/Integrations/System/LayerStack.swift
@@ -26,9 +26,13 @@ nonisolated struct LayerStack {
     /// Layers whose content the user is not seeing.
     var missingLayers: Int { excludedIndices.count + unbrowsableLayers }
 
-    /// Whether there is a stack worth describing. A subject with a single
-    /// layer has nothing to be incomplete about.
-    var describesAStack: Bool { reportedLayers > 1 }
+    /// Whether there is a browsed stack worth describing.
+    ///
+    /// A subject with a single layer has nothing to be incomplete about, and
+    /// one with no browsable root was never merged at all — describing that
+    /// as "merged from 0 of N layers" states something that did not happen,
+    /// next to an error that already explains why.
+    var describesAStack: Bool { rootURL != nil && reportedLayers > 1 }
 
     /// Why a stack could not be browsed at all.
     enum Unresolved: Equatable {

--- a/ArcBox/Integrations/System/LayeredRootFS.swift
+++ b/ArcBox/Integrations/System/LayeredRootFS.swift
@@ -52,12 +52,12 @@ nonisolated struct LayeredRootFS {
         var listings: [[LocalRootFSService.LayerItem]] = []
         var excluded: Set<Int> = []
 
+        let readings = readLayers(relativePath: relativePath, showHiddenFiles: showHiddenFiles)
+
         for (index, layer) in layers.enumerated() {
             let directory = Self.resolve(relativePath, in: layer)
             do {
-                listings.append(
-                    try LocalRootFSService.listLayerItems(
-                        at: directory, showHiddenFiles: showHiddenFiles))
+                listings.append(try readings[index].get())
             } catch {
                 switch Self.fileType(of: directory) {
                 case nil where Self.fileType(of: layer) != nil:
@@ -87,6 +87,36 @@ nonisolated struct LayeredRootFS {
         }
 
         return Listing(entries: Self.merge(listings), excludedLayers: excluded)
+    }
+
+    /// Reads the same relative directory from every layer at once.
+    ///
+    /// The listings are independent, and each is a round trip to the guest
+    /// over NFS, so reading them in sequence would make one directory expand
+    /// cost the stack depth in latency. Ordering is preserved by index, and
+    /// [`listDirectory`] still consumes the results top-down, so truncation
+    /// behaves exactly as it would have sequentially — the only difference is
+    /// that a truncated tail was fetched and then discarded, which is the
+    /// rare path.
+    private func readLayers(
+        relativePath: String,
+        showHiddenFiles: Bool
+    ) -> [Result<[LocalRootFSService.LayerItem], Error>] {
+        let lock = NSLock()
+        var readings: [Int: Result<[LocalRootFSService.LayerItem], Error>] = [:]
+
+        DispatchQueue.concurrentPerform(iterations: layers.count) { index in
+            let directory = Self.resolve(relativePath, in: layers[index])
+            let reading = Result {
+                try LocalRootFSService.listLayerItems(
+                    at: directory, showHiddenFiles: showHiddenFiles)
+            }
+            lock.lock()
+            readings[index] = reading
+            lock.unlock()
+        }
+
+        return layers.indices.map { readings[$0]! }
     }
 
     /// Layer paths mapped onto the export, and how many were left behind.

--- a/ArcBox/Integrations/System/LayeredRootFS.swift
+++ b/ArcBox/Integrations/System/LayeredRootFS.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Browses an overlay layer stack as one merged filesystem.
 ///
@@ -23,9 +24,6 @@ nonisolated struct LayeredRootFS {
         guard !layers.isEmpty else { return nil }
         self.layers = layers
     }
-
-    /// Whether composing is worth it at all: one layer merges to itself.
-    var isComposed: Bool { layers.count > 1 }
 
     /// The merged contents of one directory, plus which layers are missing
     /// from it.
@@ -61,17 +59,29 @@ nonisolated struct LayeredRootFS {
                     try LocalRootFSService.listLayerItems(
                         at: directory, showHiddenFiles: showHiddenFiles))
             } catch {
-                // A layer that is present but simply lacks this path holds no
-                // opinion about it — a whiteout would have to live inside that
-                // very directory — so it is normal and the merge continues.
-                // A layer that is missing outright is unavailable, and its
-                // whiteouts are as unknowable as an unreadable one's.
-                let layerPresent = FileManager.default.fileExists(atPath: layer.path)
-                let pathPresent = FileManager.default.fileExists(atPath: directory.path)
-                if layerPresent && !pathPresent {
+                switch Self.fileType(of: directory) {
+                case nil where Self.fileType(of: layer) != nil:
+                    // The layer is present but simply lacks this path, so it
+                    // holds no opinion about it — a whiteout would have to
+                    // live inside that very directory. Normal; keep merging.
                     continue
+                case .some(let type) where type != S_IFDIR:
+                    // A non-directory shadows everything below it, exactly as
+                    // the kernel would stop merging here. The listing is
+                    // complete, so this is not a gap to report.
+                    return Listing(entries: Self.merge(listings), excludedLayers: excluded)
+                default:
+                    // Either the layer is gone outright or the directory is
+                    // there and will not open. Both leave whiteouts and
+                    // replacements unknowable, so nothing below can be shown.
+                    Log.container.error(
+                        """
+                        layer \(index, privacy: .public) excluded from merge: \
+                        \(error.localizedDescription, privacy: .public)
+                        """
+                    )
+                    excluded.formUnion(index..<layers.count)
                 }
-                excluded.formUnion(index..<layers.count)
                 break
             }
         }
@@ -99,12 +109,15 @@ nonisolated struct LayeredRootFS {
     static func resolveHostLayers(guestPaths: [String]) -> Resolution {
         var hostURLs: [URL] = []
         for guestPath in guestPaths {
+            // Hand back what the check produced: callers would otherwise
+            // repeat the same existence check to standardize the URL, and on
+            // a wedged export that check blocks.
             guard let hostURL = GuestDataMount.hostURL(forGuestPath: guestPath),
-                (try? LocalRootFSService.resolveRootURL(path: hostURL.path)) != nil
+                let resolved = try? LocalRootFSService.resolveRootURL(path: hostURL.path)
             else {
                 break
             }
-            hostURLs.append(hostURL)
+            hostURLs.append(resolved)
         }
         return Resolution(
             hostURLs: hostURLs,
@@ -152,5 +165,15 @@ nonisolated struct LayeredRootFS {
 
     private static func resolve(_ relativePath: String, in layer: URL) -> URL {
         relativePath.isEmpty ? layer : layer.appendingPathComponent(relativePath)
+    }
+
+    /// The `S_IFMT` bits at `url`, or `nil` if nothing is there.
+    ///
+    /// Deliberately `lstat`: a symlink is a non-directory to overlayfs and
+    /// shadows lower layers, and following it here would merge past it.
+    private static func fileType(of url: URL) -> mode_t? {
+        var status = stat()
+        guard lstat(url.path, &status) == 0 else { return nil }
+        return status.st_mode & S_IFMT
     }
 }

--- a/ArcBox/Integrations/System/LocalRootFSService.swift
+++ b/ArcBox/Integrations/System/LocalRootFSService.swift
@@ -105,11 +105,16 @@ nonisolated struct LocalRootFSService {
     }
 
     static func listDirectory(at directoryURL: URL, showHiddenFiles: Bool) throws -> [LocalFileEntry] {
-        try listLayerItems(at: directoryURL, showHiddenFiles: showHiddenFiles).map(\.entry)
+        try listLayerItems(at: directoryURL, showHiddenFiles: showHiddenFiles)
+            .map(\.entry)
+            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
     }
 
     /// Lists a directory keeping the overlay whiteout marker, so a layered
     /// browse can hide both the marker and whatever it deletes underneath.
+    ///
+    /// Unordered: a merge across layers has to sort the union anyway, and
+    /// sorting each layer first would be work thrown away.
     static func listLayerItems(at directoryURL: URL, showHiddenFiles: Bool) throws -> [LayerItem] {
         var coordinatorError: NSError?
         var capturedError: Error?
@@ -161,9 +166,6 @@ nonisolated struct LocalRootFSService {
                         entry: entry,
                         isWhiteout: isWhiteout(entryURL, resourceType: values.fileResourceType)
                     )
-                }
-                .sorted {
-                    $0.entry.name.localizedStandardCompare($1.entry.name) == .orderedAscending
                 }
             } catch {
                 capturedError = error

--- a/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
@@ -10,16 +10,7 @@ struct ContainerFilesTab: View {
     @Environment(\.arcboxClient) private var arcboxClient
 
     @State private var selectedPath: String?
-    @State private var rootURL: URL?
-    @State private var layers: LayeredRootFS?
-    /// Stack layers missing from what was browsed, by index — a set so
-    /// exclusions seen in different directories union instead of collapsing
-    /// to the worst one.
-    @State private var excludedLayerIndices: Set<Int> = []
-    /// Layers whose guest path maps to no exported root: never in the stack,
-    /// so they have no index, but still missing from what the user sees.
-    @State private var unmappableLayerCount = 0
-    @State private var totalLayerCount = 0
+    @State private var stack = LayerStack()
     @State private var errorMessage: String?
     @State private var isLoadingRoot = false
     @State private var refreshToken = UUID()
@@ -56,22 +47,13 @@ struct ContainerFilesTab: View {
                 .font(.system(size: 12))
                 .foregroundStyle(AppColors.textSecondary)
 
-            Text(rootURL?.path ?? container.resolvedRootFSMountPath ?? "No rootfs mount path")
+            Text(stack.rootURL?.path ?? container.resolvedRootFSMountPath ?? "No rootfs mount path")
                 .font(.system(size: 12, design: .monospaced))
                 .foregroundStyle(AppColors.textSecondary)
                 .lineLimit(1)
                 .truncationMode(.middle)
 
-            // Keyed on what the daemon reported, not on the surviving stack:
-            // a stack truncated to a single browsable layer drops `layers`,
-            // and that is exactly when the view is least complete and least
-            // able to say so.
-            if totalLayerCount > 1 {
-                LayerMergeBadge(
-                    total: totalLayerCount,
-                    unavailable: excludedLayerIndices.count + unmappableLayerCount
-                )
-            }
+            LayerMergeBadge(stack: stack)
 
             Spacer()
 
@@ -117,22 +99,17 @@ struct ContainerFilesTab: View {
             }
         } else if let errorMessage {
             errorState(errorMessage)
-        } else if let rootURL {
+        } else if let rootURL = stack.rootURL {
             LocalRootFSOutlineView(
                 rootURL: rootURL,
-                layers: layers,
+                layers: stack.layers,
                 showHiddenFiles: showHiddenFiles,
                 reloadID: outlineReloadID,
                 selectedPath: $selectedPath,
                 onOpenURL: { url in
                     _ = NSWorkspace.shared.open(url)
                 },
-                onExcludedLayers: { indices in
-                    // Union, never replace: a layer dropped once has already
-                    // left holes in what the user browsed, and two
-                    // directories can fail on two different layers.
-                    excludedLayerIndices.formUnion(indices)
-                }
+                onExcludedLayers: { stack.exclude($0) }
             )
         } else {
             errorState("Container has no configured rootfs mount path.")
@@ -181,60 +158,37 @@ struct ContainerFilesTab: View {
         errorMessage = nil
         isLoadingRoot = true
         selectedPath = nil
-        layers = nil
-        excludedLayerIndices = []
-        unmappableLayerCount = 0
-        totalLayerCount = 0
+        stack = LayerStack()
+        defer { isLoadingRoot = false }
 
         // Inspect-provided path (classic graph drivers) is already a merged
         // rootfs; under the containerd image store inspect carries no paths,
         // so the daemon resolves the layer stack and the tab merges it.
-        var guestPaths: [String] = []
+        let guestPaths: [String]
         if let mountPath = container.resolvedRootFSMountPath {
             guestPaths = [mountPath]
         } else {
             guestPaths = await resolveViaDaemon()
         }
 
-        // The resolved paths are guest paths; browse them through ~/ArcBox.
-        // The stack stops at the first layer the host cannot browse: it still
-        // decides what lies beneath it, so merging past it would surface
-        // entries it may replace or delete.
-        // Off the main actor: resolution stats every layer, and those stats
-        // block for as long as a wedged export takes to fail.
-        let resolution = await Task.detached {
-            LayeredRootFS.resolveHostLayers(guestPaths: guestPaths)
-        }.value
-        totalLayerCount = guestPaths.count
-        unmappableLayerCount = resolution.excludedCount
-
-        guard let rootHostURL = resolution.hostURLs.first else {
-            rootURL = nil
+        stack = await LayerStack.resolve(guestPaths: guestPaths)
+        guard stack.rootURL != nil else {
             errorMessage = Self.unresolvedMessage(guestPaths: guestPaths)
-            isLoadingRoot = false
             return
         }
-
-        // Already validated and standardized by the resolution above.
-        rootURL = rootHostURL
-        layers =
-            resolution.hostURLs.count > 1 ? LayeredRootFS(layers: resolution.hostURLs) : nil
         // Listings report further exclusions as they happen — a layer can
         // die after this point — and the badge unions them.
-        isLoadingRoot = false
     }
 
-    /// Why the top layer could not be browsed: a path outside the exported
-    /// roots is a different problem from an export that is not mounted, and
-    /// only the second one is fixed by starting the VM.
     private static func unresolvedMessage(guestPaths: [String]) -> String {
-        guard let first = guestPaths.first else {
+        switch LayerStack.unresolved(guestPaths: guestPaths) {
+        case .noPaths:
             return "Container has no resolvable filesystem path."
-        }
-        guard GuestDataMount.hostURL(forGuestPath: first) != nil else {
+        case .outsideExport:
             return "Container filesystem path is outside the guest data root."
+        case .exportUnavailable:
+            return GuestDataMount.unavailableMessage(subject: "This container's filesystem")
         }
-        return GuestDataMount.unavailableMessage(subject: "This container's filesystem")
     }
 
     /// Resolves the container's snapshot layer stack via the daemon.

--- a/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
@@ -200,31 +200,41 @@ struct ContainerFilesTab: View {
         // The stack stops at the first layer the host cannot browse: it still
         // decides what lies beneath it, so merging past it would surface
         // entries it may replace or delete.
-        let resolution = LayeredRootFS.resolveHostLayers(guestPaths: guestPaths)
-        let hostURLs = resolution.hostURLs
+        // Off the main actor: resolution stats every layer, and those stats
+        // block for as long as a wedged export takes to fail.
+        let resolution = await Task.detached {
+            LayeredRootFS.resolveHostLayers(guestPaths: guestPaths)
+        }.value
         totalLayerCount = guestPaths.count
         unmappableLayerCount = resolution.excludedCount
-        guard let rootHostURL = hostURLs.first else {
+
+        guard let rootHostURL = resolution.hostURLs.first else {
             rootURL = nil
-            errorMessage =
-                guestPaths.isEmpty
-                ? "Container has no resolvable filesystem path."
-                : "Container filesystem path is outside the guest data root."
+            errorMessage = Self.unresolvedMessage(guestPaths: guestPaths)
             isLoadingRoot = false
             return
         }
 
-        do {
-            rootURL = try LocalRootFSService.resolveRootURL(path: rootHostURL.path)
-            layers = hostURLs.count > 1 ? LayeredRootFS(layers: hostURLs) : nil
-            // Listings report further exclusions as they happen — a layer can
-            // die after this point — and the badge unions them.
-        } catch {
-            rootURL = nil
-            errorMessage = GuestDataMount.unavailableMessage(subject: "This container's filesystem")
-        }
-
+        // Already validated and standardized by the resolution above.
+        rootURL = rootHostURL
+        layers =
+            resolution.hostURLs.count > 1 ? LayeredRootFS(layers: resolution.hostURLs) : nil
+        // Listings report further exclusions as they happen — a layer can
+        // die after this point — and the badge unions them.
         isLoadingRoot = false
+    }
+
+    /// Why the top layer could not be browsed: a path outside the exported
+    /// roots is a different problem from an export that is not mounted, and
+    /// only the second one is fixed by starting the VM.
+    private static func unresolvedMessage(guestPaths: [String]) -> String {
+        guard let first = guestPaths.first else {
+            return "Container has no resolvable filesystem path."
+        }
+        guard GuestDataMount.hostURL(forGuestPath: first) != nil else {
+            return "Container filesystem path is outside the guest data root."
+        }
+        return GuestDataMount.unavailableMessage(subject: "This container's filesystem")
     }
 
     /// Resolves the container's snapshot layer stack via the daemon.

--- a/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
@@ -62,9 +62,13 @@ struct ContainerFilesTab: View {
                 .lineLimit(1)
                 .truncationMode(.middle)
 
-            if let layers, layers.isComposed {
+            // Keyed on what the daemon reported, not on the surviving stack:
+            // a stack truncated to a single browsable layer drops `layers`,
+            // and that is exactly when the view is least complete and least
+            // able to say so.
+            if totalLayerCount > 1 {
                 LayerMergeBadge(
-                    total: max(totalLayerCount, layers.layers.count),
+                    total: totalLayerCount,
                     unavailable: excludedLayerIndices.count + unmappableLayerCount
                 )
             }

--- a/ArcBox/Views/Containers/Tabs/LayerMergeBadge.swift
+++ b/ArcBox/Views/Containers/Tabs/LayerMergeBadge.swift
@@ -33,8 +33,10 @@ struct LayerMergeBadge: View {
         )
     }
 
-    private var label: String {
-        isComplete
+    private var label: String { Self.label(total: total, unavailable: unavailable) }
+
+    static func label(total: Int, unavailable: Int) -> String {
+        unavailable == 0
             ? "merged from \(total) layers"
             : "merged from \(total - unavailable) of \(total) layers"
     }

--- a/ArcBox/Views/Containers/Tabs/LayerMergeBadge.swift
+++ b/ArcBox/Views/Containers/Tabs/LayerMergeBadge.swift
@@ -8,25 +8,24 @@ import SwiftUI
 /// it were complete — files unique to that layer, and the deletions it
 /// records, simply would not appear.
 struct LayerMergeBadge: View {
-    let total: Int
-    let unavailable: Int
+    private let total: Int
+    private let unavailable: Int
+    private let describesAStack: Bool
 
-    /// Describes a browsed stack. Renders nothing for a subject that has a
-    /// single layer, since there is nothing to be incomplete about.
+    /// Describes a browsed stack, and renders nothing when there is no stack
+    /// to describe — a single-layer subject, or one that could not be
+    /// browsed at all.
     init(stack: LayerStack) {
-        self.init(total: stack.reportedLayers, unavailable: stack.missingLayers)
-    }
-
-    init(total: Int, unavailable: Int) {
-        self.total = total
-        self.unavailable = unavailable
+        total = stack.reportedLayers
+        unavailable = stack.missingLayers
+        describesAStack = stack.describesAStack
     }
 
     private var isComplete: Bool { unavailable == 0 }
 
     @ViewBuilder
     var body: some View {
-        if total > 1 {
+        if describesAStack {
             badge
         }
     }

--- a/ArcBox/Views/Containers/Tabs/LayerMergeBadge.swift
+++ b/ArcBox/Views/Containers/Tabs/LayerMergeBadge.swift
@@ -11,9 +11,27 @@ struct LayerMergeBadge: View {
     let total: Int
     let unavailable: Int
 
+    /// Describes a browsed stack. Renders nothing for a subject that has a
+    /// single layer, since there is nothing to be incomplete about.
+    init(stack: LayerStack) {
+        self.init(total: stack.reportedLayers, unavailable: stack.missingLayers)
+    }
+
+    init(total: Int, unavailable: Int) {
+        self.total = total
+        self.unavailable = unavailable
+    }
+
     private var isComplete: Bool { unavailable == 0 }
 
+    @ViewBuilder
     var body: some View {
+        if total > 1 {
+            badge
+        }
+    }
+
+    private var badge: some View {
         HStack(spacing: 4) {
             if !isComplete {
                 Image(systemName: "exclamationmark.triangle.fill")

--- a/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
+++ b/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
@@ -214,17 +214,27 @@ struct ImageFilesTab: View {
             // The stack stops at the first layer the host cannot browse: it
             // still decides what lies beneath it, so merging past it would
             // surface entries it may replace or delete.
-            let resolution = LayeredRootFS.resolveHostLayers(guestPaths: mountPoints)
-            let hostURLs = resolution.hostURLs
+            // Off the main actor: resolution stats every layer, and those
+            // stats block for as long as a wedged export takes to fail.
+            let resolution = await Task.detached {
+                LayeredRootFS.resolveHostLayers(guestPaths: mountPoints)
+            }.value
             totalLayerCount = mountPoints.count
             unmappableLayerCount = resolution.excludedCount
-            guard let rootHostURL = hostURLs.first else {
-                errorMessage = "Image layer path is outside the guest data root."
+
+            guard let rootHostURL = resolution.hostURLs.first else {
+                errorMessage =
+                    mountPoints.first.flatMap(GuestDataMount.hostURL(forGuestPath:)) == nil
+                    ? "Image layer path is outside the guest data root."
+                    : GuestDataMount.unavailableMessage(subject: "This image's layers")
                 isLoadingRoot = false
                 return
             }
-            rootURL = try LocalRootFSService.resolveRootURL(path: rootHostURL.path)
-            layers = hostURLs.count > 1 ? LayeredRootFS(layers: hostURLs) : nil
+
+            // Already validated and standardized by the resolution above.
+            rootURL = rootHostURL
+            layers =
+                resolution.hostURLs.count > 1 ? LayeredRootFS(layers: resolution.hostURLs) : nil
             // Listings report further exclusions as they happen — a layer can
             // die after this point — and the badge unions them.
         } catch let error as ImageFilesTabError {

--- a/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
+++ b/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
@@ -28,16 +28,7 @@ struct ImageFilesTab: View {
     @Environment(\.arcboxClient) private var arcboxClient
 
     @State private var selectedPath: String?
-    @State private var rootURL: URL?
-    @State private var layers: LayeredRootFS?
-    /// Stack layers missing from what was browsed, by index — a set so
-    /// exclusions seen in different directories union instead of collapsing
-    /// to the worst one.
-    @State private var excludedLayerIndices: Set<Int> = []
-    /// Layers whose guest path maps to no exported root: never in the stack,
-    /// so they have no index, but still missing from what the user sees.
-    @State private var unmappableLayerCount = 0
-    @State private var totalLayerCount = 0
+    @State private var stack = LayerStack()
     @State private var resolvedRootFSMountPath: String?
     @State private var errorMessage: String?
     @State private var isLoadingRoot = false
@@ -79,22 +70,13 @@ struct ImageFilesTab: View {
                 .font(.system(size: 12))
                 .foregroundStyle(AppColors.textSecondary)
 
-            Text(rootURL?.path ?? resolvedRootFSMountPath ?? "No rootfs mount path")
+            Text(stack.rootURL?.path ?? resolvedRootFSMountPath ?? "No rootfs mount path")
                 .font(.system(size: 12, design: .monospaced))
                 .foregroundStyle(AppColors.textSecondary)
                 .lineLimit(1)
                 .truncationMode(.middle)
 
-            // Keyed on what the daemon reported, not on the surviving stack:
-            // a stack truncated to a single browsable layer drops `layers`,
-            // and that is exactly when the view is least complete and least
-            // able to say so.
-            if totalLayerCount > 1 {
-                LayerMergeBadge(
-                    total: totalLayerCount,
-                    unavailable: excludedLayerIndices.count + unmappableLayerCount
-                )
-            }
+            LayerMergeBadge(stack: stack)
 
             Spacer()
 
@@ -140,22 +122,17 @@ struct ImageFilesTab: View {
             }
         } else if let errorMessage {
             errorState(errorMessage)
-        } else if let rootURL {
+        } else if let rootURL = stack.rootURL {
             LocalRootFSOutlineView(
                 rootURL: rootURL,
-                layers: layers,
+                layers: stack.layers,
                 showHiddenFiles: showHiddenFiles,
                 reloadID: outlineReloadID,
                 selectedPath: $selectedPath,
                 onOpenURL: { url in
                     _ = NSWorkspace.shared.open(url)
                 },
-                onExcludedLayers: { indices in
-                    // Union, never replace: a layer dropped once has already
-                    // left holes in what the user browsed, and two
-                    // directories can fail on two different layers.
-                    excludedLayerIndices.formUnion(indices)
-                }
+                onExcludedLayers: { stack.exclude($0) }
             )
         } else {
             errorState("Image has no configured rootfs mount path.")
@@ -201,40 +178,19 @@ struct ImageFilesTab: View {
         errorMessage = nil
         isLoadingRoot = true
         selectedPath = nil
-        rootURL = nil
-        layers = nil
-        excludedLayerIndices = []
-        unmappableLayerCount = 0
-        totalLayerCount = 0
+        stack = LayerStack()
 
         do {
             // The layer directories are guest paths; browse them via ~/ArcBox.
             let mountPoints = try await resolveImageLayerPaths()
             resolvedRootFSMountPath = mountPoints.first
-            // The stack stops at the first layer the host cannot browse: it
-            // still decides what lies beneath it, so merging past it would
-            // surface entries it may replace or delete.
-            // Off the main actor: resolution stats every layer, and those
-            // stats block for as long as a wedged export takes to fail.
-            let resolution = await Task.detached {
-                LayeredRootFS.resolveHostLayers(guestPaths: mountPoints)
-            }.value
-            totalLayerCount = mountPoints.count
-            unmappableLayerCount = resolution.excludedCount
 
-            guard let rootHostURL = resolution.hostURLs.first else {
-                errorMessage =
-                    mountPoints.first.flatMap(GuestDataMount.hostURL(forGuestPath:)) == nil
-                    ? "Image layer path is outside the guest data root."
-                    : GuestDataMount.unavailableMessage(subject: "This image's layers")
+            stack = await LayerStack.resolve(guestPaths: mountPoints)
+            guard stack.rootURL != nil else {
+                errorMessage = Self.unresolvedMessage(guestPaths: mountPoints)
                 isLoadingRoot = false
                 return
             }
-
-            // Already validated and standardized by the resolution above.
-            rootURL = rootHostURL
-            layers =
-                resolution.hostURLs.count > 1 ? LayeredRootFS(layers: resolution.hostURLs) : nil
             // Listings report further exclusions as they happen — a layer can
             // die after this point — and the badge unions them.
         } catch let error as ImageFilesTabError {
@@ -245,6 +201,15 @@ struct ImageFilesTab: View {
         }
 
         isLoadingRoot = false
+    }
+
+    private static func unresolvedMessage(guestPaths: [String]) -> String {
+        switch LayerStack.unresolved(guestPaths: guestPaths) {
+        case .noPaths, .outsideExport:
+            return "Image layer path is outside the guest data root."
+        case .exportUnavailable:
+            return GuestDataMount.unavailableMessage(subject: "This image's layers")
+        }
     }
 
     private func resolveImageLayerPaths() async throws -> [String] {

--- a/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
+++ b/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
@@ -85,9 +85,13 @@ struct ImageFilesTab: View {
                 .lineLimit(1)
                 .truncationMode(.middle)
 
-            if let layers, layers.isComposed {
+            // Keyed on what the daemon reported, not on the surviving stack:
+            // a stack truncated to a single browsable layer drops `layers`,
+            // and that is exactly when the view is least complete and least
+            // able to say so.
+            if totalLayerCount > 1 {
                 LayerMergeBadge(
-                    total: max(totalLayerCount, layers.layers.count),
+                    total: totalLayerCount,
                     unavailable: excludedLayerIndices.count + unmappableLayerCount
                 )
             }

--- a/ArcBoxTests/LayerStackTests.swift
+++ b/ArcBoxTests/LayerStackTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+
+@testable import ArcBox
+
+final class LayerStackTests: XCTestCase {
+    func testFreshStackDescribesNothing() {
+        let stack = LayerStack()
+
+        XCTAssertNil(stack.rootURL)
+        XCTAssertNil(stack.layers)
+        XCTAssertFalse(stack.describesAStack)
+        XCTAssertEqual(stack.missingLayers, 0)
+    }
+
+    func testSingleLayerSubjectDescribesNoStack() async {
+        // Nothing to be incomplete about, so nothing to tell the user.
+        let stack = await LayerStack.resolve(guestPaths: ["/var/lib/docker/volumes"])
+
+        XCTAssertNotNil(stack.rootURL)
+        XCTAssertNil(stack.layers)
+        XCTAssertFalse(stack.describesAStack)
+        XCTAssertEqual(stack.missingLayers, 0)
+    }
+
+    func testTruncationToASingleLayerStillDescribesTheStack() async {
+        // The case the badge used to go silent on: one browsable layer left,
+        // so there is no merged stack to hang a warning off — but most of the
+        // filesystem is missing and the user has to be told.
+        let stack = await LayerStack.resolve(guestPaths: [
+            "/var/lib/docker/volumes",
+            "/somewhere/else/layer1",
+            "/somewhere/else/layer2",
+        ])
+
+        XCTAssertNotNil(stack.rootURL)
+        XCTAssertTrue(stack.describesAStack)
+        XCTAssertEqual(stack.reportedLayers, 3)
+        XCTAssertEqual(stack.missingLayers, 2)
+    }
+
+    func testExclusionsUnionAcrossListings() {
+        // Two directories failing on two different layers are two layers with
+        // holes; keeping the worst single count would report one.
+        var stack = LayerStack()
+        stack.exclude([0])
+        stack.exclude([2])
+        stack.exclude([0])
+
+        XCTAssertEqual(stack.excludedIndices, [0, 2])
+        XCTAssertEqual(stack.missingLayers, 2)
+    }
+
+    func testUnresolvedDistinguishesPathProblemsFromAMissingExport() {
+        XCTAssertEqual(LayerStack.unresolved(guestPaths: []), .noPaths)
+        // Outside the exported roots: a path problem, no VM restart will fix.
+        XCTAssertEqual(
+            LayerStack.unresolved(guestPaths: ["/somewhere/else"]), .outsideExport)
+        // Maps fine but is not there: the export is not mounted.
+        XCTAssertEqual(
+            LayerStack.unresolved(guestPaths: ["/var/lib/docker/definitely-absent-\(UUID())"]),
+            .exportUnavailable)
+    }
+}

--- a/ArcBoxTests/LayerStackTests.swift
+++ b/ArcBoxTests/LayerStackTests.swift
@@ -60,4 +60,18 @@ final class LayerStackTests: XCTestCase {
             LayerStack.unresolved(guestPaths: ["/var/lib/docker/definitely-absent-\(UUID())"]),
             .exportUnavailable)
     }
+
+    func testAnUnbrowsableStackDescribesNothing() async {
+        // Nothing was merged, so a badge reading "merged from 0 of 2 layers"
+        // beside the unresolved-filesystem error would state something that
+        // did not happen.
+        let stack = await LayerStack.resolve(guestPaths: [
+            "/somewhere/else/upper",
+            "/somewhere/else/lower",
+        ])
+
+        XCTAssertNil(stack.rootURL)
+        XCTAssertEqual(stack.reportedLayers, 2)
+        XCTAssertFalse(stack.describesAStack)
+    }
 }

--- a/ArcBoxTests/LayeredRootFSTests.swift
+++ b/ArcBoxTests/LayeredRootFSTests.swift
@@ -360,4 +360,24 @@ final class LayeredRootFSTests: XCTestCase {
         XCTAssertEqual(listing.entries.map(\.name), [])
         XCTAssertEqual(listing.excludedLayers, [1, 2])
     }
+
+    func testResolveHostLayersCanTruncateToASingleSurvivor() {
+        // The case the badge used to go silent on: the stack collapses to one
+        // browsable layer, so there is no composed stack left to hang a
+        // warning off — but four fifths of the filesystem is missing.
+        let resolution = LayeredRootFS.resolveHostLayers(guestPaths: [
+            "/var/lib/docker/volumes",
+            "/somewhere/else/layer1",
+            "/somewhere/else/layer2",
+        ])
+
+        XCTAssertEqual(resolution.hostURLs.count, 1)
+        XCTAssertEqual(resolution.excludedCount, 2)
+    }
+
+    func testBadgeLabelReportsPartialMerges() {
+        XCTAssertEqual(LayerMergeBadge.label(total: 5, unavailable: 0), "merged from 5 layers")
+        XCTAssertEqual(
+            LayerMergeBadge.label(total: 5, unavailable: 4), "merged from 1 of 5 layers")
+    }
 }

--- a/ArcBoxTests/LayeredRootFSTests.swift
+++ b/ArcBoxTests/LayeredRootFSTests.swift
@@ -5,6 +5,23 @@ import XCTest
 final class LayeredRootFSTests: XCTestCase {
     // MARK: merge precedence
 
+    /// Creates a directory that exists but cannot be listed — the real
+    /// "the layer is there and will not open" condition.
+    ///
+    /// A regular file standing in for a directory does NOT reproduce it: that
+    /// is ordinary overlay shadowing, which the merge is supposed to accept
+    /// silently, so using one here would assert the opposite of the intent.
+    private func makeUnreadableDirectory(at url: URL) throws {
+        try XCTSkipIf(getuid() == 0, "permissions do not restrict root")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o000], ofItemAtPath: url.path)
+        addTeardownBlock {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o755], ofItemAtPath: url.path)
+        }
+    }
+
     private func item(
         _ name: String, isWhiteout: Bool = false, layer: String = "l"
     )
@@ -110,11 +127,6 @@ final class LayeredRootFSTests: XCTestCase {
         XCTAssertNil(LayeredRootFS(layers: []))
     }
 
-    func testSingleLayerIsNotComposed() throws {
-        let stack = try XCTUnwrap(LayeredRootFS(layers: [URL(fileURLWithPath: "/mnt/only")]))
-        XCTAssertFalse(stack.isComposed)
-    }
-
     // MARK: on-disk merge
 
     func testListDirectoryMergesRealDirectories() throws {
@@ -209,8 +221,7 @@ final class LayeredRootFSTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: root) }
 
         try "x".write(to: good.appendingPathComponent("hosts"), atomically: true, encoding: .utf8)
-        try "not a directory".write(
-            to: root.appendingPathComponent("broken/etc"), atomically: true, encoding: .utf8)
+        try makeUnreadableDirectory(at: root.appendingPathComponent("broken/etc"))
 
         let stack = try XCTUnwrap(
             LayeredRootFS(layers: [
@@ -240,9 +251,9 @@ final class LayeredRootFSTests: XCTestCase {
             at: b.appendingPathComponent("etc"), withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
-        // Each layer has one path that exists but cannot be listed.
-        try "x".write(to: a.appendingPathComponent("etc"), atomically: true, encoding: .utf8)
-        try "x".write(to: b.appendingPathComponent("opt"), atomically: true, encoding: .utf8)
+        // Each layer has one directory that exists but cannot be listed.
+        try makeUnreadableDirectory(at: a.appendingPathComponent("etc"))
+        try makeUnreadableDirectory(at: b.appendingPathComponent("opt"))
 
         let stack = try XCTUnwrap(LayeredRootFS(layers: [a, b]))
 
@@ -267,7 +278,7 @@ final class LayeredRootFSTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: root) }
 
         // `etc` exists in the upper layer but will not list.
-        try "x".write(to: upper.appendingPathComponent("etc"), atomically: true, encoding: .utf8)
+        try makeUnreadableDirectory(at: upper.appendingPathComponent("etc"))
         try "stale".write(
             to: lower.appendingPathComponent("passwd"), atomically: true, encoding: .utf8)
 
@@ -293,7 +304,7 @@ final class LayeredRootFSTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: root) }
 
         try "top".write(to: top.appendingPathComponent("hosts"), atomically: true, encoding: .utf8)
-        try "x".write(to: mid.appendingPathComponent("etc"), atomically: true, encoding: .utf8)
+        try makeUnreadableDirectory(at: mid.appendingPathComponent("etc"))
         try "bottom".write(
             to: bottom.appendingPathComponent("resolv.conf"), atomically: true, encoding: .utf8)
 
@@ -379,5 +390,65 @@ final class LayeredRootFSTests: XCTestCase {
         XCTAssertEqual(LayerMergeBadge.label(total: 5, unavailable: 0), "merged from 5 layers")
         XCTAssertEqual(
             LayerMergeBadge.label(total: 5, unavailable: 4), "merged from 1 of 5 layers")
+    }
+
+    // MARK: browsing composition
+
+    func testExpandingAMergedDirectoryMergesAcrossEveryLayer() throws {
+        // The seam the outline depends on and nothing covered: a directory
+        // node carries the URL of whichever layer won it, so expanding it has
+        // to go back through the stack rather than list that layer alone.
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let upper = root.appendingPathComponent("upper/etc", isDirectory: true)
+        let lower = root.appendingPathComponent("lower/etc", isDirectory: true)
+        try FileManager.default.createDirectory(at: upper, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: lower, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try "u".write(to: upper.appendingPathComponent("hosts"), atomically: true, encoding: .utf8)
+        try "l".write(
+            to: lower.appendingPathComponent("resolv.conf"), atomically: true, encoding: .utf8)
+
+        let stack = try XCTUnwrap(
+            LayeredRootFS(layers: [
+                root.appendingPathComponent("upper", isDirectory: true),
+                root.appendingPathComponent("lower", isDirectory: true),
+            ]))
+
+        let rootListing = stack.listDirectory(relativePath: "", showHiddenFiles: false)
+        let etc = try XCTUnwrap(rootListing.entries.first { $0.name == "etc" })
+        // `etc` was won by the upper layer, whose copy holds only `hosts`.
+        let relativePath = try XCTUnwrap(stack.relativePath(forHostURL: etc.url))
+        let children = stack.listDirectory(relativePath: relativePath, showHiddenFiles: false)
+
+        XCTAssertEqual(relativePath, "etc")
+        XCTAssertEqual(children.entries.map(\.name), ["hosts", "resolv.conf"])
+    }
+
+    func testNonDirectoryInALowerLayerIsShadowedWithoutWarning() throws {
+        // An upper directory over a lower file is ordinary overlay shadowing:
+        // the merge stops there because the file hides everything beneath it,
+        // and reporting that as an excluded layer would cry wolf.
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let upperFoo = root.appendingPathComponent("upper/foo", isDirectory: true)
+        let lower = root.appendingPathComponent("lower", isDirectory: true)
+        try FileManager.default.createDirectory(at: upperFoo, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: lower, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try "u".write(to: upperFoo.appendingPathComponent("inside"), atomically: true, encoding: .utf8)
+        try "shadowed".write(
+            to: lower.appendingPathComponent("foo"), atomically: true, encoding: .utf8)
+
+        let stack = try XCTUnwrap(
+            LayeredRootFS(layers: [
+                root.appendingPathComponent("upper", isDirectory: true), lower,
+            ]))
+        let listing = stack.listDirectory(relativePath: "foo", showHiddenFiles: false)
+
+        XCTAssertEqual(listing.entries.map(\.name), ["inside"])
+        XCTAssertEqual(listing.excludedLayers, [])
     }
 }


### PR DESCRIPTION
Follow-up to #331: the badge gap its Greptile summary flagged after merge, plus the findings from a deeper review pass over the merged work.

## 1. Badge went silent exactly when the view was least complete

The badge was gated on the composed stack, but truncation can collapse the stack to one layer, and `layers = hostURLs.count > 1 ? … : nil` then discards it. Daemon reports 5 layers → layer 1 unbrowsable → 1 survivor → `layers == nil` → **no badge**. So 4-of-5 merged warned and 1-of-5 said nothing. Keyed on the layer count the daemon reported instead; a genuinely single-layer subject still shows nothing.

## 2. Ordinary overlay shadowing was reported as a failure

A lower layer holding a **non-directory** where an upper layer has a directory is not an error — the kernel stops merging there too, because the non-directory shadows everything below. The merge already produced the right entries, but it counted the layer as excluded, so the warning fired on images where a path changes type between layers. Classified by `lstat` now: a non-directory ends the merge silently, only a directory that will not open is a gap.

`lstat`, not `fileExists`, because a symlink shadows lower layers the same way and following it would merge past it.

## 3. Layer resolution blocked the main actor, once per layer

`resolveHostLayers` stats every layer, and on a wedged export each stat blocks until NFS gives up (`deadtimeout=60`). The single check this replaced was already that hazard; doing it per layer multiplied it by stack depth. Now resolved detached, and it hands back the URL it validated so the caller stops re-checking the same path.

## 4. Smaller

- An unresolvable stack always blamed the guest path for being outside the exported roots, even when the real cause was an unmounted export — different problem, different user fix.
- `isComposed` lost its last caller in (1) and is removed.
- `ImageFilesTab` indexed `mountPoints[0]` on a non-emptiness guarantee held a function away.
- Genuine layer failures are now logged; previously a feature built around "some layers are unreadable" had no diagnostics for *why*.

## 5. The test-fixture error, which is the finding I would want reviewed hardest

Four tests stood a **regular file** where a directory was expected, to simulate an unreadable layer. That is precisely the shadowing case in (2) — so once it was classified correctly, those tests failed. They had been asserting the opposite of their stated intent and passing for the wrong reason.

They now `chmod 000` a real directory, which is the condition they describe, and skip under root. Also adds the seam the outline depends on and nothing covered: expanding a merged directory re-derives its relative path and merges across every layer.

---

## 6. Maintainability: one owner for the layer stack

Both tabs kept their own copy of the layer state — four properties, the badge condition, the exclusion union, the resolution and its error classification. The soundness rules the merge depends on have to hold in both, and two copies is how one of them silently stops holding: findings (1) and (2) above were the same defect at two entry points, fixed once and missed once.

`LayerStack` owns that half now; the tabs keep what actually differs (asking the daemon about a container versus computing an image layer chain). The badge decides for itself whether there is a stack worth describing, so that condition cannot drift between call sites again.

## 7. Latency: layers are read in parallel

Each layer listing is a round trip to the guest over NFS, so reading them in sequence made one directory expand cost the stack depth in latency — up to ~20 round trips for a large image. They are now read at once and consumed in order exactly as before, so truncation behaves identically; the only difference is that a truncated tail was fetched and discarded, which is the rare path.

Per-layer sorting went with it: the merge sorts the union anyway, so sorting each layer first was work thrown away.

## Not fixed, and not fixable here: opaque directories

An upper layer can mark a directory *opaque* — "ignore every lower version of this" — and overlayfs records that in a `trusted.overlay.*` xattr. The export is NFSv4.0, which has no xattr support at all (RFC 8276 is 4.2), and `trusted.*` would not reach an unprivileged client regardless. So the host cannot see opacity, and a directory an upper layer replaced wholesale still shows the entries it shadowed.

This is the one place the merge knowingly violates its own rule ("when we cannot know, do not show"), because applying that rule here would mean refusing to merge under *any* directory present in an upper layer — which is the normal case, and would gut the feature. Closing it needs guest-side data: either the agent reporting opacity per directory over the existing resolve RPC, or ABX-424 kernel-composed export making the question moot. Documented at the type.

## Validation

**147 tests, 0 failures**; swiftlint + `swift-format --strict` clean.

Refs ABX-425, #331.