### PR TITLE
fix(activity): clear the filter when its field is dismissed

### DIFF
--- a/ArcBox/Views/Activity/ActivityView.swift
+++ b/ArcBox/Views/Activity/ActivityView.swift
@@ -16,10 +16,18 @@ struct ActivityView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var searchText = ""
+    @State private var isSearching = false
 
     var body: some View {
         content
-            .searchable(text: $searchText, placement: .toolbar, prompt: "Filter Containers")
+            .searchable(text: $searchText, isPresented: $isSearching, prompt: "Filter Containers")
+            // Dismissing the field has to drop the query with it, or the table
+            // stays filtered with nothing on screen explaining the missing
+            // rows. Every other list in the app does this; the placement is
+            // left to the system for the same reason.
+            .onChange(of: isSearching) { _, searching in
+                if !searching { searchText = "" }
+            }
             // Keyed on the arrival of data, not on the data: the screen
             // materialises once, and the 1 Hz samples inside it do not drag the
             // whole hierarchy through a transition every second.


### PR DESCRIPTION
Activity's search field kept its query after being dismissed. The table stayed
filtered, the field was gone, and nothing on screen explained the missing rows.

Every other list in the app already guards against this:

```swift
.searchable(text: Bindable(vm).searchText, isPresented: Bindable(vm).isSearching)
.onChange(of: vm.isSearching) { _, newValue in
    if !newValue { vm.searchText = "" }
}
```

Seven views use that pattern. Activity was the one that did not — it bound only
the text, and additionally pinned `placement: .toolbar` instead of letting the
system place the field as it does everywhere else. Both now match.

## On placement

This started as a check that `.searchable` sat correctly on a screen whose
content column collapses to zero width — the geometry
`ContentViewColumnLayoutTests` exists to protect. Measured rather than assumed,
by driving the real window through `arcbox://activity` and dumping the toolbar:

```
nav=containers  panes=[0..188, 0..468, 469..1203]
  …splitViewSeparator-0 · <2 primaryAction items> · splitViewSeparator-1 · …
  com.apple.SwiftUI.search

nav=activity    panes=[0..188, 0..188, 189..1203]
  …splitViewSeparator-0 · NSToolbarFlexibleSpaceItem
  com.apple.SwiftUI.search
```

Activity emits no `splitViewSeparator-1` at all, because its content column is
collapsed, and no positioned item follows separator-0. The search item sits in
the same trailing position it holds on Containers. So placement was never the
problem — the dismissal behaviour was.

The probe was a throwaway; it pinned SwiftUI's own layout rather than an
invariant of ours, so it is not committed.

`make lint` (274 files, 0 violations) and `make test` (159 XCTest + 81
swift-testing) pass.