### PR TITLE
fix(ui): keep the toolbar separator on every column

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		8E9980682D9BB81A4CB35673 /* ContainerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69A867E81CB7E281682A24D /* ContainerModel.swift */; };
 		8ED7BA2FEE7010BDBD4BAEDC /* VolumesViewModel+Docker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 420516961E57589A91B445DA /* VolumesViewModel+Docker.swift */; };
 		8FB67BF11BF2A3194A28BD32 /* SandboxTerminalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0841C2969EC1A1BC07489C8 /* SandboxTerminalSession.swift */; };
+		9010BB836D577FF81084FAAA /* ToolbarSeparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 823F87591055C314EC29BF67 /* ToolbarSeparator.swift */; };
 		931763946B40148917024A02 /* K8sClient in Frameworks */ = {isa = PBXBuildFile; productRef = E3B0A98EBADEEAA76280EF06 /* K8sClient */; };
 		931E9B5CD525A25F36B6A636 /* NetworkContainersTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF5769685436501744C4A83 /* NetworkContainersTab.swift */; };
 		9444132595906417360A9D44 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA88097CAC1929269BE210C5 /* ContentView.swift */; };
@@ -351,6 +352,7 @@
 		7D5BDCAAF11D1A6B52990E28 /* ContainerViewModel+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContainerViewModel+Mapping.swift"; sourceTree = "<group>"; };
 		7DAB7D8E92543D99A995003F /* CheckForUpdatesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckForUpdatesView.swift; sourceTree = "<group>"; };
 		7DDFA2EDA7A3AC8448696F91 /* VolumeFilesTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeFilesTab.swift; sourceTree = "<group>"; };
+		823F87591055C314EC29BF67 /* ToolbarSeparator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarSeparator.swift; sourceTree = "<group>"; };
 		829D8DC499E6339D13A2ADE7 /* SandboxesViewModel+GRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SandboxesViewModel+GRPC.swift"; sourceTree = "<group>"; };
 		83FBE0C82E0EB430C69EB944 /* GuestDataMount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestDataMount.swift; sourceTree = "<group>"; };
 		85321B230A582D1C0AF76B5C /* LocalRootFSService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalRootFSService.swift; sourceTree = "<group>"; };
@@ -616,6 +618,7 @@
 				BEA74DBE71D29DEB680F08E7 /* SwiftTermView.swift */,
 				312B3A0CBD47EB616127BBE5 /* TerminalSessionBridge.swift */,
 				EFB03A05EDADB4F1FA6E10A1 /* ToastView.swift */,
+				823F87591055C314EC29BF67 /* ToolbarSeparator.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1392,6 +1395,7 @@
 				43F19AF62096855162AED4D6 /* TerminalLine.swift in Sources */,
 				ED5B6539D3909308DA1C4AE4 /* TerminalSessionBridge.swift in Sources */,
 				4113241C123BBBBDEC76E5B0 /* ToastView.swift in Sources */,
+				9010BB836D577FF81084FAAA /* ToolbarSeparator.swift in Sources */,
 				525ECDE24CB1E8ADC7AADB49 /* UpdaterDelegate.swift in Sources */,
 				7DFC19087BE929DDF207A677 /* UpdaterSettingsModel.swift in Sources */,
 				96C7FFF79579D1B999ABAF3F /* Utilities.swift in Sources */,

--- a/ArcBox/Components/ToolbarSeparator.swift
+++ b/ArcBox/Components/ToolbarSeparator.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+extension View {
+    /// Gives a `NavigationSplitView` column the 1pt rule under the window
+    /// toolbar that it would otherwise show only some of the time.
+    ///
+    /// macOS 26 separates the toolbar from each split-view pane with a scroll
+    /// pocket and picks the style per pane: a pane whose root is a scroll view
+    /// gets the soft scroll-edge fade, a pane without one gets the hard rule.
+    /// ArcBox's list column scrolls and its detail column mostly does not, so
+    /// the rule appeared over one column and not its neighbour. AppKit also
+    /// forces the hard rule onto every pane while a toolbar section is too wide
+    /// for its column, which is why the rule used to reappear once the content
+    /// column was dragged below its toolbar section — see `ColumnWidth`.
+    ///
+    /// A top safe-area inset takes the scroll view off the pane root, so AppKit
+    /// draws the rule for this column unconditionally. That keeps it native —
+    /// same 1pt, same colour, same position as every other pane's — rather than
+    /// drawing a second rule 1pt below AppKit's. The inset is deliberately empty
+    /// and zero-height: it changes nothing about layout, only that decision.
+    ///
+    /// Not covered by a test: the column is only scroll-backed once its list has
+    /// loaded, and the unit-test host has no daemon, so the case never arises
+    /// there. Verify by eye after changing this — the rule has to run unbroken
+    /// from the sidebar edge to the window edge at any split position.
+    func toolbarSeparator() -> some View {
+        safeAreaInset(edge: .top, spacing: 0) {
+            Color.clear.frame(height: 0)
+        }
+    }
+}

--- a/ArcBox/Views/ContentView.swift
+++ b/ArcBox/Views/ContentView.swift
@@ -63,6 +63,7 @@ struct ContentView: View {
             // is what actually guarantees toolbar alignment. See `ColumnWidth`.
             contentColumn
                 .background(AppColors.background)
+                .toolbarSeparator()
                 .navigationSplitViewColumnWidth(
                     min: isContentColumnCollapsed ? 0 : ColumnWidth.contentMin,
                     ideal: isContentColumnCollapsed ? 0 : ColumnWidth.contentIdeal,
@@ -71,6 +72,7 @@ struct ContentView: View {
         } detail: {
             detailPanel
                 .background(AppColors.sidebar)
+                .toolbarSeparator()
         }
         .onChange(of: appVM.currentNav) { _, newNav in
             guard let newNav else { return }


### PR DESCRIPTION
## What

The 1pt rule under the window toolbar ran across the detail column but stopped at the split divider, leaving the list column without one.

## Why

macOS 26 separates the toolbar from each split-view pane with a scroll pocket, and picks the style **per pane**:

- pane whose root is a scroll view → soft scroll-edge fade, no rule
- pane without one → hard 1pt rule

The list column scrolls once its containers load; the detail column does not. Hence one rule, not two.

It was also unstable in two other ways:

- present while the list was still loading (no `ScrollView` yet), gone once it loaded
- present again whenever the content column was dragged below its **272pt** toolbar section — AppKit forces hard rules onto every pane while a section does not fit its column (same 272pt threshold behind `ColumnWidth.contentMin`)

## How

An empty, zero-height top safe-area inset takes the scroll view off each column's pane root, so AppKit draws its own rule for both columns unconditionally. This keeps the rule native — same 1pt, colour and position as every other pane's — instead of drawing a second rule 1pt below AppKit's, which is what an opaque divider produced (verified: a red test rule landed at rows 104–105 with AppKit's grey one still at 102–103).

`toolbarBackgroundVisibility(.hidden)` was rejected: it removes the rule everywhere, but also drops the toolbar background, so scrolled rows render through the navigation title.

## Verification

Measured on the running app at 2x — the rule now spans `376…935` (content) and `938…2405` (detail), one native 1pt line, unchanged at every split position.

No automated test: the column is only scroll-backed once its list has loaded, and the unit-test host has no daemon, so the case never arises there. A test written against it passed with and without the fix, so it was dropped rather than shipped green-no-matter-what. `make lint` 0 violations, `make test` 149 tests / 0 failures.