### PR TITLE
refactor(activity): rebuild the monitor on standard components

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		0601E3B8363540B1F627754C /* AppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B624914056B0B39B7A3E08 /* AppTheme.swift */; };
 		0720D45362971FA9338BAA53 /* SwiftTermView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA74DBE71D29DEB680F08E7 /* SwiftTermView.swift */; };
 		07A382D149C73C697CAA1601 /* SandboxRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE564AAFEC0EF6D094409728 /* SandboxRowView.swift */; };
+		08DDBA6E0000548FEF44EB7B /* StatsFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B33A34931421365A5BCAE6 /* StatsFormat.swift */; };
 		0999A1C28C17EFD150E56CF8 /* MachinesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ECCF18CC36CC3579EE2B5B9 /* MachinesView.swift */; };
 		09A2217B8D33E2BD87D23713 /* ActivityViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAC9EE4F067CB69F022C1E0 /* ActivityViewModel.swift */; };
 		09FF7CE0E252DAD805077C7E /* ImagesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 559C97F0CA659149BCBA59A2 /* ImagesViewModel.swift */; };
@@ -95,11 +96,13 @@
 		7329C817F923872FC238D8B3 /* ContainersViewModel+BatchOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545D230723A80CB5C011B57E /* ContainersViewModel+BatchOperations.swift */; };
 		73E1E5FC3E40AD0760A21AC0 /* PodModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37BB3605830EBE3A1625452 /* PodModel.swift */; };
 		74488A22CBA34633776AC5D2 /* SandboxDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B18FDEC4B5AE8513C98D7B4 /* SandboxDetailView.swift */; };
+		759C82DCC614CABAA93AABC4 /* ActivityContainerTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B050286A2450880AC2C95342 /* ActivityContainerTable.swift */; };
 		766ECB0DA60ABA79FE21CE2C /* ContainerInfoTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE29B2F3FF7CFA3B0325CB97 /* ContainerInfoTab.swift */; };
 		76F9D4F43F4E73B79D882830 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43B8FF992E687C114ADB8E32 /* AboutView.swift */; };
 		7895A0328F3567814B656CFD /* LocalRootFSOutlineCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0D0444E612EC32D81A7E0C /* LocalRootFSOutlineCoordinator.swift */; };
 		7910184754585B4CF647FA92 /* ContainerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C6B2F85E39321931CEC3ED /* ContainerDetailView.swift */; };
 		79C5F3DA19E7431F8B28B6F0 /* MenuBarView+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC010DD9F0AEC7E4EA778C59 /* MenuBarView+Actions.swift */; };
+		7C881FAC221912F138CD65E7 /* ActivityMetricStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F15E941FF769135D0AA218 /* ActivityMetricStrip.swift */; };
 		7DABE0FBDD17F88D47333964 /* CommandHint.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65698313C3204F5F23E099B /* CommandHint.swift */; };
 		7DFC19087BE929DDF207A677 /* UpdaterSettingsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93968609F8E058EAC838DD18 /* UpdaterSettingsModel.swift */; };
 		7F091F3F3F75F500937DC7BC /* ImageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8BD8A4B6EEE9722D54739D /* ImageModel.swift */; };
@@ -147,6 +150,7 @@
 		A9E1DA5DBCAC015D9C41FF18 /* SandboxesViewModel+Snapshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2D773B0312F0D5695D0ADA /* SandboxesViewModel+Snapshots.swift */; };
 		AA6D71D441665D617EC4597A /* TemplatesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591B3B9F3D3A0B5C43EC7B55 /* TemplatesViewModel.swift */; };
 		AA8A34E11EF00EBFB5AC1090 /* MachinesViewModel+GRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB1B1CD1D5E0E961CD17118 /* MachinesViewModel+GRPC.swift */; };
+		AAC2BE593C229A83757CCD23 /* LiquidGlass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3572105F94A4F2399F9446D4 /* LiquidGlass.swift */; };
 		ABA9E2D6873BE5FF255045F3 /* AboutView+SystemInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0C5A43740FFD68902A2F77 /* AboutView+SystemInfo.swift */; };
 		AC66C291D8250EF48B8FE3D2 /* MenuBarView+Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6744BCBFA0A05831AFED0E /* MenuBarView+Layout.swift */; };
 		AD3BD03BF47240DE0C8A9A56 /* TemplateRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4E14745A6F16951FB5B8EB /* TemplateRowView.swift */; };
@@ -286,6 +290,7 @@
 		32115BE04C97CECA9C05A273 /* StartupProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupProgressView.swift; sourceTree = "<group>"; };
 		32C86546753C11A9E6CA8CB8 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		33250D1306B30B4E3D4C9B0E /* LayeredRootFS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayeredRootFS.swift; sourceTree = "<group>"; };
+		3572105F94A4F2399F9446D4 /* LiquidGlass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlass.swift; sourceTree = "<group>"; };
 		3DAC9EE4F067CB69F022C1E0 /* ActivityViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityViewModel.swift; sourceTree = "<group>"; };
 		3E30F5FC430804013B58C6F1 /* com.arcboxlabs.desktop.daemon.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = com.arcboxlabs.desktop.daemon.plist; sourceTree = "<group>"; };
 		3ED1683EF0A3490B8B7B5CF6 /* InfoTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoTableView.swift; sourceTree = "<group>"; };
@@ -296,6 +301,7 @@
 		43F21DD7BED5D64B93FF062D /* ArcBoxDesktopApp+Telemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArcBoxDesktopApp+Telemetry.swift"; sourceTree = "<group>"; };
 		46D7B7F6B349A602A7BA973E /* SandboxSnapshotsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxSnapshotsTab.swift; sourceTree = "<group>"; };
 		472F864720948B01C9F5D5A0 /* K8sClient */ = {isa = PBXFileReference; lastKnownFileType = folder; name = K8sClient; path = Packages/K8sClient; sourceTree = SOURCE_ROOT; };
+		47B33A34931421365A5BCAE6 /* StatsFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsFormat.swift; sourceTree = "<group>"; };
 		49A8DDE58F61A6B736A63E11 /* SandboxMonitoringView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxMonitoringView.swift; sourceTree = "<group>"; };
 		4A4B5E95EA5A894B19867570 /* LocalRootFSOutlineCoordinator+Columns.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalRootFSOutlineCoordinator+Columns.swift"; sourceTree = "<group>"; };
 		4A6DE83E6B8595E5E0F1299D /* ContainerGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerGroupView.swift; sourceTree = "<group>"; };
@@ -319,6 +325,7 @@
 		5D70EF1BF223C47C7B8E71A5 /* ExternalTerminalApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalTerminalApp.swift; sourceTree = "<group>"; };
 		5F2D773B0312F0D5695D0ADA /* SandboxesViewModel+Snapshots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SandboxesViewModel+Snapshots.swift"; sourceTree = "<group>"; };
 		61EE316315F864BA1BF0FFED /* MachinesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachinesViewModel.swift; sourceTree = "<group>"; };
+		61F15E941FF769135D0AA218 /* ActivityMetricStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityMetricStrip.swift; sourceTree = "<group>"; };
 		620BCE892EDA3E7554384A0E /* NetworkRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRowView.swift; sourceTree = "<group>"; };
 		6218E84D6C2A8595FE308B5E /* ImageLayerChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLayerChain.swift; sourceTree = "<group>"; };
 		657D7543F1D47988AEC3339D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -398,6 +405,7 @@
 		AE64C34A555B2A5BA02AD9FA /* ComingSoonPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComingSoonPanel.swift; sourceTree = "<group>"; };
 		AF7C1F10630FCFA65B832FA9 /* NewNetworkSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNetworkSheet.swift; sourceTree = "<group>"; };
 		B011CA693D5A9EFCCF61AA2D /* NewContainerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewContainerSheet.swift; sourceTree = "<group>"; };
+		B050286A2450880AC2C95342 /* ActivityContainerTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityContainerTable.swift; sourceTree = "<group>"; };
 		B0841C2969EC1A1BC07489C8 /* SandboxTerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxTerminalSession.swift; sourceTree = "<group>"; };
 		B0D36CA7845959196CF9B5B3 /* TemplatesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplatesListView.swift; sourceTree = "<group>"; };
 		B2CC2B117E020C62C1E9952E /* ContainerLogsTab+Views.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContainerLogsTab+Views.swift"; sourceTree = "<group>"; };
@@ -882,7 +890,10 @@
 		8D59468C9CEC7EAAE13C8C83 /* Activity */ = {
 			isa = PBXGroup;
 			children = (
+				B050286A2450880AC2C95342 /* ActivityContainerTable.swift */,
+				61F15E941FF769135D0AA218 /* ActivityMetricStrip.swift */,
 				5B3D2AE66CD9DD4A18CADB71 /* ActivityView.swift */,
+				47B33A34931421365A5BCAE6 /* StatsFormat.swift */,
 			);
 			path = Activity;
 			sourceTree = "<group>";
@@ -1004,6 +1015,7 @@
 			children = (
 				F62FD6244C56EE8E45DF0EC7 /* AppColors.swift */,
 				42B624914056B0B39B7A3E08 /* AppTheme.swift */,
+				3572105F94A4F2399F9446D4 /* LiquidGlass.swift */,
 				F893B8994BA04A6813FCB819 /* TerminalAppearance.swift */,
 			);
 			path = Theme;
@@ -1224,6 +1236,8 @@
 				76F9D4F43F4E73B79D882830 /* AboutView.swift in Sources */,
 				D4B90FF1E30A90C8B962A30B /* AboutWindow.swift in Sources */,
 				801AAF363A7901B7D17F5C55 /* AccountSettingsView.swift in Sources */,
+				759C82DCC614CABAA93AABC4 /* ActivityContainerTable.swift in Sources */,
+				7C881FAC221912F138CD65E7 /* ActivityMetricStrip.swift in Sources */,
 				ECA0B439D329FA52C529ABE8 /* ActivityView.swift in Sources */,
 				09A2217B8D33E2BD87D23713 /* ActivityViewModel.swift in Sources */,
 				5F8BD0B16CBBDC44080F6EA5 /* Analytics.swift in Sources */,
@@ -1296,6 +1310,7 @@
 				BD0363ABBB77C56F049EE2E4 /* LayerMergeBadge.swift in Sources */,
 				3F5E421D1DA0E9C653BAEB70 /* LayerStack.swift in Sources */,
 				F0B924B312EABA596C870505 /* LayeredRootFS.swift in Sources */,
+				AAC2BE593C229A83757CCD23 /* LiquidGlass.swift in Sources */,
 				248D76E4E5597E56F48DA0F3 /* ListResizeHandle.swift in Sources */,
 				1CA50DB029E0C7A18CAF87A2 /* LocalRootFSOutlineCoordinator+Actions.swift in Sources */,
 				FFAB94A328F83148EC0ED794 /* LocalRootFSOutlineCoordinator+Columns.swift in Sources */,
@@ -1377,6 +1392,7 @@
 				D69B9880564FF221556379CF /* SleepWakeManager.swift in Sources */,
 				9E79E2BBA05690D9ECAED2CD /* SortMenuButton.swift in Sources */,
 				A03ACBF5074B007C8CD7B101 /* StartupProgressView.swift in Sources */,
+				08DDBA6E0000548FEF44EB7B /* StatsFormat.swift in Sources */,
 				22A38E75CD6CB3074F3BB6D4 /* StatusBadge.swift in Sources */,
 				B3DF6F1A9B47905BF6337A81 /* StorageSettingsView.swift in Sources */,
 				0720D45362971FA9338BAA53 /* SwiftTermView.swift in Sources */,

--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		0C35F427DABEE19C0C583BE1 /* ContainersViewModel+Docker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12C2D038DE6CC49702F85F0 /* ContainersViewModel+Docker.swift */; };
 		0C6B829AD5010FDB0E749471 /* PullImageSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8254D67C0D80B99FC18DAD5 /* PullImageSheet.swift */; };
 		0E680E7A421A91FFB668D65E /* SandboxEventsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38681FE9A98E55B1608E662 /* SandboxEventsTab.swift */; };
+		0EB4E66405DD58C377BCE0E6 /* ActivityRowGroupingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CD990EEEF43CDA673BC1816 /* ActivityRowGroupingTests.swift */; };
 		11E29BA2E32899164106A9E7 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A780F10224ACC8C1B53D1E /* AvatarView.swift */; };
 		13B8650DED39F97A96660608 /* ErrorReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DE8B823FD1E94B0073AC5A /* ErrorReporting.swift */; };
 		14F016496706C25F9CF50D75 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06688AB84392716F1108AE36 /* Logging.swift */; };
@@ -199,6 +200,7 @@
 		D6D1C18BADA9AB8CAE608A7F /* SidebarAccountButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7607A876F6C88A440DA53BE1 /* SidebarAccountButton.swift */; };
 		D745D0D7EF5FF65174C47F28 /* NewVolumeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 903FA72CEF39142ADA5CA378 /* NewVolumeSheet.swift */; };
 		D786BBF78698824ED9F5E048 /* ComingSoonPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE64C34A555B2A5BA02AD9FA /* ComingSoonPanel.swift */; };
+		DA5B57293BC69B7D95AABBA8 /* ActivityRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0201CD86DCD5E042D07FF66F /* ActivityRow.swift */; };
 		DAC7224E4BF7F459BB7013CB /* RemoteIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A18574DEF808329D8152A379 /* RemoteIconView.swift */; };
 		DC9E1747A0F6F6574688BBD0 /* arcbox.version in Resources */ = {isa = PBXBuildFile; fileRef = AC70A79B919D909CF6D811B4 /* arcbox.version */; };
 		DDF9F74BA0638A51322686DE /* PodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF5B0B3EC77FB12D8B4EA6A /* PodsViewModel.swift */; };
@@ -254,6 +256,7 @@
 /* Begin PBXFileReference section */
 		00AE70F2EF523D6E02FFF371 /* ArcBoxClient */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ArcBoxClient; path = Packages/ArcBoxClient; sourceTree = SOURCE_ROOT; };
 		0100B138714BA1626E5E8D48 /* AboutView+ReleaseRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AboutView+ReleaseRow.swift"; sourceTree = "<group>"; };
+		0201CD86DCD5E042D07FF66F /* ActivityRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityRow.swift; sourceTree = "<group>"; };
 		03C9AACAD52AFF216B6A69E0 /* ImagesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesListView.swift; sourceTree = "<group>"; };
 		064086AEC8C204E8224DF45A /* DockerContextManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockerContextManager.swift; sourceTree = "<group>"; };
 		06688AB84392716F1108AE36 /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
@@ -291,6 +294,7 @@
 		32C86546753C11A9E6CA8CB8 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		33250D1306B30B4E3D4C9B0E /* LayeredRootFS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayeredRootFS.swift; sourceTree = "<group>"; };
 		3572105F94A4F2399F9446D4 /* LiquidGlass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlass.swift; sourceTree = "<group>"; };
+		3CD990EEEF43CDA673BC1816 /* ActivityRowGroupingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityRowGroupingTests.swift; sourceTree = "<group>"; };
 		3DAC9EE4F067CB69F022C1E0 /* ActivityViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityViewModel.swift; sourceTree = "<group>"; };
 		3E30F5FC430804013B58C6F1 /* com.arcboxlabs.desktop.daemon.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = com.arcboxlabs.desktop.daemon.plist; sourceTree = "<group>"; };
 		3ED1683EF0A3490B8B7B5CF6 /* InfoTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoTableView.swift; sourceTree = "<group>"; };
@@ -892,6 +896,7 @@
 			children = (
 				B050286A2450880AC2C95342 /* ActivityContainerTable.swift */,
 				61F15E941FF769135D0AA218 /* ActivityMetricStrip.swift */,
+				0201CD86DCD5E042D07FF66F /* ActivityRow.swift */,
 				5B3D2AE66CD9DD4A18CADB71 /* ActivityView.swift */,
 				47B33A34931421365A5BCAE6 /* StatsFormat.swift */,
 			);
@@ -1050,6 +1055,7 @@
 		F40F93A7C5C0CC3834C9D722 /* ArcBoxTests */ = {
 			isa = PBXGroup;
 			children = (
+				3CD990EEEF43CDA673BC1816 /* ActivityRowGroupingTests.swift */,
 				1DC5F65FECB2F80BA3AF1D84 /* ArcBoxClientErrorTests.swift */,
 				A10ED4BA65D6B9CC56B6B329 /* ChangelogParserTests.swift */,
 				E610512C9106BB92A47DC044 /* ContainersViewModelTests.swift */,
@@ -1238,6 +1244,7 @@
 				801AAF363A7901B7D17F5C55 /* AccountSettingsView.swift in Sources */,
 				759C82DCC614CABAA93AABC4 /* ActivityContainerTable.swift in Sources */,
 				7C881FAC221912F138CD65E7 /* ActivityMetricStrip.swift in Sources */,
+				DA5B57293BC69B7D95AABBA8 /* ActivityRow.swift in Sources */,
 				ECA0B439D329FA52C529ABE8 /* ActivityView.swift in Sources */,
 				09A2217B8D33E2BD87D23713 /* ActivityViewModel.swift in Sources */,
 				5F8BD0B16CBBDC44080F6EA5 /* Analytics.swift in Sources */,
@@ -1428,6 +1435,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0EB4E66405DD58C377BCE0E6 /* ActivityRowGroupingTests.swift in Sources */,
 				C94515858BC220B73B93EC5D /* ArcBoxClientErrorTests.swift in Sources */,
 				31474CB365691C57A5568D14 /* ChangelogParserTests.swift in Sources */,
 				4D2029E55A7979B8BD9EE89A /* ContainersViewModelTests.swift in Sources */,

--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		6F8362D2C8129F7BBF6E9635 /* VolumeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD5F80A65CA7E59F453286D /* VolumeDetailView.swift */; };
 		6FE53440B9A37EC32A67D021 /* ContainerEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5626F66A42E96606730DF28C /* ContainerEmptyState.swift */; };
 		7024DB45668AC27567EB655E /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE5A29026FA64A7C0A47122 /* SettingsView.swift */; };
+		70996419B03971A57B1DCF0F /* ByteFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3750055AEC4C49576A78A909 /* ByteFormattingTests.swift */; };
 		70BCB75DB0902FECADF9BEBC /* SandboxTerminalTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C5CFE4B4D21711F8580690 /* SandboxTerminalTab.swift */; };
 		71FE37D46B4D2D51BEEA35D9 /* ImagesViewModel+Docker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2022AA30CA121A0876D0B9D5 /* ImagesViewModel+Docker.swift */; };
 		72CCF0BC7FEAEB988595757C /* NewNetworkSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7C1F10630FCFA65B832FA9 /* NewNetworkSheet.swift */; };
@@ -294,6 +295,7 @@
 		32C86546753C11A9E6CA8CB8 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		33250D1306B30B4E3D4C9B0E /* LayeredRootFS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayeredRootFS.swift; sourceTree = "<group>"; };
 		3572105F94A4F2399F9446D4 /* LiquidGlass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlass.swift; sourceTree = "<group>"; };
+		3750055AEC4C49576A78A909 /* ByteFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ByteFormattingTests.swift; sourceTree = "<group>"; };
 		3CD990EEEF43CDA673BC1816 /* ActivityRowGroupingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityRowGroupingTests.swift; sourceTree = "<group>"; };
 		3DAC9EE4F067CB69F022C1E0 /* ActivityViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityViewModel.swift; sourceTree = "<group>"; };
 		3E30F5FC430804013B58C6F1 /* com.arcboxlabs.desktop.daemon.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = com.arcboxlabs.desktop.daemon.plist; sourceTree = "<group>"; };
@@ -1057,6 +1059,7 @@
 			children = (
 				3CD990EEEF43CDA673BC1816 /* ActivityRowGroupingTests.swift */,
 				1DC5F65FECB2F80BA3AF1D84 /* ArcBoxClientErrorTests.swift */,
+				3750055AEC4C49576A78A909 /* ByteFormattingTests.swift */,
 				A10ED4BA65D6B9CC56B6B329 /* ChangelogParserTests.swift */,
 				E610512C9106BB92A47DC044 /* ContainersViewModelTests.swift */,
 				DE7E377F9D8C89E24989DE3D /* ContentViewColumnLayoutTests.swift */,
@@ -1437,6 +1440,7 @@
 			files = (
 				0EB4E66405DD58C377BCE0E6 /* ActivityRowGroupingTests.swift in Sources */,
 				C94515858BC220B73B93EC5D /* ArcBoxClientErrorTests.swift in Sources */,
+				70996419B03971A57B1DCF0F /* ByteFormattingTests.swift in Sources */,
 				31474CB365691C57A5568D14 /* ChangelogParserTests.swift in Sources */,
 				4D2029E55A7979B8BD9EE89A /* ContainersViewModelTests.swift in Sources */,
 				A537498E1D8181BB0230E199 /* ContentViewColumnLayoutTests.swift in Sources */,

--- a/ArcBox/Integrations/System/LocalRootFSService.swift
+++ b/ArcBox/Integrations/System/LocalRootFSService.swift
@@ -17,7 +17,7 @@ nonisolated struct LocalFileEntry: Identifiable, Hashable {
 
     var sizeDisplay: String {
         guard let sizeBytes else { return "" }
-        return ByteCountFormatter.string(fromByteCount: sizeBytes, countStyle: .file)
+        return formattedBytes(sizeBytes)
     }
 
     @MainActor var dateDisplay: String {

--- a/ArcBox/Support/Utilities.swift
+++ b/ArcBox/Support/Utilities.swift
@@ -15,6 +15,20 @@ func parseISO8601Date(_ string: String?) -> Date {
     return formatter.date(from: string) ?? .distantPast
 }
 
+/// Formats a byte count, always as a numeral.
+///
+/// `ByteCountFormatStyle` — and `ByteCountFormatter` before it — spell zero out
+/// by default: "Zero kB". That reads as a word dropped into a column of
+/// numbers, breaks the digit alignment those columns depend on, and is the one
+/// value a live counter sits at most of the time. Every byte figure in the app
+/// goes through here so the default cannot creep back in one call site at a
+/// time.
+/// `nonisolated` because this is pure formatting and its callers are not all on
+/// the main actor — file-size columns resolve off it.
+nonisolated func formattedBytes(_ count: Int64, style: ByteCountFormatStyle.Style = .file) -> String {
+    count.formatted(.byteCount(style: style, spellsOutZero: false))
+}
+
 /// Shared utility for relative time display
 func relativeTime(from date: Date) -> String {
     let interval = Date().timeIntervalSince(date)

--- a/ArcBox/Theme/LiquidGlass.swift
+++ b/ArcBox/Theme/LiquidGlass.swift
@@ -37,7 +37,11 @@ private struct GlassSurface: ViewModifier {
     @ViewBuilder
     func body(content: Content) -> some View {
         if #available(macOS 26, *) {
-            content.glassEffect(.regular, in: .rect(corners: .concentric(minimum: .fixed(cornerRadius))))
+            content
+                .glassEffect(.regular, in: .rect(corners: .concentric(minimum: .fixed(cornerRadius))))
+                // Arrive as a material rather than a rectangle fading up: the
+                // surface takes shape and gathers its blur on the way in.
+                .glassEffectTransition(.materialize)
         } else {
             content
                 .background(AppColors.surfaceCard, in: .rect(cornerRadius: cornerRadius))

--- a/ArcBox/Theme/LiquidGlass.swift
+++ b/ArcBox/Theme/LiquidGlass.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// Liquid Glass chrome, with the pre-macOS 26 appearance as the fallback.
+///
+/// Apple scopes the material to the *functional* layer — toolbars, floating
+/// bars, controls — so the content underneath stays legible and the two layers
+/// read as distinct. Content panels keep `cardStyle()`; stacking glass on glass
+/// is what the guidance warns against, and so is spreading it over every
+/// element on a screen.
+///
+/// The effects ship in macOS 26. Each helper degrades on its own so call sites
+/// never spell out an availability check.
+extension View {
+    /// Marks a floating, control-layer surface.
+    ///
+    /// `cornerRadius` is the radius used before macOS 26, and the floor for the
+    /// concentric radius the system derives from the enclosing window.
+    func glassSurface(cornerRadius: CGFloat = 16) -> some View {
+        modifier(GlassSurface(cornerRadius: cornerRadius))
+    }
+
+    /// Fades scrolling content out as it passes under a floating bar instead of
+    /// letting it collide with the bar's edge.
+    @ViewBuilder
+    func softScrollEdge(for edges: Edge.Set) -> some View {
+        if #available(macOS 26, *) {
+            scrollEdgeEffectStyle(.soft, for: edges)
+        } else {
+            self
+        }
+    }
+}
+
+private struct GlassSurface: ViewModifier {
+    let cornerRadius: CGFloat
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(macOS 26, *) {
+            content.glassEffect(.regular, in: .rect(corners: .concentric(minimum: .fixed(cornerRadius))))
+        } else {
+            content
+                .background(AppColors.surfaceCard, in: .rect(cornerRadius: cornerRadius))
+                .overlay {
+                    RoundedRectangle(cornerRadius: cornerRadius)
+                        .strokeBorder(AppColors.border, lineWidth: 1)
+                }
+        }
+    }
+}

--- a/ArcBox/ViewModels/ActivityViewModel.swift
+++ b/ArcBox/ViewModels/ActivityViewModel.swift
@@ -41,6 +41,10 @@ final class ActivityViewModel {
     struct MetricPoint: Identifiable {
         let index: Int
         let value: Double
+        /// Guest monotonic clock at the sample. The x-axis counts samples, not
+        /// time, so this is what lets a scrubbed point report how long ago it
+        /// was rather than assuming the stream ticks at exactly 1 Hz.
+        let monotonicMs: UInt64
         var id: Int { index }
     }
 
@@ -84,15 +88,16 @@ final class ActivityViewModel {
         current = computed
         phase = .live
         sequence += 1
-        append(&cpuHistory, computed.cpuPercent)
-        append(&memoryHistory, computed.memoryUsedPercent)
+        append(&cpuHistory, computed.cpuPercent, at: sample.monotonicMs)
+        append(&memoryHistory, computed.memoryUsedPercent, at: sample.monotonicMs)
         append(
             &networkHistory,
-            computed.networkReceiveBytesPerSecond + computed.networkTransmitBytesPerSecond)
+            computed.networkReceiveBytesPerSecond + computed.networkTransmitBytesPerSecond,
+            at: sample.monotonicMs)
     }
 
-    private func append(_ series: inout [MetricPoint], _ value: Double) {
-        series.append(MetricPoint(index: sequence, value: value))
+    private func append(_ series: inout [MetricPoint], _ value: Double, at monotonicMs: UInt64) {
+        series.append(MetricPoint(index: sequence, value: value, monotonicMs: monotonicMs))
         if series.count > Self.historyLength {
             series.removeFirst(series.count - Self.historyLength)
         }

--- a/ArcBox/Views/Activity/ActivityContainerTable.swift
+++ b/ArcBox/Views/Activity/ActivityContainerTable.swift
@@ -13,9 +13,19 @@ struct ActivityContainerTable: View {
         KeyPathComparator(\ContainerResourceStats.cpuPercent, order: .reverse)
     ]
     @State private var selection: ContainerResourceStats.ID?
+    @State private var columnLayout = TableColumnCustomization<ContainerResourceStats>()
+    /// `TableColumnCustomization` is `Codable` but not `RawRepresentable`, so it
+    /// rides in `AppStorage` as its own encoding rather than through a
+    /// retroactive conformance on a type we do not own.
+    @AppStorage("activity.containerColumns") private var storedColumnLayout = Data()
 
     var body: some View {
-        Table(containers.sorted(using: sortOrder), selection: $selection, sortOrder: $sortOrder) {
+        Table(
+            containers.sorted(using: sortOrder),
+            selection: $selection,
+            sortOrder: $sortOrder,
+            columnCustomization: $columnLayout
+        ) {
             TableColumn("Container", value: \.displayName) { container in
                 Text(container.displayName)
                     .lineLimit(1)
@@ -23,16 +33,22 @@ struct ActivityContainerTable: View {
                     .help(container.id)
             }
             .width(min: 140, ideal: 260)
+            .customizationID("container")
+            // Hiding the column that says which row is which leaves a table of
+            // anonymous numbers.
+            .disabledCustomizationBehavior(.visibility)
 
             TableColumn("CPU", value: \.cpuPercent) { container in
                 reading(StatsFormat.percent(container.cpuPercent))
             }
             .width(min: 56, ideal: 68)
+            .customizationID("cpu")
 
             TableColumn("Memory", value: \.memoryCurrentBytes) { container in
                 reading(memoryReading(container))
             }
             .width(min: 96, ideal: 150)
+            .customizationID("memory")
 
             TableColumn("Disk R/W", value: \.diskBytesPerSecond) { container in
                 reading(
@@ -40,6 +56,7 @@ struct ActivityContainerTable: View {
                 )
             }
             .width(min: 120, ideal: 170)
+            .customizationID("disk")
 
             TableColumn("Net ↓/↑", value: \.networkBytesPerSecond) { container in
                 reading(
@@ -47,14 +64,31 @@ struct ActivityContainerTable: View {
                 )
             }
             .width(min: 120, ideal: 170)
+            .customizationID("network")
 
             TableColumn("PIDs", value: \.pids) { container in
                 reading(container.pids.formatted())
             }
             .width(min: 44, ideal: 56)
+            .customizationID("pids")
         }
         .tableStyle(.inset)
         .alternatingRowBackgrounds()
+        .task { restoreColumnLayout() }
+        .onChange(of: columnLayout) { _, layout in
+            storedColumnLayout = (try? JSONEncoder().encode(layout)) ?? Data()
+        }
+    }
+
+    /// A layout saved by a build with different columns decodes into something
+    /// that no longer matches them; dropping it loses a preference, which beats
+    /// restoring a table missing half its columns.
+    private func restoreColumnLayout() {
+        guard !storedColumnLayout.isEmpty,
+            let restored = try? JSONDecoder().decode(
+                TableColumnCustomization<ContainerResourceStats>.self, from: storedColumnLayout)
+        else { return }
+        columnLayout = restored
     }
 
     /// Numbers read down the column, so they are trailing-aligned and share a

--- a/ArcBox/Views/Activity/ActivityContainerTable.swift
+++ b/ArcBox/Views/Activity/ActivityContainerTable.swift
@@ -18,6 +18,10 @@ struct ActivityContainerTable: View {
     /// than emptying it.
     let docker: [String: ActivityContainerFacts]
     let searchText: String
+    /// False until the first usable frame. An empty table means "nothing is
+    /// running" only once something has been read; before that it means
+    /// "not known yet", and saying the first would be a guess.
+    let hasLoaded: Bool
 
     @State private var sortOrder = [
         KeyPathComparator(\ActivityRow.cpuPercent, order: .reverse)
@@ -110,7 +114,9 @@ struct ActivityContainerTable: View {
     /// the same work.
     @ViewBuilder
     private var emptyState: some View {
-        if containers.isEmpty {
+        if !hasLoaded {
+            EmptyView()
+        } else if containers.isEmpty {
             ContentUnavailableView(
                 "No Running Containers",
                 systemImage: "cube",

--- a/ArcBox/Views/Activity/ActivityContainerTable.swift
+++ b/ArcBox/Views/Activity/ActivityContainerTable.swift
@@ -1,19 +1,29 @@
 import ArcBoxClient
 import SwiftUI
 
-/// Per-container resource usage.
+/// Per-container resource usage, grouped by Compose project.
 ///
-/// A native `Table` so columns sort, resize and reorder the way every other Mac
-/// table does, and so a row stays selected while the numbers update underneath
-/// it. Sorting defaults to the busiest container first, as in Activity Monitor.
+/// A native `Table` so columns sort, resize, reorder and hide the way every
+/// other Mac table does, and so a row stays selected while the numbers update
+/// underneath it. Sorting defaults to the busiest first, as in Activity
+/// Monitor.
 struct ActivityContainerTable: View {
+    @Environment(AppViewModel.self) private var appVM
+    @Environment(ContainersViewModel.self) private var containersVM
+
     let containers: [ContainerResourceStats]
+    /// Docker's view of the same containers, keyed by ID. Supplies the project
+    /// a row groups under and the fields search matches beyond the name. Absent
+    /// while the Engine has not reported yet, which flattens the table rather
+    /// than emptying it.
+    let docker: [String: ActivityContainerFacts]
+    let searchText: String
 
     @State private var sortOrder = [
-        KeyPathComparator(\ContainerResourceStats.cpuPercent, order: .reverse)
+        KeyPathComparator(\ActivityRow.cpuPercent, order: .reverse)
     ]
-    @State private var selection: ContainerResourceStats.ID?
-    @State private var columnLayout = TableColumnCustomization<ContainerResourceStats>()
+    @State private var selection: ActivityRow.ID?
+    @State private var columnLayout = TableColumnCustomization<ActivityRow>()
     /// `TableColumnCustomization` is `Codable` but not `RawRepresentable`, so it
     /// rides in `AppStorage` as its own encoding rather than through a
     /// retroactive conformance on a type we do not own.
@@ -21,64 +31,171 @@ struct ActivityContainerTable: View {
 
     var body: some View {
         Table(
-            containers.sorted(using: sortOrder),
+            of: ActivityRow.self,
             selection: $selection,
             sortOrder: $sortOrder,
             columnCustomization: $columnLayout
         ) {
-            TableColumn("Container", value: \.displayName) { container in
-                Text(container.displayName)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .help(container.id)
+            TableColumn("Container", value: \.title) { row in
+                title(row)
             }
-            .width(min: 140, ideal: 260)
-            .customizationID("container")
+            .width(min: 160, ideal: 280)
             // Hiding the column that says which row is which leaves a table of
             // anonymous numbers.
             .disabledCustomizationBehavior(.visibility)
+            .customizationID("container")
 
-            TableColumn("CPU", value: \.cpuPercent) { container in
-                reading(StatsFormat.percent(container.cpuPercent))
+            TableColumn("CPU", value: \.cpuPercent) { row in
+                reading(StatsFormat.percent(row.cpuPercent), isProject: row.isProject)
             }
             .width(min: 56, ideal: 68)
             .customizationID("cpu")
 
-            TableColumn("Memory", value: \.memoryCurrentBytes) { container in
-                reading(memoryReading(container))
+            TableColumn("Memory", value: \.memoryCurrentBytes) { row in
+                reading(memoryReading(row), isProject: row.isProject)
             }
             .width(min: 96, ideal: 150)
             .customizationID("memory")
 
-            TableColumn("Disk R/W", value: \.diskBytesPerSecond) { container in
+            TableColumn("Disk R/W", value: \.diskBytesPerSecond) { row in
                 reading(
-                    "\(StatsFormat.rate(container.diskReadBytesPerSecond)) / \(StatsFormat.rate(container.diskWriteBytesPerSecond))"
+                    "\(StatsFormat.rate(row.diskReadBytesPerSecond)) / \(StatsFormat.rate(row.diskWriteBytesPerSecond))",
+                    isProject: row.isProject
                 )
             }
             .width(min: 120, ideal: 170)
             .customizationID("disk")
 
-            TableColumn("Net ↓/↑", value: \.networkBytesPerSecond) { container in
+            TableColumn("Net ↓/↑", value: \.networkBytesPerSecond) { row in
                 reading(
-                    "\(StatsFormat.rate(container.networkReceiveBytesPerSecond)) / \(StatsFormat.rate(container.networkTransmitBytesPerSecond))"
+                    "\(StatsFormat.rate(row.networkReceiveBytesPerSecond)) / \(StatsFormat.rate(row.networkTransmitBytesPerSecond))",
+                    isProject: row.isProject
                 )
             }
             .width(min: 120, ideal: 170)
             .customizationID("network")
 
-            TableColumn("PIDs", value: \.pids) { container in
-                reading(container.pids.formatted())
+            TableColumn("PIDs", value: \.pids) { row in
+                reading(row.pids.formatted(), isProject: row.isProject)
             }
             .width(min: 44, ideal: 56)
             .customizationID("pids")
+        } rows: {
+            ForEach(groups) { group in
+                if group.children.isEmpty {
+                    TableRow(group.summary)
+                } else {
+                    DisclosureTableRow(group.summary) {
+                        ForEach(group.children) { TableRow($0) }
+                    }
+                }
+            }
         }
         .tableStyle(.inset)
         .alternatingRowBackgrounds()
+        .overlay { emptyState }
+        .contextMenu(forSelectionType: ActivityRow.ID.self) { ids in
+            menu(for: ids)
+        } primaryAction: { ids in
+            if let id = ids.first { reveal(id) }
+        }
         .task { restoreColumnLayout() }
         .onChange(of: columnLayout) { _, layout in
             storedColumnLayout = (try? JSONEncoder().encode(layout)) ?? Data()
         }
     }
+
+    /// Both empty states live here because filtering does: the view above
+    /// cannot tell "nothing is running" from "nothing matches" without redoing
+    /// the same work.
+    @ViewBuilder
+    private var emptyState: some View {
+        if containers.isEmpty {
+            ContentUnavailableView(
+                "No Running Containers",
+                systemImage: "cube",
+                description: Text("Per-container usage appears here while containers are running.")
+            )
+        } else if groups.isEmpty {
+            ContentUnavailableView.search(text: searchText)
+        }
+    }
+
+    private var groups: [ActivityRowGroup] {
+        let rows = containers.map(ActivityRow.init).filter(matchesSearch)
+        return ActivityRowGrouping.groups(
+            for: rows,
+            projects: docker.compactMapValues(\.project),
+            sortedBy: sortOrder
+        )
+    }
+
+    /// Matches the Containers list: name, image and project, so a query that
+    /// finds a container there finds it here too.
+    private func matchesSearch(_ row: ActivityRow) -> Bool {
+        guard !searchText.isEmpty else { return true }
+        let query = searchText.lowercased()
+        if row.title.lowercased().contains(query) { return true }
+        guard let id = row.containerID, let container = docker[id] else { return false }
+        return container.image.lowercased().contains(query)
+            || (container.project?.lowercased().contains(query) ?? false)
+    }
+
+    // MARK: - Cells
+
+    @ViewBuilder
+    private func title(_ row: ActivityRow) -> some View {
+        if row.isProject {
+            Label(row.title, systemImage: "square.stack.3d.up")
+                .font(.body.weight(.medium))
+                .lineLimit(1)
+        } else {
+            Text(row.title)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .help(row.containerID ?? row.title)
+        }
+    }
+
+    /// Numbers read down the column, so they are trailing-aligned and share a
+    /// digit width. A project's totals carry the same weight as its title.
+    private func reading(_ text: String, isProject: Bool) -> some View {
+        Text(text)
+            .monospacedDigit()
+            .fontWeight(isProject ? .medium : .regular)
+            .foregroundStyle(isProject ? .primary : .secondary)
+            .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+
+    private func memoryReading(_ row: ActivityRow) -> String {
+        guard row.memoryLimitBytes > 0 else {
+            return StatsFormat.bytes(row.memoryCurrentBytes)
+        }
+        return "\(StatsFormat.bytes(row.memoryCurrentBytes)) / \(StatsFormat.bytes(row.memoryLimitBytes))"
+    }
+
+    // MARK: - Actions
+
+    @ViewBuilder
+    private func menu(for ids: Set<ActivityRow.ID>) -> some View {
+        // Every action here addresses one container; a project row and a
+        // multiple selection have no single subject.
+        if ids.count == 1, let id = ids.first, docker[id] != nil {
+            Button("Show in Containers") { reveal(id) }
+            Button("Copy Container ID") {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(id, forType: .string)
+            }
+        }
+    }
+
+    private func reveal(_ id: ActivityRow.ID) {
+        guard docker[id] != nil else { return }
+        containersVM.selectedID = id
+        appVM.currentNav = .containers
+    }
+
+    // MARK: - Column layout
 
     /// A layout saved by a build with different columns decodes into something
     /// that no longer matches them; dropping it loses a preference, which beats
@@ -86,31 +203,8 @@ struct ActivityContainerTable: View {
     private func restoreColumnLayout() {
         guard !storedColumnLayout.isEmpty,
             let restored = try? JSONDecoder().decode(
-                TableColumnCustomization<ContainerResourceStats>.self, from: storedColumnLayout)
+                TableColumnCustomization<ActivityRow>.self, from: storedColumnLayout)
         else { return }
         columnLayout = restored
     }
-
-    /// Numbers read down the column, so they are trailing-aligned and share a
-    /// digit width.
-    private func reading(_ text: String) -> some View {
-        Text(text)
-            .monospacedDigit()
-            .foregroundStyle(.secondary)
-            .frame(maxWidth: .infinity, alignment: .trailing)
-    }
-
-    private func memoryReading(_ container: ContainerResourceStats) -> String {
-        guard container.memoryLimitBytes > 0 else {
-            return StatsFormat.bytes(container.memoryCurrentBytes)
-        }
-        return "\(StatsFormat.bytes(container.memoryCurrentBytes)) / \(StatsFormat.bytes(container.memoryLimitBytes))"
-    }
-}
-
-extension ContainerResourceStats {
-    /// Combined throughput, so the paired read/write columns can sort on the
-    /// figure the column actually shows.
-    var diskBytesPerSecond: Double { diskReadBytesPerSecond + diskWriteBytesPerSecond }
-    var networkBytesPerSecond: Double { networkReceiveBytesPerSecond + networkTransmitBytesPerSecond }
 }

--- a/ArcBox/Views/Activity/ActivityContainerTable.swift
+++ b/ArcBox/Views/Activity/ActivityContainerTable.swift
@@ -1,0 +1,82 @@
+import ArcBoxClient
+import SwiftUI
+
+/// Per-container resource usage.
+///
+/// A native `Table` so columns sort, resize and reorder the way every other Mac
+/// table does, and so a row stays selected while the numbers update underneath
+/// it. Sorting defaults to the busiest container first, as in Activity Monitor.
+struct ActivityContainerTable: View {
+    let containers: [ContainerResourceStats]
+
+    @State private var sortOrder = [
+        KeyPathComparator(\ContainerResourceStats.cpuPercent, order: .reverse)
+    ]
+    @State private var selection: ContainerResourceStats.ID?
+
+    var body: some View {
+        Table(containers.sorted(using: sortOrder), selection: $selection, sortOrder: $sortOrder) {
+            TableColumn("Container", value: \.displayName) { container in
+                Text(container.displayName)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(container.id)
+            }
+            .width(min: 140, ideal: 260)
+
+            TableColumn("CPU", value: \.cpuPercent) { container in
+                reading(StatsFormat.percent(container.cpuPercent))
+            }
+            .width(min: 56, ideal: 68)
+
+            TableColumn("Memory", value: \.memoryCurrentBytes) { container in
+                reading(memoryReading(container))
+            }
+            .width(min: 96, ideal: 150)
+
+            TableColumn("Disk R/W", value: \.diskBytesPerSecond) { container in
+                reading(
+                    "\(StatsFormat.rate(container.diskReadBytesPerSecond)) / \(StatsFormat.rate(container.diskWriteBytesPerSecond))"
+                )
+            }
+            .width(min: 120, ideal: 170)
+
+            TableColumn("Net ↓/↑", value: \.networkBytesPerSecond) { container in
+                reading(
+                    "\(StatsFormat.rate(container.networkReceiveBytesPerSecond)) / \(StatsFormat.rate(container.networkTransmitBytesPerSecond))"
+                )
+            }
+            .width(min: 120, ideal: 170)
+
+            TableColumn("PIDs", value: \.pids) { container in
+                reading(container.pids.formatted())
+            }
+            .width(min: 44, ideal: 56)
+        }
+        .tableStyle(.inset)
+        .alternatingRowBackgrounds()
+    }
+
+    /// Numbers read down the column, so they are trailing-aligned and share a
+    /// digit width.
+    private func reading(_ text: String) -> some View {
+        Text(text)
+            .monospacedDigit()
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+
+    private func memoryReading(_ container: ContainerResourceStats) -> String {
+        guard container.memoryLimitBytes > 0 else {
+            return StatsFormat.bytes(container.memoryCurrentBytes)
+        }
+        return "\(StatsFormat.bytes(container.memoryCurrentBytes)) / \(StatsFormat.bytes(container.memoryLimitBytes))"
+    }
+}
+
+extension ContainerResourceStats {
+    /// Combined throughput, so the paired read/write columns can sort on the
+    /// figure the column actually shows.
+    var diskBytesPerSecond: Double { diskReadBytesPerSecond + diskWriteBytesPerSecond }
+    var networkBytesPerSecond: Double { networkReceiveBytesPerSecond + networkTransmitBytesPerSecond }
+}

--- a/ArcBox/Views/Activity/ActivityMetricStrip.swift
+++ b/ArcBox/Views/Activity/ActivityMetricStrip.swift
@@ -71,6 +71,8 @@ private enum MetricTint {
 /// Label, headline number, a figure (sparkline or gauge) and a caption, at the
 /// one shape every tile in the strip shares.
 private struct MetricTile<Figure: View>: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     let title: LocalizedStringKey
     let value: String
     let caption: String
@@ -78,6 +80,10 @@ private struct MetricTile<Figure: View>: View {
     @ViewBuilder var figure: Figure
 
     var body: some View {
+        // Label and caption share one tint and separate by weight and size.
+        // Reaching for `.tertiary` instead would stack a faint grey on a
+        // translucent surface with content moving behind it, which is where
+        // legibility goes first.
         VStack(alignment: .leading, spacing: 4) {
             Text(title)
                 .font(.caption.weight(.medium))
@@ -85,18 +91,42 @@ private struct MetricTile<Figure: View>: View {
             Text(value)
                 .font(.system(.title2, design: .rounded, weight: .semibold))
                 .monospacedDigit()
-                .contentTransition(.numericText())
+                .contentTransition(reduceMotion ? .identity : .numericText())
                 .foregroundStyle(valueColor)
-                .animation(.smooth(duration: 0.25), value: value)
+                .liveValueAnimation(value)
             figure
                 .frame(height: 30)
             Text(caption)
                 .font(.caption2)
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(.secondary)
                 .lineLimit(1)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .combine)
+    }
+}
+
+// MARK: - Motion
+
+extension View {
+    /// Settles a value that the stream, not the user, changed.
+    ///
+    /// Critically damped, because nothing here was thrown: overshoot belongs to
+    /// motion a gesture handed momentum to. Dropped outright under Reduce
+    /// Motion — SwiftUI adapts its own transitions for that setting, but not
+    /// animations you write.
+    fileprivate func liveValueAnimation<V: Equatable>(_ value: V) -> some View {
+        modifier(LiveValueAnimation(value: value))
+    }
+}
+
+private struct LiveValueAnimation<V: Equatable>: ViewModifier {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    let value: V
+
+    func body(content: Content) -> some View {
+        content.animation(reduceMotion ? nil : .smooth(duration: 0.3), value: value)
     }
 }
 
@@ -137,7 +167,7 @@ private struct Sparkline: View {
         .chartYAxis(.hidden)
         .chartYScale(domain: domain ?? autoDomain)
         .chartLegend(.hidden)
-        .animation(.smooth(duration: 0.25), value: points.last?.index)
+        .liveValueAnimation(points.last?.index)
         .accessibilityHidden(true)
     }
 
@@ -166,7 +196,7 @@ private struct PressureTile: View {
             .gaugeStyle(.linearCapacity)
             .tint(tint)
             .opacity(stats.hasMemoryPressure ? 1 : 0.35)
-            .animation(.smooth(duration: 0.25), value: level)
+            .liveValueAnimation(level)
         }
     }
 

--- a/ArcBox/Views/Activity/ActivityMetricStrip.swift
+++ b/ArcBox/Views/Activity/ActivityMetricStrip.swift
@@ -8,7 +8,11 @@ import SwiftUI
 /// layer: a pane per tile would stack glass on glass, and the tiles are one
 /// bar, not four floating controls.
 struct ActivityMetricStrip: View {
-    let stats: MachineResourceStats
+    /// `nil` until the first usable frame. The tiles then render
+    /// representatively-shaped stand-ins for the caller to redact, so the strip
+    /// reaches its real size immediately and nothing moves when the numbers
+    /// arrive.
+    let stats: MachineResourceStats?
     let cpuHistory: [ActivityViewModel.MetricPoint]
     let memoryHistory: [ActivityViewModel.MetricPoint]
     let networkHistory: [ActivityViewModel.MetricPoint]
@@ -24,8 +28,9 @@ struct ActivityMetricStrip: View {
                 points: cpuHistory,
                 tint: MetricTint.cpu,
                 domain: 0...100,
-                liveValue: StatsFormat.percent(stats.cpuPercent),
-                liveCaption: "\(stats.onlineCPUs) cores · load \(StatsFormat.load(stats.loadaverage1))",
+                liveValue: stats.map { StatsFormat.percent($0.cpuPercent) } ?? "00%",
+                liveCaption: stats.map { "\($0.onlineCPUs) cores · load \(StatsFormat.load($0.loadaverage1))" }
+                    ?? "0 cores · load 0.00",
                 format: StatsFormat.percent
             )
 
@@ -34,9 +39,10 @@ struct ActivityMetricStrip: View {
                 points: memoryHistory,
                 tint: MetricTint.memory,
                 domain: 0...100,
-                liveValue: StatsFormat.percent(stats.memoryUsedPercent),
-                liveCaption:
-                    "\(StatsFormat.bytes(stats.memoryUsedBytes)) of \(StatsFormat.bytes(stats.memoryTotalBytes))",
+                liveValue: stats.map { StatsFormat.percent($0.memoryUsedPercent) } ?? "00%",
+                liveCaption: stats.map {
+                    "\(StatsFormat.bytes($0.memoryUsedBytes)) of \(StatsFormat.bytes($0.memoryTotalBytes))"
+                } ?? "0 GB of 0 GB",
                 format: StatsFormat.percent
             )
 
@@ -45,10 +51,12 @@ struct ActivityMetricStrip: View {
                 points: networkHistory,
                 tint: MetricTint.network,
                 domain: nil,
-                liveValue: StatsFormat.rate(
-                    stats.networkReceiveBytesPerSecond + stats.networkTransmitBytesPerSecond),
-                liveCaption:
-                    "↓ \(StatsFormat.rate(stats.networkReceiveBytesPerSecond))  ↑ \(StatsFormat.rate(stats.networkTransmitBytesPerSecond))",
+                liveValue: stats.map {
+                    StatsFormat.rate($0.networkReceiveBytesPerSecond + $0.networkTransmitBytesPerSecond)
+                } ?? "0 MB/s",
+                liveCaption: stats.map {
+                    "↓ \(StatsFormat.rate($0.networkReceiveBytesPerSecond))  ↑ \(StatsFormat.rate($0.networkTransmitBytesPerSecond))"
+                } ?? "↓ 0 MB/s  ↑ 0 MB/s",
                 format: StatsFormat.rate
             )
 
@@ -141,6 +149,9 @@ private struct MetricTile<Figure: View>: View {
             Text(title)
                 .font(.caption.weight(.medium))
                 .foregroundStyle(.secondary)
+                // The label is known before the sample is; redacting it would
+                // claim the screen knows less than it does.
+                .unredacted()
             Text(value)
                 .font(.system(.title2, design: .rounded, weight: .semibold))
                 .monospacedDigit()
@@ -247,13 +258,13 @@ private struct Sparkline: View {
 /// PSI memory pressure. Green under light pressure, amber past 10%, red past
 /// 40% — the daemon's own thresholds.
 private struct PressureTile: View {
-    let stats: MachineResourceStats
+    let stats: MachineResourceStats?
 
     var body: some View {
         MetricTile(
             title: "Memory Pressure",
-            value: stats.hasMemoryPressure ? StatsFormat.percent(stats.memoryPressurePercent) : "n/a",
-            caption: stats.hasMemoryPressure ? "PSI full avg10" : "PSI unavailable (no CONFIG_PSI)",
+            value: value,
+            caption: caption,
             valueColor: tint
         ) {
             Gauge(value: level, in: 0...100) {
@@ -261,17 +272,28 @@ private struct PressureTile: View {
             }
             .gaugeStyle(.linearCapacity)
             .tint(tint)
-            .opacity(stats.hasMemoryPressure ? 1 : 0.35)
+            .opacity(stats?.hasMemoryPressure == false ? 0.35 : 1)
             .liveValueAnimation(level)
         }
     }
 
+    private var value: String {
+        guard let stats else { return "00%" }
+        return stats.hasMemoryPressure ? StatsFormat.percent(stats.memoryPressurePercent) : "n/a"
+    }
+
+    private var caption: String {
+        guard let stats else { return "PSI full avg10" }
+        return stats.hasMemoryPressure ? "PSI full avg10" : "PSI unavailable (no CONFIG_PSI)"
+    }
+
     private var level: Double {
-        stats.hasMemoryPressure ? min(stats.memoryPressurePercent, 100) : 0
+        guard let stats, stats.hasMemoryPressure else { return 0 }
+        return min(stats.memoryPressurePercent, 100)
     }
 
     private var tint: Color {
-        guard stats.hasMemoryPressure else { return AppColors.textMuted }
+        guard let stats, stats.hasMemoryPressure else { return AppColors.textMuted }
         switch stats.memoryPressurePercent {
         case ..<10: return AppColors.running
         case ..<40: return AppColors.warning

--- a/ArcBox/Views/Activity/ActivityMetricStrip.swift
+++ b/ArcBox/Views/Activity/ActivityMetricStrip.swift
@@ -19,31 +19,38 @@ struct ActivityMetricStrip: View {
             alignment: .leading,
             spacing: 14
         ) {
-            MetricTile(
+            SparklineTile(
                 title: "CPU",
-                value: StatsFormat.percent(stats.cpuPercent),
-                caption: "\(stats.onlineCPUs) cores · load \(StatsFormat.load(stats.loadaverage1))"
-            ) {
-                Sparkline(points: cpuHistory, tint: MetricTint.cpu, domain: 0...100)
-            }
+                points: cpuHistory,
+                tint: MetricTint.cpu,
+                domain: 0...100,
+                liveValue: StatsFormat.percent(stats.cpuPercent),
+                liveCaption: "\(stats.onlineCPUs) cores · load \(StatsFormat.load(stats.loadaverage1))",
+                format: StatsFormat.percent
+            )
 
-            MetricTile(
+            SparklineTile(
                 title: "Memory",
-                value: StatsFormat.percent(stats.memoryUsedPercent),
-                caption: "\(StatsFormat.bytes(stats.memoryUsedBytes)) of \(StatsFormat.bytes(stats.memoryTotalBytes))"
-            ) {
-                Sparkline(points: memoryHistory, tint: MetricTint.memory, domain: 0...100)
-            }
+                points: memoryHistory,
+                tint: MetricTint.memory,
+                domain: 0...100,
+                liveValue: StatsFormat.percent(stats.memoryUsedPercent),
+                liveCaption:
+                    "\(StatsFormat.bytes(stats.memoryUsedBytes)) of \(StatsFormat.bytes(stats.memoryTotalBytes))",
+                format: StatsFormat.percent
+            )
 
-            MetricTile(
+            SparklineTile(
                 title: "Network",
-                value: StatsFormat.rate(
+                points: networkHistory,
+                tint: MetricTint.network,
+                domain: nil,
+                liveValue: StatsFormat.rate(
                     stats.networkReceiveBytesPerSecond + stats.networkTransmitBytesPerSecond),
-                caption:
-                    "↓ \(StatsFormat.rate(stats.networkReceiveBytesPerSecond))  ↑ \(StatsFormat.rate(stats.networkTransmitBytesPerSecond))"
-            ) {
-                Sparkline(points: networkHistory, tint: MetricTint.network, domain: nil)
-            }
+                liveCaption:
+                    "↓ \(StatsFormat.rate(stats.networkReceiveBytesPerSecond))  ↑ \(StatsFormat.rate(stats.networkTransmitBytesPerSecond))",
+                format: StatsFormat.rate
+            )
 
             PressureTile(stats: stats)
         }
@@ -66,7 +73,53 @@ private enum MetricTint {
     static let network = Color.purple
 }
 
-// MARK: - Tile
+// MARK: - Tiles
+
+/// A metric with history. Selecting a point on the sparkline rewinds the
+/// headline to that sample and says how long ago it was, which is the whole
+/// reason to keep a minute of history on screen rather than just the latest
+/// number. `chartXSelection` decides what counts as selecting — the platform's
+/// convention, not ours.
+private struct SparklineTile: View {
+    let title: LocalizedStringKey
+    let points: [ActivityViewModel.MetricPoint]
+    let tint: Color
+    /// Fixed y range, or `nil` to autoscale (used for byte rates).
+    let domain: ClosedRange<Double>?
+    let liveValue: String
+    let liveCaption: String
+    let format: (Double) -> String
+
+    @State private var scrubbedIndex: Int?
+
+    var body: some View {
+        MetricTile(
+            title: title,
+            value: scrubbed.map { format($0.value) } ?? liveValue,
+            caption: scrubbed.map(elapsedCaption) ?? liveCaption,
+            // Tinting only while scrubbing marks the headline as a reading from
+            // the past rather than the live value.
+            valueColor: scrubbed == nil ? AppColors.text : tint
+        ) {
+            Sparkline(points: points, tint: tint, domain: domain, scrubbedIndex: $scrubbedIndex)
+        }
+    }
+
+    private var scrubbed: ActivityViewModel.MetricPoint? {
+        scrubbedIndex.flatMap { index in points.first { $0.index == index } }
+    }
+
+    /// Guest-clock distance from the newest sample. Reported from the timestamps
+    /// rather than the sample count, so a stalled or throttled stream doesn't
+    /// quietly misreport the age.
+    private func elapsedCaption(_ point: ActivityViewModel.MetricPoint) -> String {
+        guard let latest = points.last, latest.monotonicMs > point.monotonicMs else {
+            return "latest sample"
+        }
+        let seconds = Int((latest.monotonicMs - point.monotonicMs) / 1000)
+        return seconds < 1 ? "latest sample" : "\(seconds)s ago"
+    }
+}
 
 /// Label, headline number, a figure (sparkline or gauge) and a caption, at the
 /// one shape every tile in the strip shares.
@@ -132,13 +185,15 @@ private struct LiveValueAnimation<V: Equatable>: ViewModifier {
 
 // MARK: - Figures
 
-/// A filled line over the rolling history. Purely a trend cue — the tile's
-/// number carries the value, so it stays out of the accessibility tree.
+/// A filled line over the rolling history, scrubbable with the pointer. The
+/// tile's headline carries the value in text, so the chart itself stays out of
+/// the accessibility tree rather than announcing sixty unlabelled samples.
 private struct Sparkline: View {
     let points: [ActivityViewModel.MetricPoint]
     let tint: Color
     /// Fixed y range, or `nil` to autoscale (used for byte rates).
     let domain: ClosedRange<Double>?
+    @Binding var scrubbedIndex: Int?
 
     var body: some View {
         Chart {
@@ -157,18 +212,29 @@ private struct Sparkline: View {
                     .lineStyle(StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round))
                     .interpolationMethod(.monotone)
             }
-            if let latest = points.last {
-                PointMark(x: .value("Sample", latest.index), y: .value("Value", latest.value))
+            // The marker follows the pointer while scrubbing and returns to the
+            // newest sample when it leaves, so there is always exactly one.
+            if let marked = marked {
+                RuleMark(x: .value("Sample", marked.index))
+                    .foregroundStyle(tint.opacity(scrubbedIndex == nil ? 0 : 0.35))
+                    .lineStyle(StrokeStyle(lineWidth: 1))
+                PointMark(x: .value("Sample", marked.index), y: .value("Value", marked.value))
                     .foregroundStyle(tint)
-                    .symbolSize(16)
+                    .symbolSize(scrubbedIndex == nil ? 16 : 40)
             }
         }
         .chartXAxis(.hidden)
         .chartYAxis(.hidden)
         .chartYScale(domain: domain ?? autoDomain)
         .chartLegend(.hidden)
+        .chartXSelection(value: $scrubbedIndex)
         .liveValueAnimation(points.last?.index)
         .accessibilityHidden(true)
+    }
+
+    private var marked: ActivityViewModel.MetricPoint? {
+        guard let scrubbedIndex else { return points.last }
+        return points.first { $0.index == scrubbedIndex } ?? points.last
     }
 
     /// Headroom above the observed peak so a flat-zero series still renders.

--- a/ArcBox/Views/Activity/ActivityMetricStrip.swift
+++ b/ArcBox/Views/Activity/ActivityMetricStrip.swift
@@ -1,0 +1,185 @@
+import ArcBoxClient
+import Charts
+import SwiftUI
+
+/// The machine-wide metric bar that floats over the container table.
+///
+/// One glass surface holds every tile. Liquid Glass is a single functional
+/// layer: a pane per tile would stack glass on glass, and the tiles are one
+/// bar, not four floating controls.
+struct ActivityMetricStrip: View {
+    let stats: MachineResourceStats
+    let cpuHistory: [ActivityViewModel.MetricPoint]
+    let memoryHistory: [ActivityViewModel.MetricPoint]
+    let networkHistory: [ActivityViewModel.MetricPoint]
+
+    var body: some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 170), spacing: 20)],
+            alignment: .leading,
+            spacing: 14
+        ) {
+            MetricTile(
+                title: "CPU",
+                value: StatsFormat.percent(stats.cpuPercent),
+                caption: "\(stats.onlineCPUs) cores · load \(StatsFormat.load(stats.loadaverage1))"
+            ) {
+                Sparkline(points: cpuHistory, tint: MetricTint.cpu, domain: 0...100)
+            }
+
+            MetricTile(
+                title: "Memory",
+                value: StatsFormat.percent(stats.memoryUsedPercent),
+                caption: "\(StatsFormat.bytes(stats.memoryUsedBytes)) of \(StatsFormat.bytes(stats.memoryTotalBytes))"
+            ) {
+                Sparkline(points: memoryHistory, tint: MetricTint.memory, domain: 0...100)
+            }
+
+            MetricTile(
+                title: "Network",
+                value: StatsFormat.rate(
+                    stats.networkReceiveBytesPerSecond + stats.networkTransmitBytesPerSecond),
+                caption:
+                    "↓ \(StatsFormat.rate(stats.networkReceiveBytesPerSecond))  ↑ \(StatsFormat.rate(stats.networkTransmitBytesPerSecond))"
+            ) {
+                Sparkline(points: networkHistory, tint: MetricTint.network, domain: nil)
+            }
+
+            PressureTile(stats: stats)
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 14)
+        .glassSurface()
+        .padding(.horizontal, 16)
+        .padding(.top, 10)
+        .padding(.bottom, 12)
+    }
+}
+
+/// Sparkline hues. System colors, so they track the appearance and the
+/// increase-contrast setting; deliberately not the accent color, which means
+/// "interactive" everywhere else in the app, and deliberately three distinct
+/// hues so no two trends read as the same series.
+private enum MetricTint {
+    static let cpu = Color.green
+    static let memory = Color.blue
+    static let network = Color.purple
+}
+
+// MARK: - Tile
+
+/// Label, headline number, a figure (sparkline or gauge) and a caption, at the
+/// one shape every tile in the strip shares.
+private struct MetricTile<Figure: View>: View {
+    let title: LocalizedStringKey
+    let value: String
+    let caption: String
+    var valueColor: Color = AppColors.text
+    @ViewBuilder var figure: Figure
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(.title2, design: .rounded, weight: .semibold))
+                .monospacedDigit()
+                .contentTransition(.numericText())
+                .foregroundStyle(valueColor)
+                .animation(.smooth(duration: 0.25), value: value)
+            figure
+                .frame(height: 30)
+            Text(caption)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+// MARK: - Figures
+
+/// A filled line over the rolling history. Purely a trend cue — the tile's
+/// number carries the value, so it stays out of the accessibility tree.
+private struct Sparkline: View {
+    let points: [ActivityViewModel.MetricPoint]
+    let tint: Color
+    /// Fixed y range, or `nil` to autoscale (used for byte rates).
+    let domain: ClosedRange<Double>?
+
+    var body: some View {
+        Chart {
+            ForEach(points) { point in
+                AreaMark(x: .value("Sample", point.index), y: .value("Value", point.value))
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [tint.opacity(0.35), tint.opacity(0.02)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                    .interpolationMethod(.monotone)
+                LineMark(x: .value("Sample", point.index), y: .value("Value", point.value))
+                    .foregroundStyle(tint)
+                    .lineStyle(StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round))
+                    .interpolationMethod(.monotone)
+            }
+            if let latest = points.last {
+                PointMark(x: .value("Sample", latest.index), y: .value("Value", latest.value))
+                    .foregroundStyle(tint)
+                    .symbolSize(16)
+            }
+        }
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
+        .chartYScale(domain: domain ?? autoDomain)
+        .chartLegend(.hidden)
+        .animation(.smooth(duration: 0.25), value: points.last?.index)
+        .accessibilityHidden(true)
+    }
+
+    /// Headroom above the observed peak so a flat-zero series still renders.
+    private var autoDomain: ClosedRange<Double> {
+        let peak = points.map(\.value).max() ?? 1
+        return 0...max(peak * 1.2, 1)
+    }
+}
+
+/// PSI memory pressure. Green under light pressure, amber past 10%, red past
+/// 40% — the daemon's own thresholds.
+private struct PressureTile: View {
+    let stats: MachineResourceStats
+
+    var body: some View {
+        MetricTile(
+            title: "Memory Pressure",
+            value: stats.hasMemoryPressure ? StatsFormat.percent(stats.memoryPressurePercent) : "n/a",
+            caption: stats.hasMemoryPressure ? "PSI full avg10" : "PSI unavailable (no CONFIG_PSI)",
+            valueColor: tint
+        ) {
+            Gauge(value: level, in: 0...100) {
+                EmptyView()
+            }
+            .gaugeStyle(.linearCapacity)
+            .tint(tint)
+            .opacity(stats.hasMemoryPressure ? 1 : 0.35)
+            .animation(.smooth(duration: 0.25), value: level)
+        }
+    }
+
+    private var level: Double {
+        stats.hasMemoryPressure ? min(stats.memoryPressurePercent, 100) : 0
+    }
+
+    private var tint: Color {
+        guard stats.hasMemoryPressure else { return AppColors.textMuted }
+        switch stats.memoryPressurePercent {
+        case ..<10: return AppColors.running
+        case ..<40: return AppColors.warning
+        default: return AppColors.error
+        }
+    }
+}

--- a/ArcBox/Views/Activity/ActivityRow.swift
+++ b/ArcBox/Views/Activity/ActivityRow.swift
@@ -1,0 +1,162 @@
+import ArcBoxClient
+import Foundation
+
+/// One line in the activity table: a container, or a Compose project's total.
+///
+/// The join happens here rather than in the daemon. The stats stream carries
+/// cgroup counters keyed by container ID — all the guest can measure — while
+/// the project a container belongs to is a Docker label the app already holds
+/// from the Engine API. Combining them client-side keeps the daemon's stats
+/// path to what it can actually observe.
+nonisolated struct ActivityRow: Identifiable, Equatable, Sendable {
+    enum Kind: Equatable, Sendable {
+        /// A single container, carrying its full ID for actions and joins.
+        case container(id: String)
+        /// A Compose project's total.
+        case project
+    }
+
+    let id: String
+    let title: String
+    let kind: Kind
+    let cpuPercent: Double
+    let memoryCurrentBytes: UInt64
+    /// 0 means unlimited. A project reports 0 unless every member is limited —
+    /// summing around an unlimited member would invent a ceiling.
+    let memoryLimitBytes: UInt64
+    let diskReadBytesPerSecond: Double
+    let diskWriteBytesPerSecond: Double
+    let networkReceiveBytesPerSecond: Double
+    let networkTransmitBytesPerSecond: Double
+    let pids: UInt32
+
+    /// Combined throughput, so the paired read/write columns sort on the figure
+    /// the column actually shows.
+    var diskBytesPerSecond: Double { diskReadBytesPerSecond + diskWriteBytesPerSecond }
+    var networkBytesPerSecond: Double {
+        networkReceiveBytesPerSecond + networkTransmitBytesPerSecond
+    }
+
+    var containerID: String? {
+        guard case .container(let id) = kind else { return nil }
+        return id
+    }
+
+    var isProject: Bool { kind == .project }
+}
+
+nonisolated extension ActivityRow {
+    init(_ container: ContainerResourceStats) {
+        self.init(
+            id: container.id,
+            title: container.displayName,
+            kind: .container(id: container.id),
+            cpuPercent: container.cpuPercent,
+            memoryCurrentBytes: container.memoryCurrentBytes,
+            memoryLimitBytes: container.memoryLimitBytes,
+            diskReadBytesPerSecond: container.diskReadBytesPerSecond,
+            diskWriteBytesPerSecond: container.diskWriteBytesPerSecond,
+            networkReceiveBytesPerSecond: container.networkReceiveBytesPerSecond,
+            networkTransmitBytesPerSecond: container.networkTransmitBytesPerSecond,
+            pids: container.pids
+        )
+    }
+
+    /// A project's total.
+    ///
+    /// The ID is namespaced with a character a container ID cannot contain —
+    /// those are hex — so a project and a container can never collide in the
+    /// table's selection or in its saved disclosure state.
+    static func project(named project: String, totalling members: [ActivityRow]) -> ActivityRow {
+        let limits = members.map(\.memoryLimitBytes)
+        return ActivityRow(
+            id: "project:\(project)",
+            title: project,
+            kind: .project,
+            cpuPercent: members.reduce(0) { $0 + $1.cpuPercent },
+            memoryCurrentBytes: members.reduce(0) { $0 + $1.memoryCurrentBytes },
+            memoryLimitBytes: limits.contains(0) ? 0 : limits.reduce(0, +),
+            diskReadBytesPerSecond: members.reduce(0) { $0 + $1.diskReadBytesPerSecond },
+            diskWriteBytesPerSecond: members.reduce(0) { $0 + $1.diskWriteBytesPerSecond },
+            networkReceiveBytesPerSecond: members.reduce(0) { $0 + $1.networkReceiveBytesPerSecond },
+            networkTransmitBytesPerSecond: members.reduce(0) {
+                $0 + $1.networkTransmitBytesPerSecond
+            },
+            pids: members.reduce(0) { $0 + $1.pids }
+        )
+    }
+}
+
+/// What Docker contributes to a stats row that the guest's cgroup counters
+/// cannot: the project it groups under, and the image the search field matches.
+///
+/// Narrower than the container view model it comes from, so the table depends
+/// on the two facts it uses rather than on the Containers feature.
+nonisolated struct ActivityContainerFacts: Equatable, Sendable {
+    let project: String?
+    let image: String
+}
+
+/// A top-level row and, when it totals a project, the containers beneath it.
+nonisolated struct ActivityRowGroup: Identifiable, Equatable, Sendable {
+    let summary: ActivityRow
+    /// Empty for a standalone container, which renders as a plain row.
+    let children: [ActivityRow]
+
+    var id: String { summary.id }
+}
+
+nonisolated enum ActivityRowGrouping {
+    /// Groups rows by Compose project, matching what the Containers list does:
+    /// a project for every container that declares one, standalone rows for the
+    /// rest.
+    ///
+    /// A container absent from `projects` — started with a plain `docker run`,
+    /// or not yet reported by the Engine — stays at the top level rather than
+    /// landing in a catch-all bucket that would imply a relationship it has no
+    /// evidence for.
+    static func groups(
+        for rows: [ActivityRow],
+        projects: [String: String],
+        sortedBy comparators: [KeyPathComparator<ActivityRow>]
+    ) -> [ActivityRowGroup] {
+        var members: [String: [ActivityRow]] = [:]
+        var standalone: [ActivityRow] = []
+        for row in rows {
+            guard let id = row.containerID, let project = projects[id] else {
+                standalone.append(row)
+                continue
+            }
+            members[project, default: []].append(row)
+        }
+
+        let projects = members.map { project, members in
+            ActivityRowGroup(
+                summary: .project(named: project, totalling: members),
+                children: members.sorted(using: comparators)
+            )
+        }
+        let loose = standalone.map { ActivityRowGroup(summary: $0, children: []) }
+        return (projects + loose).sorted {
+            precedes($0.summary, $1.summary, using: comparators)
+        }
+    }
+
+    /// Applies a table's comparators in order, as `sorted(using:)` would to the
+    /// rows themselves — the summaries are what order the groups, and they are
+    /// not a flat array the table can sort on its own.
+    private static func precedes(
+        _ lhs: ActivityRow,
+        _ rhs: ActivityRow,
+        using comparators: [KeyPathComparator<ActivityRow>]
+    ) -> Bool {
+        for comparator in comparators {
+            switch comparator.compare(lhs, rhs) {
+            case .orderedAscending: return true
+            case .orderedDescending: return false
+            case .orderedSame: continue
+            }
+        }
+        return false
+    }
+}

--- a/ArcBox/Views/Activity/ActivityView.swift
+++ b/ArcBox/Views/Activity/ActivityView.swift
@@ -1,332 +1,119 @@
 import ArcBoxClient
-import Charts
 import SwiftUI
 
-/// Live resource monitor for the System VM: machine CPU / memory / network
-/// with short history sparklines, a PSI memory-pressure gauge, and a
-/// per-container table. Backed by the daemon's `StatsService` stream via
-/// `ActivityViewModel`.
+/// Live resource monitor for the System VM, backed by the daemon's
+/// `StatsService` stream via `ActivityViewModel`.
+///
+/// The machine-wide metrics float in the Liquid Glass layer while the
+/// per-container table scrolls beneath them, so the numbers you are comparing
+/// against stay on screen while you scan containers.
 struct ActivityView: View {
     @Environment(ActivityViewModel.self) private var vm
     @Environment(\.arcboxClient) private var arcboxClient
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                header
-
-                if let stats = vm.current {
-                    charts(stats)
-                    containerSection(stats)
-                } else {
-                    waitingForData
+        content
+            .navigationTitle("Activity")
+            .navigationSubtitle(subtitle)
+            .toolbar {
+                ToolbarItem(placement: .status) {
+                    StreamStatusPill(phase: vm.phase)
                 }
             }
-            .padding(20)
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .background(AppColors.background)
-        .navigationTitle("Activity")
-        // Re-key on the client's identity so the stream (re)starts when the
-        // client first becomes available or is swapped.
-        .task(id: arcboxClient.map(ObjectIdentifier.init)) {
-            guard let client = arcboxClient else { return }
-            await vm.run(client: client)
-        }
-    }
-
-    // MARK: - Header
-
-    private var header: some View {
-        HStack {
-            Text("System VM")
-                .font(.system(size: 20, weight: .semibold))
-                .foregroundStyle(AppColors.text)
-            Spacer()
-            switch vm.phase {
-            case .live:
-                StatusBadge(color: AppColors.running, label: "LIVE")
-            case .reconnecting:
-                // Charts keep showing the last data; the badge tells the
-                // user it is stale while the stream reconnects.
-                StatusBadge(color: AppColors.warning, label: "RECONNECTING")
-            case .connecting:
-                EmptyView()
+            // Re-key on the client's identity so the stream (re)starts when the
+            // client first becomes available or is swapped.
+            .task(id: arcboxClient.map(ObjectIdentifier.init)) {
+                guard let client = arcboxClient else { return }
+                await vm.run(client: client)
             }
-        }
     }
-
-    private var waitingForData: some View {
-        HStack(spacing: 10) {
-            ProgressView().controlSize(.small)
-            Text(waitingLabel)
-                .foregroundStyle(AppColors.textSecondary)
-                .font(.system(size: 13))
-        }
-        .frame(maxWidth: .infinity, minHeight: 160)
-    }
-
-    /// Distinguishes a first connection from a stream that keeps failing
-    /// before its first sample, so persistent errors don't render as an
-    /// eternal "waiting" spinner.
-    private var waitingLabel: String {
-        if case .reconnecting(let attempt) = vm.phase {
-            return "Stats stream unavailable — retrying (attempt \(attempt))…"
-        }
-        return "Waiting for the first sample…"
-    }
-
-    // MARK: - Charts
-
-    private func charts(_ stats: MachineResourceStats) -> some View {
-        LazyVGrid(
-            columns: [GridItem(.adaptive(minimum: 240), spacing: 12)],
-            spacing: 12
-        ) {
-            SparklineCard(
-                title: "CPU",
-                value: StatsFormat.percent(stats.cpuPercent),
-                subtitle: "\(stats.onlineCPUs) cores · load \(String(format: "%.2f", stats.loadaverage1))",
-                points: vm.cpuHistory,
-                tint: AppColors.running,
-                yDomain: 0...100
-            )
-            SparklineCard(
-                title: "Memory",
-                value: StatsFormat.percent(stats.memoryUsedPercent),
-                subtitle: "\(StatsFormat.bytes(stats.memoryUsedBytes)) / \(StatsFormat.bytes(stats.memoryTotalBytes))",
-                points: vm.memoryHistory,
-                tint: AppColors.accent,
-                yDomain: 0...100
-            )
-            SparklineCard(
-                title: "Network",
-                value: StatsFormat.rate(
-                    stats.networkReceiveBytesPerSecond + stats.networkTransmitBytesPerSecond),
-                subtitle:
-                    "↓ \(StatsFormat.rate(stats.networkReceiveBytesPerSecond))   ↑ \(StatsFormat.rate(stats.networkTransmitBytesPerSecond))",
-                points: vm.networkHistory,
-                tint: AppColors.warning,
-                yDomain: nil
-            )
-            PressureCard(stats: stats)
-        }
-    }
-
-    // MARK: - Containers
 
     @ViewBuilder
-    private func containerSection(_ stats: MachineResourceStats) -> some View {
-        Text("Containers")
-            .font(.system(size: 11, weight: .medium))
-            .foregroundStyle(AppColors.sectionHeader)
-            .textCase(.uppercase)
-            .padding(.top, 4)
-
-        if stats.containers.isEmpty {
-            Text("No running containers")
-                .foregroundStyle(AppColors.textMuted)
-                .font(.system(size: 13))
-                .padding(.vertical, 8)
-        } else {
-            VStack(spacing: 0) {
-                ContainerStatsHeader()
-                ForEach(stats.containers) { container in
-                    ContainerStatsRow(container: container)
-                    if container.id != stats.containers.last?.id {
-                        Divider().overlay(AppColors.borderSubtle)
+    private var content: some View {
+        if let stats = vm.current {
+            ActivityContainerTable(containers: stats.containers)
+                .overlay {
+                    if stats.containers.isEmpty {
+                        ContentUnavailableView(
+                            "No Running Containers",
+                            systemImage: "cube",
+                            description: Text("Per-container usage appears here while containers are running.")
+                        )
                     }
                 }
+                .safeAreaInset(edge: .top, spacing: 0) {
+                    ActivityMetricStrip(
+                        stats: stats,
+                        cpuHistory: vm.cpuHistory,
+                        memoryHistory: vm.memoryHistory,
+                        networkHistory: vm.networkHistory
+                    )
+                }
+                .softScrollEdge(for: .top)
+        } else {
+            waitingForData
+        }
+    }
+
+    /// The machine's shape, once known — the toolbar's own line for the
+    /// constants the tiles would otherwise have to repeat.
+    private var subtitle: String {
+        guard let stats = vm.current else { return "System VM" }
+        return "System VM · \(stats.onlineCPUs) cores · \(StatsFormat.bytes(stats.memoryTotalBytes))"
+    }
+
+    /// Distinguishes a first connection from a stream that keeps failing before
+    /// its first sample, so a persistent error stops looking like a spinner
+    /// that will resolve on its own.
+    @ViewBuilder
+    private var waitingForData: some View {
+        if case .reconnecting(let attempt) = vm.phase, attempt >= 3 {
+            ContentUnavailableView {
+                Label("Stats Unavailable", systemImage: "waveform.path.ecg")
+            } description: {
+                Text("The daemon's stats stream keeps dropping. Retrying — attempt \(attempt).")
             }
-            .cardStyle()
-        }
-    }
-}
-
-// MARK: - Sparkline card
-
-private struct SparklineCard: View {
-    let title: String
-    let value: String
-    let subtitle: String
-    let points: [ActivityViewModel.MetricPoint]
-    let tint: Color
-    /// Fixed y-axis range, or `nil` to autoscale (used for byte rates).
-    let yDomain: ClosedRange<Double>?
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(title)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(AppColors.textSecondary)
-                .textCase(.uppercase)
-            Text(value)
-                .font(.system(size: 28, weight: .semibold, design: .rounded))
-                .foregroundStyle(AppColors.text)
-                .contentTransition(.numericText())
-            chart
-                .frame(height: 44)
-            Text(subtitle)
-                .font(.system(size: 11))
-                .foregroundStyle(AppColors.textMuted)
-                .lineLimit(1)
-        }
-        .padding(16)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .cardStyle()
-    }
-
-    private var chart: some View {
-        Chart(points) { point in
-            AreaMark(x: .value("t", point.index), y: .value("v", point.value))
-                .foregroundStyle(tint.opacity(0.15))
-                .interpolationMethod(.monotone)
-            LineMark(x: .value("t", point.index), y: .value("v", point.value))
-                .foregroundStyle(tint)
-                .interpolationMethod(.monotone)
-        }
-        .chartXAxis(.hidden)
-        .chartYAxis(.hidden)
-        .chartYScale(domain: yDomain ?? autoDomain)
-        .animation(.easeOut(duration: 0.25), value: points.last?.index)
-    }
-
-    /// Headroom above the observed peak so a flat-zero series still renders.
-    private var autoDomain: ClosedRange<Double> {
-        let peak = points.map(\.value).max() ?? 1
-        return 0...max(peak * 1.2, 1)
-    }
-}
-
-// MARK: - Pressure gauge card
-
-private struct PressureCard: View {
-    let stats: MachineResourceStats
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Memory Pressure")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(AppColors.textSecondary)
-                .textCase(.uppercase)
-            Text(valueText)
-                .font(.system(size: 28, weight: .semibold, design: .rounded))
-                .foregroundStyle(tint)
-                .contentTransition(.numericText())
-            Gauge(value: stats.hasMemoryPressure ? min(stats.memoryPressurePercent, 100) : 0, in: 0...100) {
-                EmptyView()
+        } else {
+            VStack(spacing: 12) {
+                ProgressView()
+                    .controlSize(.large)
+                Text("Waiting for the first sample…")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
             }
-            .gaugeStyle(.accessoryLinearCapacity)
-            .tint(tint)
-            .frame(height: 44)
-            .opacity(stats.hasMemoryPressure ? 1 : 0.35)
-            Text(stats.hasMemoryPressure ? "PSI full avg10" : "PSI unavailable (no CONFIG_PSI)")
-                .font(.system(size: 11))
-                .foregroundStyle(AppColors.textMuted)
-                .lineLimit(1)
-        }
-        .padding(16)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .cardStyle()
-    }
-
-    private var valueText: String {
-        stats.hasMemoryPressure ? StatsFormat.percent(stats.memoryPressurePercent) : "n/a"
-    }
-
-    /// Green under light pressure, amber past 10%, red past 40% — matching
-    /// the daemon's own pressure thresholds.
-    private var tint: Color {
-        guard stats.hasMemoryPressure else { return AppColors.textMuted }
-        switch stats.memoryPressurePercent {
-        case ..<10: return AppColors.running
-        case ..<40: return AppColors.warning
-        default: return AppColors.error
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 }
 
-// MARK: - Container table
+// MARK: - Status
 
-private struct ContainerStatsHeader: View {
-    var body: some View {
-        HStack(spacing: 12) {
-            cell("CONTAINER", width: nil, alignment: .leading)
-            cell("CPU", width: 64, alignment: .trailing)
-            cell("MEMORY", width: 96, alignment: .trailing)
-            cell("DISK R/W", width: 128, alignment: .trailing)
-            cell("NET ↓/↑", width: 128, alignment: .trailing)
-            cell("PIDS", width: 48, alignment: .trailing)
-        }
-        .font(.system(size: 10, weight: .medium))
-        .foregroundStyle(AppColors.sectionHeader)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-    }
-
-    private func cell(_ text: String, width: CGFloat?, alignment: Alignment) -> some View {
-        Text(text)
-            .frame(width: width, alignment: alignment)
-            .frame(maxWidth: width == nil ? .infinity : nil, alignment: alignment)
-    }
-}
-
-private struct ContainerStatsRow: View {
-    let container: ContainerResourceStats
+/// Stream health, in the toolbar's status slot: absent while connecting, quiet
+/// once live, and loud only when the data on screen has gone stale.
+private struct StreamStatusPill: View {
+    let phase: ActivityViewModel.StreamPhase
 
     var body: some View {
-        HStack(spacing: 12) {
-            Text(container.displayName)
-                .font(.system(size: 13))
-                .foregroundStyle(AppColors.text)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            Text(StatsFormat.percent(container.cpuPercent))
-                .frame(width: 64, alignment: .trailing)
-            Text(memoryText)
-                .frame(width: 96, alignment: .trailing)
-            Text(
-                "\(StatsFormat.rate(container.diskReadBytesPerSecond)) / \(StatsFormat.rate(container.diskWriteBytesPerSecond))"
-            )
-            .frame(width: 128, alignment: .trailing)
-            Text(
-                "\(StatsFormat.rate(container.networkReceiveBytesPerSecond)) / \(StatsFormat.rate(container.networkTransmitBytesPerSecond))"
-            )
-            .frame(width: 128, alignment: .trailing)
-            Text("\(container.pids)")
-                .frame(width: 48, alignment: .trailing)
+        if let (color, label) = descriptor {
+            HStack(spacing: 5) {
+                Circle()
+                    .fill(color)
+                    .frame(width: 7, height: 7)
+                Text(label)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityElement(children: .combine)
         }
-        .font(.system(size: 12).monospacedDigit())
-        .foregroundStyle(AppColors.textSecondary)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
     }
 
-    private var memoryText: String {
-        if container.memoryLimitBytes == 0 {
-            return StatsFormat.bytes(container.memoryCurrentBytes)
+    private var descriptor: (Color, LocalizedStringKey)? {
+        switch phase {
+        case .live: (AppColors.running, "Live")
+        // Charts keep showing the last data; the pill tells the user it is
+        // stale while the stream reconnects.
+        case .reconnecting: (AppColors.warning, "Reconnecting")
+        case .connecting: nil
         }
-        return
-            "\(StatsFormat.bytes(container.memoryCurrentBytes)) / \(StatsFormat.bytes(container.memoryLimitBytes))"
-    }
-}
-
-// MARK: - Formatting
-
-/// Formatting for resource values, using `ByteCountFormatter` (memory
-/// style) so sizes match Finder/Activity Monitor conventions.
-enum StatsFormat {
-    static func percent(_ value: Double) -> String {
-        String(format: "%.0f%%", value)
-    }
-
-    static func bytes(_ value: UInt64) -> String {
-        ByteCountFormatter.string(fromByteCount: Int64(clamping: value), countStyle: .memory)
-    }
-
-    static func rate(_ bytesPerSecond: Double) -> String {
-        let clamped = Int64(max(0, bytesPerSecond).rounded())
-        return ByteCountFormatter.string(fromByteCount: clamped, countStyle: .memory) + "/s"
     }
 }

--- a/ArcBox/Views/Activity/ActivityView.swift
+++ b/ArcBox/Views/Activity/ActivityView.swift
@@ -75,7 +75,8 @@ struct ActivityView: View {
     /// constants the tiles would otherwise have to repeat.
     private var subtitle: String {
         guard let stats = vm.current else { return "System VM" }
-        return "System VM · \(stats.onlineCPUs) cores · \(StatsFormat.bytes(stats.memoryTotalBytes))"
+        return
+            "System VM · \(stats.onlineCPUs) cores · \(StatsFormat.bytes(stats.memoryTotalBytes)) · up \(StatsFormat.uptime(stats.uptime))"
     }
 
     /// Distinguishes a first connection from a stream that keeps failing before

--- a/ArcBox/Views/Activity/ActivityView.swift
+++ b/ArcBox/Views/Activity/ActivityView.swift
@@ -10,7 +10,9 @@ import SwiftUI
 struct ActivityView: View {
     @Environment(ActivityViewModel.self) private var vm
     @Environment(ContainersViewModel.self) private var containersVM
+    @Environment(DaemonManager.self) private var daemonManager
     @Environment(\.arcboxClient) private var arcboxClient
+    @Environment(\.dockerClient) private var docker
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var searchText = ""
@@ -34,6 +36,27 @@ struct ActivityView: View {
             .task(id: arcboxClient.map(ObjectIdentifier.init)) {
                 guard let client = arcboxClient else { return }
                 await vm.run(client: client)
+            }
+            // Activity owns its own Docker load. `ContainersListView` is not in
+            // the hierarchy while this screen is up — the content column
+            // collapses — so its load and its event handler cannot keep the
+            // join fresh, and the menu bar's copy only runs once the menu is
+            // opened. Without this, containers started while Activity is
+            // showing never gain a project, and a launch straight into Activity
+            // has no Docker metadata at all.
+            //
+            // Gated on `isDockerReady` rather than `dockerSocketLinked`, and
+            // keyed on both readiness and client presence, because the client
+            // can arrive after the daemon is already up.
+            .task(id: daemonManager.setupPhase.isDockerReady && docker != nil) {
+                guard daemonManager.setupPhase.isDockerReady, docker != nil else { return }
+                await containersVM.loadContainersFromDocker(docker: docker, iconClient: arcboxClient)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .dockerContainerChanged)) { _ in
+                Task {
+                    await containersVM.loadContainersFromDocker(
+                        docker: docker, iconClient: arcboxClient)
+                }
             }
     }
 

--- a/ArcBox/Views/Activity/ActivityView.swift
+++ b/ArcBox/Views/Activity/ActivityView.swift
@@ -10,9 +10,14 @@ import SwiftUI
 struct ActivityView: View {
     @Environment(ActivityViewModel.self) private var vm
     @Environment(\.arcboxClient) private var arcboxClient
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         content
+            // Keyed on the arrival of data, not on the data: the screen
+            // materialises once, and the 1 Hz samples inside it do not drag the
+            // whole hierarchy through a transition every second.
+            .animation(reduceMotion ? nil : .smooth(duration: 0.35), value: vm.current == nil)
             .navigationTitle("Activity")
             .navigationSubtitle(subtitle)
             .toolbar {

--- a/ArcBox/Views/Activity/ActivityView.swift
+++ b/ArcBox/Views/Activity/ActivityView.swift
@@ -9,11 +9,15 @@ import SwiftUI
 /// against stay on screen while you scan containers.
 struct ActivityView: View {
     @Environment(ActivityViewModel.self) private var vm
+    @Environment(ContainersViewModel.self) private var containersVM
     @Environment(\.arcboxClient) private var arcboxClient
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+    @State private var searchText = ""
+
     var body: some View {
         content
+            .searchable(text: $searchText, placement: .toolbar, prompt: "Filter Containers")
             // Keyed on the arrival of data, not on the data: the screen
             // materialises once, and the 1 Hz samples inside it do not drag the
             // whole hierarchy through a transition every second.
@@ -36,28 +40,35 @@ struct ActivityView: View {
     @ViewBuilder
     private var content: some View {
         if let stats = vm.current {
-            ActivityContainerTable(containers: stats.containers)
-                .overlay {
-                    if stats.containers.isEmpty {
-                        ContentUnavailableView(
-                            "No Running Containers",
-                            systemImage: "cube",
-                            description: Text("Per-container usage appears here while containers are running.")
-                        )
-                    }
-                }
-                .safeAreaInset(edge: .top, spacing: 0) {
-                    ActivityMetricStrip(
-                        stats: stats,
-                        cpuHistory: vm.cpuHistory,
-                        memoryHistory: vm.memoryHistory,
-                        networkHistory: vm.networkHistory
-                    )
-                }
-                .softScrollEdge(for: .top)
+            ActivityContainerTable(
+                containers: stats.containers,
+                docker: dockerContainers,
+                searchText: searchText
+            )
+            .safeAreaInset(edge: .top, spacing: 0) {
+                ActivityMetricStrip(
+                    stats: stats,
+                    cpuHistory: vm.cpuHistory,
+                    memoryHistory: vm.memoryHistory,
+                    networkHistory: vm.networkHistory
+                )
+            }
+            .softScrollEdge(for: .top)
         } else {
             waitingForData
         }
+    }
+
+    /// Docker's view of the containers the stats stream reports, keyed by ID.
+    /// The two sources are independent, so this is a join, not a lookup: an ID
+    /// the Engine has not reported simply contributes nothing.
+    private var dockerContainers: [String: ActivityContainerFacts] {
+        Dictionary(
+            containersVM.containers.map {
+                ($0.id, ActivityContainerFacts(project: $0.composeProject, image: $0.image))
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
     }
 
     /// The machine's shape, once known — the toolbar's own line for the

--- a/ArcBox/Views/Activity/ActivityView.swift
+++ b/ArcBox/Views/Activity/ActivityView.swift
@@ -37,26 +37,47 @@ struct ActivityView: View {
             }
     }
 
+    /// Rates come from deltas, so the first usable frame is two samples in — a
+    /// second or two at the daemon's 1 Hz cadence. Rather than hold the screen
+    /// back behind a spinner for that, the real layout goes up immediately and
+    /// carries redacted values until the numbers are real. Nothing false is
+    /// shown, nothing moves when the data lands, and there is no separate
+    /// loading screen to perceive.
     @ViewBuilder
     private var content: some View {
-        if let stats = vm.current {
+        if streamHasGivenUp {
+            unavailable
+        } else {
             ActivityContainerTable(
-                containers: stats.containers,
+                containers: vm.current?.containers ?? [],
                 docker: dockerContainers,
-                searchText: searchText
+                searchText: searchText,
+                // "No containers" is a finding; before the first frame it would
+                // be a guess.
+                hasLoaded: vm.current != nil
             )
             .safeAreaInset(edge: .top, spacing: 0) {
                 ActivityMetricStrip(
-                    stats: stats,
+                    stats: vm.current,
                     cpuHistory: vm.cpuHistory,
                     memoryHistory: vm.memoryHistory,
                     networkHistory: vm.networkHistory
                 )
+                // Only the strip redacts. The table's column headers are known
+                // labels, not pending data, and `TableColumn` gives no handle
+                // to exempt them — an empty table under live headers already
+                // reads as rows on the way.
+                .redacted(reason: vm.current == nil ? .placeholder : [])
             }
             .softScrollEdge(for: .top)
-        } else {
-            waitingForData
         }
+    }
+
+    /// A stream that keeps failing before its first sample is not loading, and
+    /// must stop looking like it.
+    private var streamHasGivenUp: Bool {
+        guard vm.current == nil, case .reconnecting(let attempt) = vm.phase else { return false }
+        return attempt >= 3
     }
 
     /// Docker's view of the containers the stats stream reports, keyed by ID.
@@ -79,26 +100,14 @@ struct ActivityView: View {
             "System VM · \(stats.onlineCPUs) cores · \(StatsFormat.bytes(stats.memoryTotalBytes)) · up \(StatsFormat.uptime(stats.uptime))"
     }
 
-    /// Distinguishes a first connection from a stream that keeps failing before
-    /// its first sample, so a persistent error stops looking like a spinner
-    /// that will resolve on its own.
     @ViewBuilder
-    private var waitingForData: some View {
-        if case .reconnecting(let attempt) = vm.phase, attempt >= 3 {
-            ContentUnavailableView {
-                Label("Stats Unavailable", systemImage: "waveform.path.ecg")
-            } description: {
+    private var unavailable: some View {
+        ContentUnavailableView {
+            Label("Stats Unavailable", systemImage: "waveform.path.ecg")
+        } description: {
+            if case .reconnecting(let attempt) = vm.phase {
                 Text("The daemon's stats stream keeps dropping. Retrying — attempt \(attempt).")
             }
-        } else {
-            VStack(spacing: 12) {
-                ProgressView()
-                    .controlSize(.large)
-                Text("Waiting for the first sample…")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 }

--- a/ArcBox/Views/Activity/StatsFormat.swift
+++ b/ArcBox/Views/Activity/StatsFormat.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Formatting for resource values.
+///
+/// Byte sizes use the memory count style so they match Finder and Activity
+/// Monitor; everything goes through `FormatStyle` so digits, separators and
+/// percent signs follow the user's locale.
+enum StatsFormat {
+    static func percent(_ value: Double) -> String {
+        (value / 100).formatted(.percent.precision(.fractionLength(0)))
+    }
+
+    static func bytes(_ value: UInt64) -> String {
+        Int64(clamping: value).formatted(.byteCount(style: .memory))
+    }
+
+    static func rate(_ bytesPerSecond: Double) -> String {
+        let clamped = Int64(max(0, bytesPerSecond).rounded())
+        return clamped.formatted(.byteCount(style: .memory)) + "/s"
+    }
+
+    /// Load average, at the two decimals `uptime` reports.
+    static func load(_ value: Double) -> String {
+        value.formatted(.number.precision(.fractionLength(2)))
+    }
+}

--- a/ArcBox/Views/Activity/StatsFormat.swift
+++ b/ArcBox/Views/Activity/StatsFormat.swift
@@ -23,4 +23,13 @@ enum StatsFormat {
     static func load(_ value: Double) -> String {
         value.formatted(.number.precision(.fractionLength(2)))
     }
+
+    /// Uptime at the two coarsest units that apply — "5d 3h", "3h 12m", "8m".
+    ///
+    /// Deliberately no seconds: this sits in the window subtitle, and a figure
+    /// that rewrites itself every second is chrome that never stops moving.
+    static func uptime(_ duration: Duration) -> String {
+        duration.formatted(
+            .units(allowed: [.days, .hours, .minutes], width: .narrow, maximumUnitCount: 2))
+    }
 }

--- a/ArcBox/Views/Activity/StatsFormat.swift
+++ b/ArcBox/Views/Activity/StatsFormat.swift
@@ -5,18 +5,17 @@ import Foundation
 /// Byte sizes use the memory count style so they match Finder and Activity
 /// Monitor; everything goes through `FormatStyle` so digits, separators and
 /// percent signs follow the user's locale.
-enum StatsFormat {
+nonisolated enum StatsFormat {
     static func percent(_ value: Double) -> String {
         (value / 100).formatted(.percent.precision(.fractionLength(0)))
     }
 
     static func bytes(_ value: UInt64) -> String {
-        Int64(clamping: value).formatted(.byteCount(style: .memory))
+        formattedBytes(Int64(clamping: value), style: .memory)
     }
 
     static func rate(_ bytesPerSecond: Double) -> String {
-        let clamped = Int64(max(0, bytesPerSecond).rounded())
-        return clamped.formatted(.byteCount(style: .memory)) + "/s"
+        formattedBytes(Int64(max(0, bytesPerSecond).rounded()), style: .memory) + "/s"
     }
 
     /// Load average, at the two decimals `uptime` reports.

--- a/ArcBox/Views/Sandboxes/Tabs/SandboxFilesTab.swift
+++ b/ArcBox/Views/Sandboxes/Tabs/SandboxFilesTab.swift
@@ -191,6 +191,6 @@ struct SandboxFilesTab: View {
     }
 
     private func byteCount(_ count: Int) -> String {
-        ByteCountFormatter.string(fromByteCount: Int64(count), countStyle: .file)
+        formattedBytes(Int64(count))
     }
 }

--- a/ArcBoxTests/ActivityRowGroupingTests.swift
+++ b/ArcBoxTests/ActivityRowGroupingTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+
+@testable import ArcBox
+
+/// Covers the join between the daemon's cgroup stats and Docker's Compose
+/// labels: which rows group, what a project's totals mean, and how the table's
+/// sort reaches rows nested under a project.
+final class ActivityRowGroupingTests: XCTestCase {
+
+    func testContainersWithoutAProjectStayAtTheTopLevel() throws {
+        let groups = ActivityRowGrouping.groups(
+            for: [row(id: "a"), row(id: "b")],
+            projects: ["a": "web"],
+            sortedBy: []
+        )
+
+        XCTAssertEqual(
+            groups.count, 2,
+            "the project and the loose container are both top-level rows")
+        let standalone = try XCTUnwrap(groups.first { $0.summary.containerID == "b" })
+        XCTAssertEqual(standalone.children, [], "a project-less container should not gain children")
+    }
+
+    /// A container the Engine has not reported yet has no project, and must not
+    /// be swept into a shared bucket that would claim a relationship.
+    func testUnknownContainersAreNotBucketedTogether() {
+        let groups = ActivityRowGrouping.groups(
+            for: [row(id: "a"), row(id: "b")],
+            projects: [:],
+            sortedBy: []
+        )
+
+        XCTAssertEqual(groups.count, 2)
+        XCTAssertTrue(groups.allSatisfy { $0.children.isEmpty })
+        XCTAssertTrue(groups.allSatisfy { !$0.summary.isProject })
+    }
+
+    func testProjectTotalsSumItsMembers() throws {
+        let groups = ActivityRowGrouping.groups(
+            for: [
+                row(id: "a", cpu: 12.5, memory: 100, disk: (1, 2), network: (3, 4), pids: 7),
+                row(id: "b", cpu: 7.5, memory: 200, disk: (10, 20), network: (30, 40), pids: 11),
+            ],
+            projects: ["a": "web", "b": "web"],
+            sortedBy: []
+        )
+
+        let project = try XCTUnwrap(groups.first)
+        XCTAssertEqual(project.summary.cpuPercent, 20)
+        XCTAssertEqual(project.summary.memoryCurrentBytes, 300)
+        XCTAssertEqual(project.summary.diskReadBytesPerSecond, 11)
+        XCTAssertEqual(project.summary.diskWriteBytesPerSecond, 22)
+        XCTAssertEqual(project.summary.networkReceiveBytesPerSecond, 33)
+        XCTAssertEqual(project.summary.networkTransmitBytesPerSecond, 44)
+        XCTAssertEqual(project.summary.pids, 18)
+        XCTAssertEqual(project.children.count, 2)
+    }
+
+    func testProjectMemoryLimitSumsOnlyWhenEveryMemberIsLimited() {
+        let limited = ActivityRowGrouping.groups(
+            for: [row(id: "a", memoryLimit: 512), row(id: "b", memoryLimit: 256)],
+            projects: ["a": "web", "b": "web"],
+            sortedBy: []
+        )
+        XCTAssertEqual(limited.first?.summary.memoryLimitBytes, 768)
+
+        let mixed = ActivityRowGrouping.groups(
+            for: [row(id: "a", memoryLimit: 512), row(id: "b", memoryLimit: 0)],
+            projects: ["a": "web", "b": "web"],
+            sortedBy: []
+        )
+        XCTAssertEqual(
+            mixed.first?.summary.memoryLimitBytes, 0,
+            "one unlimited member makes the project's ceiling unknowable, not 512")
+    }
+
+    func testSortReachesBothTheProjectsAndTheirMembers() {
+        let groups = ActivityRowGrouping.groups(
+            for: [
+                row(id: "quiet", cpu: 1),
+                row(id: "busy-a", cpu: 30),
+                row(id: "busy-b", cpu: 60),
+            ],
+            projects: ["busy-a": "web", "busy-b": "web"],
+            sortedBy: [KeyPathComparator(\ActivityRow.cpuPercent, order: .reverse)]
+        )
+
+        XCTAssertEqual(
+            groups.map(\.summary.title), ["web", "quiet"],
+            "the project totals 90% and outranks the standalone container")
+        XCTAssertEqual(
+            groups.first?.children.map(\.title), ["busy-b", "busy-a"],
+            "members sort by the same comparator as the groups")
+    }
+
+    /// Selection and the table's saved disclosure state are keyed by ID, so a
+    /// project must never be able to impersonate a container.
+    func testProjectIDsCannotCollideWithContainerIDs() {
+        let summary = ActivityRow.project(named: "web", totalling: [row(id: "a")])
+
+        XCTAssertNotEqual(summary.id, "web")
+        XCTAssertNil(summary.containerID)
+        XCTAssertFalse(
+            summary.id.allSatisfy(\.isHexDigit),
+            "a container ID is hex, so the project prefix has to break that")
+    }
+
+    // MARK: - Fixtures
+
+    private func row(
+        id: String,
+        cpu: Double = 0,
+        memory: UInt64 = 0,
+        memoryLimit: UInt64 = 0,
+        disk: (read: Double, write: Double) = (0, 0),
+        network: (receive: Double, transmit: Double) = (0, 0),
+        pids: UInt32 = 0
+    ) -> ActivityRow {
+        ActivityRow(
+            id: id,
+            title: id,
+            kind: .container(id: id),
+            cpuPercent: cpu,
+            memoryCurrentBytes: memory,
+            memoryLimitBytes: memoryLimit,
+            diskReadBytesPerSecond: disk.read,
+            diskWriteBytesPerSecond: disk.write,
+            networkReceiveBytesPerSecond: network.receive,
+            networkTransmitBytesPerSecond: network.transmit,
+            pids: pids
+        )
+    }
+}

--- a/ArcBoxTests/ByteFormattingTests.swift
+++ b/ArcBoxTests/ByteFormattingTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+@testable import ArcBox
+
+/// Guards the one thing `formattedBytes` exists to override.
+///
+/// `ByteCountFormatStyle` spells zero out as "Zero kB" unless told not to, and
+/// zero is where an idle container's counters sit — so the default turns most
+/// of a live table into words. These pin the override; the non-zero cases are
+/// here to show it changes nothing else.
+final class ByteFormattingTests: XCTestCase {
+
+    func testZeroFormatsAsANumeralNotAWord() {
+        XCTAssertFalse(
+            formattedBytes(0).lowercased().contains("zero"),
+            "Foundation spells zero out by default; formattedBytes has to suppress that")
+        XCTAssertTrue(formattedBytes(0).contains("0"))
+    }
+
+    func testZeroIsANumeralInEveryCountStyle() {
+        for style in [ByteCountFormatStyle.Style.file, .memory, .binary, .decimal] {
+            XCTAssertFalse(
+                formattedBytes(0, style: style).lowercased().contains("zero"),
+                "style \(style) still spells zero out")
+        }
+    }
+
+    /// The stats table's zero cells: an idle container reports no disk and no
+    /// network traffic, and both render through the rate formatter.
+    func testIdleRatesReadAsZero() {
+        XCTAssertFalse(StatsFormat.rate(0).lowercased().contains("zero"))
+        XCTAssertFalse(StatsFormat.bytes(0).lowercased().contains("zero"))
+        XCTAssertTrue(StatsFormat.rate(0).hasSuffix("/s"))
+    }
+
+    func testNonZeroCountsAreUnaffectedBySuppressingTheWord() {
+        XCTAssertEqual(formattedBytes(1, style: .memory), Int64(1).formatted(.byteCount(style: .memory)))
+        XCTAssertEqual(
+            formattedBytes(1_048_576, style: .memory),
+            Int64(1_048_576).formatted(.byteCount(style: .memory)))
+    }
+}

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/ResourceStats.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/ResourceStats.swift
@@ -11,6 +11,10 @@ public struct MachineResourceStats: Sendable, Equatable {
     public var cpuPercent: Double
     public var onlineCPUs: UInt32
     public var loadaverage1: Double
+    /// How long the guest has been up, from the same `/proc/uptime` clock the
+    /// rate denominators come from. Resets when the VM reboots, which is what
+    /// makes it a truthful uptime rather than a session age.
+    public var uptime: Duration
     public var memoryTotalBytes: UInt64
     public var memoryUsedBytes: UInt64
     public var memoryUsedPercent: Double
@@ -78,6 +82,7 @@ public enum ResourceStatsCalculator {
             cpuPercent: min(busyTicks / totalTicks * 100, 100),
             onlineCPUs: current.onlineCpus,
             loadaverage1: current.loadavg1,
+            uptime: .milliseconds(current.monotonicMs),
             memoryTotalBytes: current.memoryTotalBytes,
             memoryUsedBytes: memoryUsed,
             memoryUsedPercent: current.memoryTotalBytes == 0

--- a/Packages/ArcBoxClient/Tests/ArcBoxClientTests/ResourceStatsTests.swift
+++ b/Packages/ArcBoxClient/Tests/ArcBoxClientTests/ResourceStatsTests.swift
@@ -132,4 +132,14 @@ import Testing
         let stats = ResourceStatsCalculator.compute(previous: prev, current: cur)!
         #expect(stats.hasMemoryPressure == false)
     }
+
+    /// Uptime is the newer sample's own clock, not the span between the two —
+    /// reading it off the delta would report the sampling interval.
+    @Test func uptimeIsTheCurrentSamplesGuestClock() {
+        let prev = machine(monotonicMs: 10_000, busy: 100, total: 1000)
+        let cur = machine(monotonicMs: 3_600_000, busy: 150, total: 1200)
+
+        let stats = ResourceStatsCalculator.compute(previous: prev, current: cur)!
+        #expect(stats.uptime == .seconds(3600))
+    }
 }


### PR DESCRIPTION
Rebuilds the Activity screen on the components AppKit and SwiftUI already
ship, and puts Liquid Glass where Apple's guidance puts it.

## What was wrong

The screen was hand-rolled where the platform already had the control: a
fixed-width `HStack` stood in for a table, `.system(size:)` literals for the
text styles, and a spinner for every failure. None of that picks up the
platform's own behaviour, and none of it picks up Liquid Glass.

## Structure

The container list is a native `Table` — sortable, resizable, reorderable
columns with selection and hideable columns whose layout survives relaunch.
Rows nest under the Compose project they belong to, and a project's row
carries its members' totals.

The machine metrics moved into a bar that floats over the scrolling table, so
what you compare against stays on screen. That bar is the one custom element
on the functional layer, so it — and nothing else here — takes Liquid Glass,
with the pre-26 card as the fallback. Apple scopes the material to
toolbars/controls/navigation and warns against spreading it over content or
stacking it, so there is exactly one glass surface holding all four tiles
rather than one per tile.

Text uses the semantic styles, so it tracks Dynamic Type and the accessibility
settings. Section headers lose the all-caps treatment macOS 26 dropped from
lists and tables. Values format through `FormatStyle`, so digits and percent
signs follow the locale.

## Behaviour

- Selecting a point on a sparkline rewinds that tile's headline to the sample
  under the pointer and reports its age, from the guest clock rather than the
  sample count — inferring seconds from the x-axis would misreport the moment
  the stream stalls.
- The toolbar filters on name, image and project: the same three the Containers
  list matches, so a query that finds a container there finds it here.
- Rows carry a context menu to copy the ID or jump to the container in
  Containers, which is also what double-click does.
- The subtitle reports the System VM's uptime.
- A stream that keeps dropping before its first sample now says so instead of
  spinning forever; an idle machine gets a `ContentUnavailableView`.

## Correctness

- **Reduce Motion is honoured.** SwiftUI adapts its own transitions for that
  setting and leaves animations you wrote running. The sparkline redraw, the
  gauge and the digit morph are all ours, so they read the environment and drop
  out.
- **Zero no longer spells itself out.** An idle container reported
  `Zero kB/s / Zero kB/s`; `ByteCountFormatStyle` and `ByteCountFormatter`
  before it both spell zero out by default, so this predates the rewrite. Every
  byte figure now goes through one `formattedBytes` — the stats table, the
  local rootfs size column and the sandbox transfer log.
- **Legibility on glass.** Tile captions sat at `.tertiary` on a translucent
  surface with a table scrolling under them. They move up to the label's tint
  and keep their rank through weight and size instead.
- **Project totals only sum what summing means.** A project's memory ceiling
  stays unknown when any member is unlimited, rather than reporting the limited
  members' sum as if it bounded the project. Containers the Engine has not
  labelled stay at the top level instead of collecting in a bucket that would
  imply they belong together.

## Why the join is client-side

`MachineStats.containers` is what the guest agent reads out of cgroups, keyed
by container ID. The project is a Docker label, and the app already holds it
from the Engine API for the Containers list. The daemon has no labels — its
registry maps IDs to names — so putting the join there would mean the daemon
querying Docker once per frame to recover something the client already has. No
protocol or daemon change.

## Testing

`make lint` (273 files, 0 violations) and `make test` (159 tests) pass, as does
the `git diff --exit-code ArcBox.xcodeproj` project-drift gate.

New tests cover the grouping join (standalone rows, unlabelled containers not
bucketed, limit aggregation, sort reaching nested rows, project IDs unable to
collide with container IDs) and the zero-spelling regression across all four
count styles, including an assertion that non-zero counts are unchanged.

Both appearances were checked against a rendered window with fabricated stats;
the project aggregates were verified arithmetically against the fixture.

## Known gaps

- **`Packages/ArcBoxClient/Tests` is not in the scheme, so CI never runs it.**
  This PR adds a test there; it passes when run directly (10 tests), but no gate
  executes it. Same class as #339. Left for its own PR because wiring it in
  pulls `ArcBoxAuth`'s tests along, which are unverified here.
- `chartXSelection`'s input modality on macOS (hover vs click-drag) is
  unverified: synthesised `NSEvent`s do not drive SwiftUI's gesture machinery,
  so the harness could exercise only the rendering path. Worth a look in the
  running app.
- `.searchable`'s toolbar placement is likewise unverified visually; it compiles
  and `ContentViewColumnLayoutTests` still passes.