### PR TITLE
fix(ci): make CI actually build and test, and stop devenv from breaking it

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,15 +44,12 @@ jobs:
           brew install protobuf
           make verify-arcbox-protobuf
 
-      - name: Swift format check
+      # `make lint` is what a contributor runs, and scripts/tool.sh holds the
+      # version floors, so the two cannot drift apart.
+      - name: Lint
         run: |
-          brew install swift-format
-          swift-format lint -r --strict ArcBox/ Packages/
-
-      - name: SwiftLint
-        run: |
-          brew install swiftlint
-          swiftlint lint --strict --config .swiftlint.yml
+          brew install swift-format swiftlint
+          make lint
 
       - name: Create local Xcode config
         run: |
@@ -68,7 +65,7 @@ jobs:
       - name: Generate Xcode project
         run: |
           brew install xcodegen
-          xcodegen generate
+          make generate-xcodeproj
           git diff --exit-code ArcBox.xcodeproj ArcBox/Info.plist project.yml
 
       - name: Record build environment
@@ -113,48 +110,28 @@ jobs:
             -scheme ArcBox \
             -clonedSourcePackagesDirPath .build/SourcePackages
 
+      # `shell: bash` is load-bearing on every step that pipes into xcpretty:
+      # the default shell is `bash -e`, whose pipeline status comes from
+      # xcpretty, so a failing xcodebuild reported success. `shell: bash` runs
+      # with `-eo pipefail`. Build and test go through the Makefile so a
+      # contributor's `make test` runs exactly what CI runs.
       - name: Build (Debug)
-        run: |
-          xcodebuild build \
-            -project ArcBox.xcodeproj \
-            -scheme ArcBox \
-            -configuration Debug \
-            -destination 'platform=macOS' \
-            -showBuildTimingSummary \
-            -derivedDataPath .build/DerivedData \
-            -clonedSourcePackagesDirPath .build/SourcePackages \
-            CODE_SIGN_IDENTITY=- \
-            SKIP_RUST_BUILD=1 \
-            | xcpretty --color
+        shell: bash
+        run: make build XCODEBUILD_EXTRA=-showBuildTimingSummary | xcpretty --color
 
       - name: Run Tests
-        run: |
-          xcodebuild test \
-            -project ArcBox.xcodeproj \
-            -scheme ArcBox \
-            -configuration Debug \
-            -destination 'platform=macOS' \
-            -showBuildTimingSummary \
-            -derivedDataPath .build/DerivedData \
-            -clonedSourcePackagesDirPath .build/SourcePackages \
-            CODE_SIGN_IDENTITY=- \
-            SKIP_RUST_BUILD=1 \
-            | xcpretty --color
+        shell: bash
+        run: make test XCODEBUILD_EXTRA=-showBuildTimingSummary | xcpretty --color
 
       - name: Warm Release cache (ARM64)
         if: github.event_name == 'push'
+        shell: bash
         run: |
-          xcodebuild build \
-            -project ArcBox.xcodeproj \
-            -scheme ArcBox \
-            -configuration Release \
-            -destination 'platform=macOS,arch=arm64' \
-            -showBuildTimingSummary \
-            -derivedDataPath .build/DerivedData \
-            -clonedSourcePackagesDirPath .build/SourcePackages \
+          make build \
+            CONFIGURATION=Release \
+            DESTINATION='platform=macOS,arch=arm64' \
             ARCHS=arm64 \
-            CODE_SIGN_IDENTITY=- \
-            SKIP_RUST_BUILD=1
+            XCODEBUILD_EXTRA=-showBuildTimingSummary
 
       - name: Save desktop Rust tooling cache
         if: github.event_name == 'push' && steps.desktop_rust_cache.outputs.cache-hit != 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,13 @@
 # ArcBox Desktop — Agent Guidelines
 
 ## Build & Test
-- Build: `xcodebuild build -project ArcBox.xcodeproj -scheme ArcBox -configuration Debug`
-- Test all: `xcodebuild test -project ArcBox.xcodeproj -scheme ArcBox -configuration Debug -destination 'platform=macOS'`
-- Swift-only (skip Rust): add `SKIP_RUST_BUILD=1 CODE_SIGN_IDENTITY=-` to xcodebuild
-- Rust binaries: the Xcode build phase runs `cargo xtask macos embed`, which calls `make build-rust` in `../arcbox`
+- Build: `make build` — Swift only, no embedded Rust binaries
+- Test all: `make test`
+- Format / lint: `make format`, `make lint`
+- Regenerate the Xcode project after adding or removing a file: `make generate-xcodeproj`
+- Rust binaries: the Xcode build phase runs `cargo xtask macos embed`, which calls `make build-rust` in `../arcbox`. `make build`/`make test` set `SKIP_RUST_BUILD=1`; use `make dmg` for a runnable bundle.
+
+**Do not call `xcodebuild` or `xcodegen` directly.** This repo uses devenv, whose Rust toolchain exports `CC`/`CXX`/`LD`/`SDKROOT`/`DEVELOPER_DIR` (pointed at a nix SDK) and ~30 `NIX_*` variables. A bare `xcodebuild` then fails with `no such module 'SwiftShims'`, `unknown argument: -index-store-path`, or `ld: unknown options: -Xlinker`, and devenv's `xcodegen` is older than `project.yml`'s `minimumXcodeGenVersion`. The Makefile targets run xcodebuild in an allowlisted environment and pick a new enough xcodegen, so they work identically inside `devenv shell` and on a clean CI runner — which is what CI itself runs.
 
 ## Architecture
 - **ArcBox/** — SwiftUI macOS app (MVVM): Views/, ViewModels/, Models/, Services/, Components/, Theme/, Integrations/, Support/

--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		D32166A92BDA2FB6B6037D94 /* DeepLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C649765AA76CFCBFC3302DA /* DeepLinkRouter.swift */; };
 		D49278FBAD2A7E36CD278147 /* MachineRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949DB8BB8139F8D3C37503E9 /* MachineRowView.swift */; };
 		D4B90FF1E30A90C8B962A30B /* AboutWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE313F40E79E409C942B1EE /* AboutWindow.swift */; };
+		D4FFF718B8B6D79B469D2C3C /* GuestExportFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738233A82C7BAA825F73EE2F /* GuestExportFixture.swift */; };
 		D69B9880564FF221556379CF /* SleepWakeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7058C8975F3F2684714E24E2 /* SleepWakeManager.swift */; };
 		D6D1C18BADA9AB8CAE608A7F /* SidebarAccountButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7607A876F6C88A440DA53BE1 /* SidebarAccountButton.swift */; };
 		D745D0D7EF5FF65174C47F28 /* NewVolumeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 903FA72CEF39142ADA5CA378 /* NewVolumeSheet.swift */; };
@@ -332,6 +333,7 @@
 		7058C8975F3F2684714E24E2 /* SleepWakeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepWakeManager.swift; sourceTree = "<group>"; };
 		70D9A8B5B6000070B4D69A07 /* SandboxDisabledView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxDisabledView.swift; sourceTree = "<group>"; };
 		727A1DD3E8D3B0BB875475A8 /* MachineEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachineEmptyState.swift; sourceTree = "<group>"; };
+		738233A82C7BAA825F73EE2F /* GuestExportFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestExportFixture.swift; sourceTree = "<group>"; };
 		7607A876F6C88A440DA53BE1 /* SidebarAccountButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarAccountButton.swift; sourceTree = "<group>"; };
 		77BE672A52785F040AC6CEB2 /* ExternalTerminalDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalTerminalDiscovery.swift; sourceTree = "<group>"; };
 		789DE20DB0F3E106BFAC6E10 /* MenuBarHoverButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarHoverButton.swift; sourceTree = "<group>"; };
@@ -1040,6 +1042,7 @@
 				F5B3B3C54B6D49C6198E9E26 /* DeepLinkTests.swift */,
 				06DFFB59D72F27F14A233B81 /* DockerEventMonitorTests.swift */,
 				27130DDA57D2645C7E81D75D /* GuestDataMountTests.swift */,
+				738233A82C7BAA825F73EE2F /* GuestExportFixture.swift */,
 				C964312D5336EE55A8E4680B /* ImageLayerChainTests.swift */,
 				A2B6587D59B9EFA18E51A3F3 /* ImagesViewModelTests.swift */,
 				7B6FDB677AE01E62877A17AC /* K8sModelsTests.swift */,
@@ -1412,6 +1415,7 @@
 				EE2D38BC76500BF768EEE20F /* DeepLinkTests.swift in Sources */,
 				8466B000B68A87CEECA6756F /* DockerEventMonitorTests.swift in Sources */,
 				D2AB4B6BF0723EE12A0DBC83 /* GuestDataMountTests.swift in Sources */,
+				D4FFF718B8B6D79B469D2C3C /* GuestExportFixture.swift in Sources */,
 				8BBBA54130403D89D35986F7 /* ImageLayerChainTests.swift in Sources */,
 				0BCE503CC2BF6C2BEC9DC4EA /* ImagesViewModelTests.swift in Sources */,
 				F40C3E6023452858EEEA893F /* K8sModelsTests.swift in Sources */,

--- a/ArcBox/Integrations/System/GuestDataMount.swift
+++ b/ArcBox/Integrations/System/GuestDataMount.swift
@@ -32,25 +32,32 @@ nonisolated enum GuestDataMount {
     }
 
     /// Rewrites a guest path under one of the exported roots to its host URL
-    /// under `~/ArcBox`, or `nil` if the path is not within an exported root.
+    /// under `exportRoot`, or `nil` if the path is not within an exported root.
     ///
     /// Guest paths can come from image/container labels, i.e. untrusted input;
     /// any `.`/`..` component is rejected so a crafted label cannot escape the
     /// export once the URL is standardized downstream.
-    static func hostURL(forGuestPath guestPath: String) -> URL? {
+    ///
+    /// `exportRoot` is where the export is mounted. It is a parameter rather
+    /// than a hardcoded `~/ArcBox` so that the resolution rules layered on top
+    /// of it — truncation, exclusion counting — can be exercised against a
+    /// directory tree the caller controls instead of a live NFS mount.
+    static func hostURL(forGuestPath guestPath: String, exportRoot: URL = rootURL) -> URL? {
         let trimmed = guestPath.trimmingCharacters(in: .whitespacesAndNewlines)
         // Check containerd first: its prefix is not nested inside the docker
         // root, but keeping the more specific mapping first stays correct if
         // that ever changes.
-        if let url = rewrite(trimmed, root: guestContainerdRoot, to: containerdHostRoot) {
+        if let url = rewrite(
+            trimmed, root: guestContainerdRoot, to: containerdHostRoot(under: exportRoot))
+        {
             return url
         }
-        return rewrite(trimmed, root: guestDataRoot, to: rootURL)
+        return rewrite(trimmed, root: guestDataRoot, to: exportRoot)
     }
 
     /// Host location of the containerd child export.
-    private static var containerdHostRoot: URL {
-        rootURL.appendingPathComponent("containerd")
+    private static func containerdHostRoot(under exportRoot: URL) -> URL {
+        exportRoot.appendingPathComponent("containerd")
     }
 
     private static func rewrite(_ path: String, root: String, to hostRoot: URL) -> URL? {

--- a/ArcBox/Integrations/System/LayerStack.swift
+++ b/ArcBox/Integrations/System/LayerStack.swift
@@ -49,9 +49,11 @@ nonisolated struct LayerStack {
     ///
     /// Runs off the main actor: resolution stats every layer, and on a
     /// wedged export each stat blocks until NFS gives up.
-    static func resolve(guestPaths: [String]) async -> LayerStack {
+    static func resolve(
+        guestPaths: [String], exportRoot: URL = GuestDataMount.rootURL
+    ) async -> LayerStack {
         let resolution = await Task.detached {
-            LayeredRootFS.resolveHostLayers(guestPaths: guestPaths)
+            LayeredRootFS.resolveHostLayers(guestPaths: guestPaths, exportRoot: exportRoot)
         }.value
 
         var stack = LayerStack()

--- a/ArcBox/Integrations/System/LayeredRootFS.swift
+++ b/ArcBox/Integrations/System/LayeredRootFS.swift
@@ -136,13 +136,15 @@ nonisolated struct LayeredRootFS {
     /// inside [`listDirectory`]: a layer that cannot be browsed still decides
     /// what the layers beneath it may show, so merging past it would surface
     /// entries it may replace or delete.
-    static func resolveHostLayers(guestPaths: [String]) -> Resolution {
+    static func resolveHostLayers(
+        guestPaths: [String], exportRoot: URL = GuestDataMount.rootURL
+    ) -> Resolution {
         var hostURLs: [URL] = []
         for guestPath in guestPaths {
             // Hand back what the check produced: callers would otherwise
             // repeat the same existence check to standardize the URL, and on
             // a wedged export that check blocks.
-            guard let hostURL = GuestDataMount.hostURL(forGuestPath: guestPath),
+            guard let hostURL = GuestDataMount.hostURL(forGuestPath: guestPath, exportRoot: exportRoot),
                 let resolved = try? LocalRootFSService.resolveRootURL(path: hostURL.path)
             else {
                 break

--- a/ArcBoxTests/GuestExportFixture.swift
+++ b/ArcBoxTests/GuestExportFixture.swift
@@ -1,0 +1,32 @@
+import Foundation
+import XCTest
+
+extension XCTestCase {
+    /// Builds a throwaway stand-in for the `~/ArcBox` export containing the
+    /// given layer directories.
+    ///
+    /// Layer resolution maps a guest path onto the export and then stats it, so
+    /// tests that need a layer to *resolve* would otherwise only pass on a
+    /// machine where the daemon is running and the export is mounted. Pointing
+    /// resolution at a directory the test owns keeps the rules under test —
+    /// truncation, exclusion counting — and drops the host dependency.
+    ///
+    /// The directory is removed when the test finishes.
+    func makeGuestExport(
+        containing layers: [String] = [],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+
+        for layer in layers {
+            try FileManager.default.createDirectory(
+                at: root.appendingPathComponent(layer, isDirectory: true),
+                withIntermediateDirectories: true)
+        }
+        return root
+    }
+}

--- a/ArcBoxTests/LayerStackTests.swift
+++ b/ArcBoxTests/LayerStackTests.swift
@@ -12,9 +12,11 @@ final class LayerStackTests: XCTestCase {
         XCTAssertEqual(stack.missingLayers, 0)
     }
 
-    func testSingleLayerSubjectDescribesNoStack() async {
+    func testSingleLayerSubjectDescribesNoStack() async throws {
         // Nothing to be incomplete about, so nothing to tell the user.
-        let stack = await LayerStack.resolve(guestPaths: ["/var/lib/docker/volumes"])
+        let export = try makeGuestExport(containing: ["volumes"])
+        let stack = await LayerStack.resolve(
+            guestPaths: ["/var/lib/docker/volumes"], exportRoot: export)
 
         XCTAssertNotNil(stack.rootURL)
         XCTAssertNil(stack.layers)
@@ -22,15 +24,17 @@ final class LayerStackTests: XCTestCase {
         XCTAssertEqual(stack.missingLayers, 0)
     }
 
-    func testTruncationToASingleLayerStillDescribesTheStack() async {
+    func testTruncationToASingleLayerStillDescribesTheStack() async throws {
         // The case the badge used to go silent on: one browsable layer left,
         // so there is no merged stack to hang a warning off — but most of the
         // filesystem is missing and the user has to be told.
-        let stack = await LayerStack.resolve(guestPaths: [
-            "/var/lib/docker/volumes",
-            "/somewhere/else/layer1",
-            "/somewhere/else/layer2",
-        ])
+        let export = try makeGuestExport(containing: ["volumes"])
+        let stack = await LayerStack.resolve(
+            guestPaths: [
+                "/var/lib/docker/volumes",
+                "/somewhere/else/layer1",
+                "/somewhere/else/layer2",
+            ], exportRoot: export)
 
         XCTAssertNotNil(stack.rootURL)
         XCTAssertTrue(stack.describesAStack)

--- a/ArcBoxTests/LayeredRootFSTests.swift
+++ b/ArcBoxTests/LayeredRootFSTests.swift
@@ -322,26 +322,31 @@ final class LayeredRootFSTests: XCTestCase {
 
     // MARK: host-layer resolution
 
-    func testResolveHostLayersTruncatesAtAnUnmappableLayer() {
+    func testResolveHostLayersTruncatesAtAnUnmappableLayer() throws {
         // An unmappable upper layer still decides what the layers beneath it
         // may show, so dropping it and keeping the lower ones would surface
-        // files it may have replaced or deleted.
-        let resolution = LayeredRootFS.resolveHostLayers(guestPaths: [
-            "/somewhere/else/upper",
-            "/var/lib/docker/volumes",
-        ])
+        // files it may have replaced or deleted. The lower layer is present in
+        // the export, so only truncation can keep it out of the result.
+        let export = try makeGuestExport(containing: ["volumes"])
+        let resolution = LayeredRootFS.resolveHostLayers(
+            guestPaths: [
+                "/somewhere/else/upper",
+                "/var/lib/docker/volumes",
+            ], exportRoot: export)
 
         XCTAssertEqual(resolution.hostURLs, [])
         XCTAssertEqual(resolution.excludedCount, 2)
     }
 
-    func testResolveHostLayersTruncatesAtAMissingLayer() {
+    func testResolveHostLayersTruncatesAtAMissingLayer() throws {
         // Same rule when the path maps fine but is not on the host: the
         // layer is unavailable, and what it deletes is unknowable.
-        let resolution = LayeredRootFS.resolveHostLayers(guestPaths: [
-            "/var/lib/docker/definitely-not-present-\(UUID().uuidString)",
-            "/var/lib/docker/volumes",
-        ])
+        let export = try makeGuestExport(containing: ["volumes"])
+        let resolution = LayeredRootFS.resolveHostLayers(
+            guestPaths: [
+                "/var/lib/docker/definitely-not-present-\(UUID().uuidString)",
+                "/var/lib/docker/volumes",
+            ], exportRoot: export)
 
         XCTAssertEqual(resolution.hostURLs, [])
         XCTAssertEqual(resolution.excludedCount, 2)
@@ -372,15 +377,17 @@ final class LayeredRootFSTests: XCTestCase {
         XCTAssertEqual(listing.excludedLayers, [1, 2])
     }
 
-    func testResolveHostLayersCanTruncateToASingleSurvivor() {
+    func testResolveHostLayersCanTruncateToASingleSurvivor() throws {
         // The case the badge used to go silent on: the stack collapses to one
         // browsable layer, so there is no composed stack left to hang a
         // warning off — but four fifths of the filesystem is missing.
-        let resolution = LayeredRootFS.resolveHostLayers(guestPaths: [
-            "/var/lib/docker/volumes",
-            "/somewhere/else/layer1",
-            "/somewhere/else/layer2",
-        ])
+        let export = try makeGuestExport(containing: ["volumes"])
+        let resolution = LayeredRootFS.resolveHostLayers(
+            guestPaths: [
+                "/var/lib/docker/volumes",
+                "/somewhere/else/layer1",
+                "/somewhere/else/layer2",
+            ], exportRoot: export)
 
         XCTAssertEqual(resolution.hostURLs.count, 1)
         XCTAssertEqual(resolution.excludedCount, 2)

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,15 @@ PROVISIONING_PROFILE ?=
 
 ABCTL := $(ARCBOX_DIR)/target/release/abctl
 
-.PHONY: generate-xcodeproj bump-arcbox verify-arcbox-protobuf build-rust prefetch dmg dmg-signed dmg-release clean help
+.PHONY: build test format lint generate-xcodeproj bump-arcbox verify-arcbox-protobuf build-rust prefetch dmg dmg-signed dmg-release clean help
 
 help:
 	@echo "ArcBox build targets:"
 	@echo ""
+	@echo "  make build          Build the Swift app (Debug, no Rust binaries)"
+	@echo "  make test           Build and run the test suite"
+	@echo "  make format         Apply swift-format in place"
+	@echo "  make lint           Run swift-format --strict and swiftlint (as CI does)"
 	@echo "  make generate-xcodeproj  Regenerate ArcBox.xcodeproj from project.yml"
 	@echo "  make bump-arcbox VERSION=vX.Y.Z"
 	@echo "                         Update arcbox.version and regenerate protobuf client"
@@ -52,10 +56,81 @@ help:
 	@echo "  SKIP_RESOURCES=$(SKIP_RESOURCES)"
 	@echo "  SKIP_XCODE_EMBED=$(SKIP_XCODE_EMBED)"
 
+## ── Swift app ─────────────────────────────────────────
+
+# devenv's Rust toolchain exports CC/CXX/LD/SDKROOT/MACOSX_DEPLOYMENT_TARGET
+# and ~30 NIX_* variables that xcodebuild and SwiftPM cannot use: the nix clang
+# rejects -index-store-path, the bare `ld` breaks SPM C-shim links, and the nix
+# SDK is older than the Xcode compiler ("no such module 'SwiftShims'"). Each
+# nix bump adds more of them, so unsetting the known offenders is a losing
+# game — start from an empty environment and allow in only what a build needs.
+# On a clean CI runner this changes nothing, which is the point: one recipe
+# that behaves the same inside `devenv shell` and on a runner.
+#
+# devenv also points DEVELOPER_DIR at the nix SDK, which `xcode-select -p`
+# echoes back — so dropping it is what restores the real Xcode. To pin a
+# specific Xcode, pass XCODE_DEVELOPER_DIR=... (a separate name, so the
+# poisoned DEVELOPER_DIR cannot leak in through it).
+XCODE_DEVELOPER_DIR ?=
+XCODE_ENV = /usr/bin/env -i \
+	HOME="$$HOME" \
+	PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+	$(if $(TMPDIR),TMPDIR="$(TMPDIR)") \
+	$(if $(USER),USER="$(USER)") \
+	$(if $(LANG),LANG="$(LANG)") \
+	$(if $(XCODE_DEVELOPER_DIR),DEVELOPER_DIR="$(XCODE_DEVELOPER_DIR)")
+
+CONFIGURATION ?= Debug
+DESTINATION ?= platform=macOS
+
+# `-skipPackagePluginValidation`/`-skipMacroValidation`: Xcode requires each
+# SwiftPM plugin to be trusted interactively before it will run it. That
+# consent lives in Xcode's user defaults, so a machine that has never opened
+# the project — every CI runner — fails with `Plugin "OpenAPIGenerator" … must
+# be enabled before it can be used`. Skipping validation everywhere keeps
+# local and CI on the same command.
+#
+# SKIP_RUST_BUILD=1: the embed phase pulls prebuilt binaries from ../arcbox.
+# These targets compile and test Swift; use `make dmg` for a runnable bundle.
+XCODEBUILD_FLAGS = \
+	-project ArcBox.xcodeproj \
+	-scheme ArcBox \
+	-configuration $(CONFIGURATION) \
+	-destination '$(DESTINATION)' \
+	-derivedDataPath .build/DerivedData \
+	-clonedSourcePackagesDirPath .build/SourcePackages \
+	-skipPackagePluginValidation \
+	-skipMacroValidation \
+	$(XCODEBUILD_EXTRA) \
+	CODE_SIGN_IDENTITY=- \
+	SKIP_RUST_BUILD=1 \
+	$(if $(ARCHS),ARCHS=$(ARCHS))
+
+build:
+	$(XCODE_ENV) xcodebuild build $(XCODEBUILD_FLAGS)
+
+test:
+	$(XCODE_ENV) xcodebuild test $(XCODEBUILD_FLAGS)
+
+# Feed swift-format the tracked sources rather than walking directories: a
+# local `Packages/*/.build/checkouts` holds vendored third-party code that is
+# absent on a fresh CI checkout, so `-r Packages/` lints different files (and
+# crashes on some of them) depending on where it runs. swiftlint has its own
+# excludes in .swiftlint.yml.
+SWIFT_SOURCES = git ls-files -z '*.swift'
+TOOL = scripts/tool.sh
+
+format:
+	$(SWIFT_SOURCES) | xargs -0 $(TOOL) swift-format format -i
+
+lint:
+	$(SWIFT_SOURCES) | xargs -0 $(TOOL) swift-format lint --strict
+	$(TOOL) swiftlint lint --strict --config .swiftlint.yml
+
 ## ── Xcode Project ─────────────────────────────────────
 
 generate-xcodeproj:
-	xcodegen generate
+	$(TOOL) xcodegen generate
 
 ## ── ArcBox Protocol ───────────────────────────────────
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,6 +1,12 @@
 { pkgs, ... }:
 
 {
+  # nixpkgs lags the Homebrew bottles CI installs, and for xcodegen /
+  # swift-format / swiftlint the gap changes behaviour: xcodegen refuses
+  # project.yml's minimumXcodeGenVersion, and swift-format disagrees with CI
+  # about whole files. These stay for convenience, but they are not
+  # authoritative — `make lint` and `make generate-xcodeproj` go through
+  # scripts/tool.sh, which enforces the floors CI builds against.
   packages = with pkgs; [
     xcodegen
     swift-format

--- a/prek.toml
+++ b/prek.toml
@@ -1,3 +1,7 @@
+# Hooks resolve their tool through scripts/tool.sh so a commit is checked with
+# the versions CI uses — devenv's nixpkgs builds lag far enough behind that
+# swift-format disagrees with CI about whole files.
+
 [[repos]]
 repo = "local"
 
@@ -5,12 +9,12 @@ repo = "local"
 id = "swift-format"
 name = "swift-format"
 language = "system"
-entry = "swift-format format -i"
+entry = "scripts/tool.sh swift-format format -i"
 types = ["swift"]
 
 [[repos.hooks]]
 id = "swiftlint"
 name = "swiftlint"
 language = "system"
-entry = "swiftlint lint --strict --config .swiftlint.yml"
+entry = "scripts/tool.sh swiftlint lint --strict --config .swiftlint.yml"
 types = ["swift"]

--- a/scripts/tool.sh
+++ b/scripts/tool.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Resolves a developer tool to a build new enough to agree with CI.
+#
+# devenv pins these through nixpkgs, which lags well behind the Homebrew
+# bottles CI installs — swift-format especially, where the two versions
+# disagree about whole files. The result is a formatter that is happy locally
+# and a red PR, or a spec that xcodegen refuses to read. So: take the first
+# candidate that meets the floor, and say so plainly when there is none.
+#
+# Floors track what CI installs. Raise them together with .github/workflows.
+#
+#   scripts/tool.sh <name>              print the path
+#   scripts/tool.sh <name> [args...]    run it
+set -euo pipefail
+
+name=${1:?usage: tool.sh <name> [args...]}
+shift
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+
+case $name in
+xcodegen)
+    # project.yml refuses to load on anything older.
+    minimum=$(awk '/minimumXcodeGenVersion:/ { print $2 }' "$repo_root/project.yml")
+    ;;
+swift-format) minimum=603.0.0 ;;
+swiftlint) minimum=0.65.0 ;;
+*)
+    echo "tool.sh: no version floor recorded for '$name'" >&2
+    exit 2
+    ;;
+esac
+
+for candidate in "$name" "/opt/homebrew/bin/$name" "/usr/local/bin/$name"; do
+    bin=$(command -v "$candidate" 2>/dev/null) || continue
+    # `xcodegen --version` prints "Version: 2.45.4", the others just the number.
+    version=$("$bin" --version 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)+' | head -1) || continue
+    [ -n "$version" ] || continue
+    [ "$(printf '%s\n%s\n' "$minimum" "$version" | sort -V | head -1)" = "$minimum" ] || continue
+
+    if [ "$#" -eq 0 ]; then
+        printf '%s\n' "$bin"
+    else
+        exec "$bin" "$@"
+    fi
+    exit 0
+done
+
+echo "error: no $name >= $minimum on PATH." >&2
+echo "  devenv ships an older one; install a current build with: brew install $name" >&2
+exit 1


### PR DESCRIPTION
Three problems that turn out to be one story: nothing was verifying anything.

## 1. CI has not built or tested for some time, and said it had

```
- name: Run Tests
  run: |
    xcodebuild test ... | xcpretty --color
```

No `shell:` key, so the step runs under the default `bash -e` — which has **no `pipefail`**. The pipeline's status comes from `xcpretty`, which always succeeds. From the last run on `master`:

| step | reported | actually |
|---|---|---|
| Build (Debug) | ✓ | `** BUILD FAILED **` |
| Run Tests | ✓ | `** TEST FAILED **` — zero tests ran |
| Warm Release cache | ✗ | same failure, no pipe, so exit 65 escapes |

`Warm Release cache` is `if: github.event_name == 'push'`, so **pull requests were fully green while nothing was built or tested.**

What all three were failing on:

```
Plugin “OpenAPIGenerator” from package “swift-openapi-generator” must be enabled before it can be used
```

Xcode requires each SwiftPM plugin to be trusted interactively; the consent lives in Xcode's user defaults, and a runner has none. `-skipPackagePluginValidation -skipMacroValidation` is the non-interactive equivalent.

Fixed by adding those flags, and by giving every piping step `shell: bash` (`-eo pipefail`) so a failure can never be swallowed again.

## 2. The suite only passed on a machine running the daemon

Five tests resolved `/var/lib/docker/volumes`, which is rewritten to `~/ArcBox/volumes` and then `stat`'d — a path that exists only while the daemon is running and the NFS export is mounted. On any other machine, 7 assertions failed.

The export root becomes an explicit input (defaulting to `~/ArcBox`) and the tests build their own directory.

**Two of them get stronger.** `TruncatesAtAnUnmappableLayer` and `TruncatesAtAMissingLayer` assert a bad upper layer drops everything below it — but the layer below was `/var/lib/docker/volumes`, which did not resolve either, so they held whether or not truncation happened. Verified by mutation: replacing the `break` in `resolveHostLayers` with `continue` now fails both, and failed neither before.

## 3. devenv fights the Xcode toolchain, so everyone invents their own workaround

Inside `devenv shell`, `languages.rust` exports `CC`/`CXX`/`LD`, `SDKROOT` and `DEVELOPER_DIR` pointed at a nix apple-sdk, plus ~30 `NIX_*` variables. A plain `xcodebuild` dies with `no such module 'SwiftShims'`, `unknown argument: -index-store-path`, or `ld: unknown options: -Xlinker`. And the pinned tools disagree with CI:

| tool | devenv | CI (brew) |
|---|---|---|
| xcodegen | 2.44.1 | 2.45.4 — below `minimumXcodeGenVersion`, refuses the spec |
| swift-format | 508.0.0 | 603.0.0 — **disagree about whole files** |
| swiftlint | 0.63.2 | 0.65.0 |

So: `make build`, `make test`, `make format`, `make lint`.

- xcodebuild runs through an **allowlisted** environment, not a blacklist of known offenders — each nix bump adds more. Dropping `DEVELOPER_DIR` is what restores the real Xcode, since `xcode-select -p` echoes it back.
- `scripts/tool.sh` resolves each tool to a build meeting CI's floor, falls back to Homebrew, and gives an actionable error when nothing does. The Makefile **and the prek hooks** both use it, so the pre-commit hook formats the way CI checks.
- `make lint` feeds swift-format the git-tracked sources rather than walking directories — a local `Packages/*/.build/checkouts` holds vendored code absent from a fresh checkout, so `-r Packages/` linted different files locally than in CI (and crashed on some).

CI now runs those same targets, so local and CI cannot drift apart.

## Verification

From inside a normal `devenv shell`, with no manual environment handling:

```
$ make lint     # 265 files, 0 violations
$ make test     # Executed 148 tests, with 0 failures
```

## Notes

- `swift-format` scope gains `ArcBoxTests/`, which swiftlint already covered and swift-format did not. It is already clean.
- Floors in `scripts/tool.sh` track what CI installs; raise them together.
- Stacked concern: #338 (toolbar alignment) is independent and adds one more test.