### PR TITLE
fix(ui): keep the content column wider than its toolbar section

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		9E79E2BBA05690D9ECAED2CD /* SortMenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97E7E52D3A54846906EB064D /* SortMenuButton.swift */; };
 		9EAE5E0BF3CB9432D7A228C2 /* ContainersListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA69DFAC30647687529C962A /* ContainersListView.swift */; };
 		A03ACBF5074B007C8CD7B101 /* StartupProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32115BE04C97CECA9C05A273 /* StartupProgressView.swift */; };
+		A537498E1D8181BB0230E199 /* ContentViewColumnLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E377F9D8C89E24989DE3D /* ContentViewColumnLayoutTests.swift */; };
 		A75C60F77B89D7AEE365BC2E /* VolumeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF2337ED21F8382F7ABB29A /* VolumeModel.swift */; };
 		A9E1DA5DBCAC015D9C41FF18 /* SandboxesViewModel+Snapshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2D773B0312F0D5695D0ADA /* SandboxesViewModel+Snapshots.swift */; };
 		AA6D71D441665D617EC4597A /* TemplatesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591B3B9F3D3A0B5C43EC7B55 /* TemplatesViewModel.swift */; };
@@ -432,6 +433,7 @@
 		DAE5A29026FA64A7C0A47122 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		DBEBBF08F0E4AC45D9C0BB83 /* ChangelogParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangelogParser.swift; sourceTree = "<group>"; };
 		DE564AAFEC0EF6D094409728 /* SandboxRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxRowView.swift; sourceTree = "<group>"; };
+		DE7E377F9D8C89E24989DE3D /* ContentViewColumnLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewColumnLayoutTests.swift; sourceTree = "<group>"; };
 		DF34CA0688377F7956F2FD3D /* NewSandboxSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSandboxSheet.swift; sourceTree = "<group>"; };
 		E06B22BB8B92AF78C2B87ADC /* AboutView+LinkButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AboutView+LinkButton.swift"; sourceTree = "<group>"; };
 		E18EB65626D97DF7604580DF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -1039,6 +1041,7 @@
 				1DC5F65FECB2F80BA3AF1D84 /* ArcBoxClientErrorTests.swift */,
 				A10ED4BA65D6B9CC56B6B329 /* ChangelogParserTests.swift */,
 				E610512C9106BB92A47DC044 /* ContainersViewModelTests.swift */,
+				DE7E377F9D8C89E24989DE3D /* ContentViewColumnLayoutTests.swift */,
 				F5B3B3C54B6D49C6198E9E26 /* DeepLinkTests.swift */,
 				06DFFB59D72F27F14A233B81 /* DockerEventMonitorTests.swift */,
 				27130DDA57D2645C7E81D75D /* GuestDataMountTests.swift */,
@@ -1412,6 +1415,7 @@
 				C94515858BC220B73B93EC5D /* ArcBoxClientErrorTests.swift in Sources */,
 				31474CB365691C57A5568D14 /* ChangelogParserTests.swift in Sources */,
 				4D2029E55A7979B8BD9EE89A /* ContainersViewModelTests.swift in Sources */,
+				A537498E1D8181BB0230E199 /* ContentViewColumnLayoutTests.swift in Sources */,
 				EE2D38BC76500BF768EEE20F /* DeepLinkTests.swift in Sources */,
 				8466B000B68A87CEECA6756F /* DockerEventMonitorTests.swift in Sources */,
 				D2AB4B6BF0723EE12A0DBC83 /* GuestDataMountTests.swift in Sources */,

--- a/ArcBox/Views/ContentView.swift
+++ b/ArcBox/Views/ContentView.swift
@@ -1,6 +1,30 @@
 import ArcBoxClient
 import SwiftUI
 
+/// Column geometry for the main window's three-column layout.
+///
+/// The window toolbar reserves one section for the content column — its
+/// navigation title and subtitle plus its `.primaryAction` items — ending at
+/// the split-view tracking separator. AppKit will not compress that section
+/// below its intrinsic width. If the column is allowed to be narrower, the
+/// separator stops following the split divider and the list's toolbar buttons
+/// render over the detail column instead of over the list they act on.
+///
+/// The section's intrinsic width is driven by the item count, not by the title
+/// text (measured identical for a one-character, a 39-character and a CJK
+/// title). On macOS 26: one item 212pt, two items 270pt, three items 316pt.
+/// `contentMin` clears the two-item case the widest list columns ship today.
+///
+/// Adding a third `.primaryAction` item to any list column would exceed
+/// `contentMin` — raise it alongside, and let
+/// `ContentViewColumnLayoutTests` confirm the new value.
+enum ColumnWidth {
+    static let sidebar: CGFloat = 180
+    static let contentMin: CGFloat = 280
+    static let contentIdeal: CGFloat = 320
+    static let contentMax: CGFloat = 600
+}
+
 struct ContentView: View {
     @Environment(AppViewModel.self) private var appVM
 
@@ -33,12 +57,16 @@ struct ContentView: View {
             // `(min:ideal:max:)` one across sibling branches makes the column
             // width latch near 0 on navigation, collapsing the list content to
             // one-character-per-line text (Activity/Templates collapse to 0).
+            //
+            // `ideal` only applies on a first launch: afterwards the split
+            // position is restored from the window's autosaved state, so `min`
+            // is what actually guarantees toolbar alignment. See `ColumnWidth`.
             contentColumn
                 .background(AppColors.background)
                 .navigationSplitViewColumnWidth(
-                    min: isContentColumnCollapsed ? 0 : 150,
-                    ideal: isContentColumnCollapsed ? 0 : 320,
-                    max: isContentColumnCollapsed ? 0 : 600
+                    min: isContentColumnCollapsed ? 0 : ColumnWidth.contentMin,
+                    ideal: isContentColumnCollapsed ? 0 : ColumnWidth.contentIdeal,
+                    max: isContentColumnCollapsed ? 0 : ColumnWidth.contentMax
                 )
         } detail: {
             detailPanel
@@ -96,7 +124,7 @@ struct ContentView: View {
         .safeAreaInset(edge: .bottom, spacing: 0) {
             SidebarAccountButton()
         }
-        .navigationSplitViewColumnWidth(180)
+        .navigationSplitViewColumnWidth(ColumnWidth.sidebar)
     }
 
     /// Sections rendered full-width in the detail column collapse the content

--- a/ArcBoxTests/ContentViewColumnLayoutTests.swift
+++ b/ArcBoxTests/ContentViewColumnLayoutTests.swift
@@ -12,6 +12,11 @@ import XCTest
 /// section with the split divider, so the list's sort/add buttons end up
 /// floating over the detail column. Adding a third `.primaryAction` item to a
 /// list column is what would break this.
+///
+/// Measured against the real window — the unit-test host is the app itself —
+/// because the geometry only reproduces in a SwiftUI `Scene`: the same view
+/// hierarchy in an `NSHostingController` clips overflowing toolbar items
+/// instead of letting them overhang, and so cannot show the defect.
 @MainActor
 final class ContentViewColumnLayoutTests: XCTestCase {
 
@@ -84,19 +89,26 @@ final class ContentViewColumnLayoutTests: XCTestCase {
 
     private func mainWindow() throws -> NSWindow {
         let deadline = Date().addingTimeInterval(10)
-        while Date() < deadline {
-            if let window = NSApp.windows.first(where: {
+        var found: NSWindow?
+        while found == nil, Date() < deadline {
+            found = NSApp.windows.first {
                 $0.toolbar != nil && findSplitView(in: $0.contentView) != nil
-            }) {
-                // Toolbar item views are only realized for an on-screen window.
-                window.makeKeyAndOrderFront(nil)
-                pumpRunLoop()
-                return window
             }
-            pumpRunLoop()
+            if found == nil { pumpRunLoop() }
         }
-        throw XCTSkip(
-            "main window with a toolbar never appeared — this environment cannot host it")
+
+        let window = try XCTUnwrap(
+            found,
+            """
+            the app's main window never appeared, so nothing was measured. This is a \
+            failure, not a reason to skip: GitHub's macos runners do host the window \
+            (verified — the assertions run there in under a second), so an environment \
+            that cannot needs this test reworked rather than silenced.
+            """)
+        // Toolbar item views are only realized for an on-screen window.
+        window.makeKeyAndOrderFront(nil)
+        pumpRunLoop()
+        return window
     }
 
     private func findSplitView(in view: NSView?) -> NSSplitView? {

--- a/ArcBoxTests/ContentViewColumnLayoutTests.swift
+++ b/ArcBoxTests/ContentViewColumnLayoutTests.swift
@@ -1,0 +1,117 @@
+import AppKit
+import XCTest
+
+@testable import ArcBox
+
+/// Guards the invariant behind `ColumnWidth.contentMin`: at the narrowest the
+/// content column is allowed to be, its toolbar items must still sit over the
+/// column itself.
+///
+/// The window toolbar cannot compress a column's section below its intrinsic
+/// width. Let the column go narrower than that and AppKit stops moving the
+/// section with the split divider, so the list's sort/add buttons end up
+/// floating over the detail column. Adding a third `.primaryAction` item to a
+/// list column is what would break this.
+@MainActor
+final class ContentViewColumnLayoutTests: XCTestCase {
+
+    func testContentToolbarItemsStayOverTheirColumnAtTheNarrowestWidth() throws {
+        let window = try mainWindow()
+        let splitView = try XCTUnwrap(
+            findSplitView(in: window.contentView), "no NSSplitView in the main window")
+        XCTAssertEqual(splitView.arrangedSubviews.count, 3, "expected a three-column split view")
+
+        let originalPosition = splitView.arrangedSubviews[1].frame.maxX
+        defer {
+            splitView.setPosition(originalPosition, ofDividerAt: 1)
+            pumpRunLoop()
+        }
+
+        // 0 collapses onto whatever floor NavigationSplitView enforces.
+        splitView.setPosition(0, ofDividerAt: 1)
+        pumpRunLoop()
+
+        let panes = splitView.arrangedSubviews.map { $0.convert($0.bounds, to: nil) }
+        let dividerX = panes[2].minX
+        let contentWidth = dividerX - panes[0].width
+
+        XCTAssertEqual(
+            contentWidth, ColumnWidth.contentMin, accuracy: 2,
+            "the content column floor is not ColumnWidth.contentMin")
+
+        let items = contentColumnItemFrames(in: window)
+        XCTAssertFalse(
+            items.isEmpty,
+            "no content-column toolbar items found; items: \(toolbarDump(window))")
+
+        let overhang = items.map { $0.maxX - dividerX }.max() ?? 0
+        XCTAssertLessThanOrEqual(
+            overhang, 0,
+            """
+            content-column toolbar items overhang the split divider by \(overhang)pt at the \
+            column floor (\(contentWidth)pt): they render over the detail column instead of \
+            over the list. The column's toolbar section no longer fits — raise \
+            ColumnWidth.contentMin above it, or drop a toolbar item.
+            """)
+    }
+
+    // MARK: - Helpers
+
+    /// Toolbar items SwiftUI emits for the content column sit between the
+    /// tracking separators for split divider 0 (sidebar|content) and 1
+    /// (content|detail).
+    private func contentColumnItemFrames(in window: NSWindow) -> [NSRect] {
+        guard let items = window.toolbar?.items else { return [] }
+        let identifiers = items.map(\.itemIdentifier.rawValue)
+        guard
+            let start = identifiers.firstIndex(where: { $0.hasSuffix("splitViewSeparator-0") }),
+            let end = identifiers.firstIndex(where: { $0.hasSuffix("splitViewSeparator-1") }),
+            start < end
+        else { return [] }
+
+        return items[(start + 1)..<end].compactMap { item in
+            guard let view = item.view, let superview = view.superview else { return nil }
+            let frame = superview.convert(view.frame, to: nil)
+            return frame.width > 0 ? frame : nil
+        }
+    }
+
+    private func toolbarDump(_ window: NSWindow) -> String {
+        (window.toolbar?.items ?? [])
+            .map { "\($0.itemIdentifier.rawValue)[view: \($0.view == nil ? "nil" : "yes")]" }
+            .joined(separator: ", ")
+    }
+
+    private func mainWindow() throws -> NSWindow {
+        let deadline = Date().addingTimeInterval(10)
+        while Date() < deadline {
+            if let window = NSApp.windows.first(where: {
+                $0.toolbar != nil && findSplitView(in: $0.contentView) != nil
+            }) {
+                // Toolbar item views are only realized for an on-screen window.
+                window.makeKeyAndOrderFront(nil)
+                pumpRunLoop()
+                return window
+            }
+            pumpRunLoop()
+        }
+        throw XCTSkip(
+            "main window with a toolbar never appeared — this environment cannot host it")
+    }
+
+    private func findSplitView(in view: NSView?) -> NSSplitView? {
+        guard let view else { return nil }
+        if let split = view as? NSSplitView, split.arrangedSubviews.count == 3 { return split }
+        for subview in view.subviews {
+            if let split = findSplitView(in: subview) { return split }
+        }
+        return nil
+    }
+
+    private func pumpRunLoop(for duration: TimeInterval = 0.3) {
+        let deadline = Date().addingTimeInterval(duration)
+        while Date() < deadline {
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+    }
+}


### PR DESCRIPTION
## Problem

On the main window the list column's toolbar buttons (⇅, ＋) rendered over the **detail** column instead of over the list they act on. The split divider and the toolbar's tracking separator disagreed by ~120pt. This has been patched a few times without sticking.

## Root cause

Two causes compounding.

**1. The toolbar section has a hard floor.** The window toolbar reserves one section for the content column — nav title + subtitle + its `.primaryAction` items — ending at the split-view tracking separator, and AppKit will not compress it below its intrinsic width. Measured on macOS 26, that width is driven by the *item count*, not the title text:

| items | intrinsic width |
|---|---|
| 1 (＋ only, Machines) | 212pt |
| 2 (sort + ＋, Containers/Volumes/Images/Networks/Sandboxes) | **270pt** |
| 3 | 316pt |

Identical for a one-character, a 39-character and a CJK title. The column's floor was `min: 150`, so any column narrower than 270pt detached the separator from the divider.

Reproduced to the pixel: the reported screenshot has the divider at 338pt into the window and the separator at ~460pt; a harness with a 152pt column gives 341 / 459.5.

**2. `ideal:` only applies when there is no saved state** — which is why earlier fixes appeared not to work. Split positions persist under `NSSplitView Subview Frames …, SidebarNavigationSplitView` in the app's defaults, with a key that is stable per build. A width stored once is restored on every later launch, so what looks like a first launch is really the old state.

## Fix

Raise the content column's floor to 280pt and name the geometry in `ColumnWidth`, with the measured numbers and the "a third toolbar item would exceed this" warning in the doc comment.

`NSSplitView` clamps a restored width up to `min`, so **existing installs self-heal on next launch** — no defaults migration. Verified by seeding the exact narrow state from the bug report into the real app's defaults and relaunching: `152pt` comes back as `280pt`.

## Test

`ContentViewColumnLayoutTests` measures the real app window (the unit-test host *is* the app), pushes the divider onto the floor, and asserts the content column's toolbar items stay over their own column.

- at the old 150pt floor: fails with `content-column toolbar items overhang the split divider by 112.0pt at the column floor (151.0pt)`
- at 280pt: passes

It has to use the real window: the same hierarchy in an `NSHostingController` clips overflowing toolbar items rather than letting them overhang, so it cannot show the defect.

The helper initially skipped when no window appeared, on the guess that a runner might not host one. It does — on `macos-26` the assertions run in 0.96s, the same as locally, where a skip would have burned the full 10s poll first. That skip is now a failure with an explanation, since a green check that measured nothing is exactly what #339 was about.

## Notes

- The search field stays at the trailing edge over the detail column. That is the native convention (Mail, Finder) and is unchanged here.
- `project.pbxproj` regenerated for the new test file.
- Rebased onto master after #339, so this run genuinely built and tested — the earlier green check on this branch did neither.