### PR TITLE
refactor: layout tokens, derived tab widths, and a lockfile gate

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -110,12 +110,17 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-xcode-${{ steps.build_environment.outputs.xcode_cache_key }}-swift-${{ hashFiles('ArcBox.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'Packages/**/Package.resolved', 'Packages/**/Package.swift') }}-${{ hashFiles('ArcBox.xcodeproj/project.pbxproj') }}-
             ${{ runner.os }}-${{ runner.arch }}-xcode-${{ steps.build_environment.outputs.xcode_cache_key }}-swift-${{ hashFiles('ArcBox.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'Packages/**/Package.resolved', 'Packages/**/Package.swift') }}-
 
+      # `-onlyUsePackageVersionsFromResolvedFile` is what makes this a gate
+      # rather than a cache warm-up: without it this step would quietly repair a
+      # stale Package.resolved, and the build that follows would never see the
+      # drift. A PR that edits a Package.swift must commit the lockfile too.
       - name: Resolve Swift packages
         run: |
           xcodebuild -resolvePackageDependencies \
             -project ArcBox.xcodeproj \
             -scheme ArcBox \
-            -clonedSourcePackagesDirPath .build/SourcePackages
+            -clonedSourcePackagesDirPath .build/SourcePackages \
+            -onlyUsePackageVersionsFromResolvedFile
 
       # `shell: bash` is load-bearing on every step that pipes into xcpretty:
       # the default shell is `bash -e`, whose pipeline status comes from

--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		525ECDE24CB1E8ADC7AADB49 /* UpdaterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9234FC5BCCDDCBF441A94880 /* UpdaterDelegate.swift */; };
 		56DB59DA2A954436369BAC24 /* SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1808332CF700CF6900F556F5 /* SampleData.swift */; };
 		592D8D15F0AD149B578AC661 /* VolumesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209E974D66F4B2D9B5CDA2D9 /* VolumesListView.swift */; };
+		5C24B61DEC9BC6CE303FF52A /* AppMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0084D4B147FA59C7CCC0F5 /* AppMetrics.swift */; };
 		5D4AD52D29953C3DB6552B97 /* ContainerLogsTab+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DD7F5E0115C839BB364D59F /* ContainerLogsTab+Formatting.swift */; };
 		5D859AD67E6BF46402B5B621 /* ServicesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4009DCC81EA64B23A77FB0C4 /* ServicesViewModel.swift */; };
 		5DBFB63C5C744C1FC45C7808 /* SandboxMonitoringView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A8DDE58F61A6B736A63E11 /* SandboxMonitoringView.swift */; };
@@ -107,6 +108,7 @@
 		73E1E5FC3E40AD0760A21AC0 /* PodModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37BB3605830EBE3A1625452 /* PodModel.swift */; };
 		74488A22CBA34633776AC5D2 /* SandboxDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B18FDEC4B5AE8513C98D7B4 /* SandboxDetailView.swift */; };
 		759C82DCC614CABAA93AABC4 /* ActivityContainerTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B050286A2450880AC2C95342 /* ActivityContainerTable.swift */; };
+		7611F110DA849DA460755BE4 /* DetailTabPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1AD9099DE0BF8CCBC35667 /* DetailTabPicker.swift */; };
 		766ECB0DA60ABA79FE21CE2C /* ContainerInfoTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE29B2F3FF7CFA3B0325CB97 /* ContainerInfoTab.swift */; };
 		76F9D4F43F4E73B79D882830 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43B8FF992E687C114ADB8E32 /* AboutView.swift */; };
 		7895A0328F3567814B656CFD /* LocalRootFSOutlineCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0D0444E612EC32D81A7E0C /* LocalRootFSOutlineCoordinator.swift */; };
@@ -333,6 +335,7 @@
 		4CC37601A89C4ED758AC6C45 /* ContainerTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerTypes.swift; sourceTree = "<group>"; };
 		4CEDB1A7E6E5F0EEA2214D21 /* VolumeTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeTypes.swift; sourceTree = "<group>"; };
 		4DD7F5E0115C839BB364D59F /* ContainerLogsTab+Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContainerLogsTab+Formatting.swift"; sourceTree = "<group>"; };
+		4E0084D4B147FA59C7CCC0F5 /* AppMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMetrics.swift; sourceTree = "<group>"; };
 		4E7528A43356F3BB6CE3FB96 /* ArcBox.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ArcBox.entitlements; sourceTree = "<group>"; };
 		4F0D0444E612EC32D81A7E0C /* LocalRootFSOutlineCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalRootFSOutlineCoordinator.swift; sourceTree = "<group>"; };
 		50C68609B67AC82FF386CB92 /* SandboxEventMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxEventMonitor.swift; sourceTree = "<group>"; };
@@ -472,6 +475,7 @@
 		D3DB0D1F23DD6976DA73A33C /* PKCETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PKCETests.swift; sourceTree = "<group>"; };
 		D4ED3EC883A488801DE03195 /* NetworksViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworksViewModel.swift; sourceTree = "<group>"; };
 		DAE5A29026FA64A7C0A47122 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		DB1AD9099DE0BF8CCBC35667 /* DetailTabPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailTabPicker.swift; sourceTree = "<group>"; };
 		DBEBBF08F0E4AC45D9C0BB83 /* ChangelogParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangelogParser.swift; sourceTree = "<group>"; };
 		DE25BFAD7CCE499E2AA55EE9 /* IDTokenClaimsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDTokenClaimsTests.swift; sourceTree = "<group>"; };
 		DE564AAFEC0EF6D094409728 /* SandboxRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxRowView.swift; sourceTree = "<group>"; };
@@ -649,6 +653,7 @@
 			isa = PBXGroup;
 			children = (
 				B65698313C3204F5F23E099B /* CommandHint.swift */,
+				DB1AD9099DE0BF8CCBC35667 /* DetailTabPicker.swift */,
 				5272B55436BFFB8D2021CA20 /* EmptyStateView.swift */,
 				9E73318FC9D8EBCB39E5C0AE /* IconButton.swift */,
 				F5F318A121B0C8EA1A05BFE5 /* InfoRow.swift */,
@@ -1082,6 +1087,7 @@
 			isa = PBXGroup;
 			children = (
 				F62FD6244C56EE8E45DF0EC7 /* AppColors.swift */,
+				4E0084D4B147FA59C7CCC0F5 /* AppMetrics.swift */,
 				42B624914056B0B39B7A3E08 /* AppTheme.swift */,
 				3572105F94A4F2399F9446D4 /* LiquidGlass.swift */,
 				F893B8994BA04A6813FCB819 /* TerminalAppearance.swift */,
@@ -1316,6 +1322,7 @@
 				5F8BD0B16CBBDC44080F6EA5 /* Analytics.swift in Sources */,
 				B91D470DA46003D64389C7DE /* AppColors.swift in Sources */,
 				BA8E4BE30E5FBB6B8548E214 /* AppDelegate.swift in Sources */,
+				5C24B61DEC9BC6CE303FF52A /* AppMetrics.swift in Sources */,
 				0601E3B8363540B1F627754C /* AppTheme.swift in Sources */,
 				F0B6CC9DB9992CE44F2A7F70 /* AppViewModel.swift in Sources */,
 				B52AB7A6781786A6ECB4B59E /* ArcBoxApp.swift in Sources */,
@@ -1351,6 +1358,7 @@
 				172FA4919687A4616E0BC135 /* DaemonLoadingView.swift in Sources */,
 				BA3195811383AD00D29B32AE /* DeepLink.swift in Sources */,
 				D32166A92BDA2FB6B6037D94 /* DeepLinkRouter.swift in Sources */,
+				7611F110DA849DA460755BE4 /* DetailTabPicker.swift in Sources */,
 				632810E9B138C535A11E7EBF /* DiagnosticBundleExporter.swift in Sources */,
 				6EE6805F5EC85742CC665575 /* DockerCLIResolver.swift in Sources */,
 				BD99D14EC5ED57BA1FF283CC /* DockerContextManager.swift in Sources */,

--- a/ArcBox/Components/DetailTabPicker.swift
+++ b/ArcBox/Components/DetailTabPicker.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// The tab set of a detail view.
+///
+/// Every conforming enum already satisfies each requirement; the protocol
+/// exists so `DetailTabPicker` can name them in one place.
+///
+/// Conformers write `@MainActor DetailTab`. The target builds with
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION: MainActor`, so each enum's hand-written
+/// `Identifiable` conformance is main-actor isolated, and a conformance that
+/// depends on it has to say so.
+protocol DetailTab: CaseIterable, Identifiable, Hashable, RawRepresentable
+where RawValue == String, AllCases: RandomAccessCollection {}
+
+/// The segmented tab bar in a detail view's toolbar.
+///
+/// The width follows from the tab count. Each detail view used to carry its own
+/// total — 120 through 420 across eight views, fitted by eye and with no
+/// consistent width per segment — so adding a tab meant re-tuning a number that
+/// gave no hint it needed re-tuning.
+struct DetailTabPicker<Tab: DetailTab>: ToolbarContent {
+    @Binding var selection: Tab
+
+    var body: some ToolbarContent {
+        ToolbarItem(placement: .principal) {
+            Picker("Tab", selection: $selection) {
+                ForEach(Tab.allCases) { tab in
+                    Text(tab.rawValue).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(maxWidth: CGFloat(Tab.allCases.count) * AppMetrics.detailTabSegment)
+        }
+    }
+}

--- a/ArcBox/Components/IconButton.swift
+++ b/ArcBox/Components/IconButton.swift
@@ -13,7 +13,7 @@ struct IconButton: View {
             Image(systemName: symbol)
                 .font(.system(size: 12))
                 .foregroundStyle(color)
-                .frame(width: 26, height: 26)
+                .frame(width: AppMetrics.rowActionButton, height: AppMetrics.rowActionButton)
                 .background(
                     RoundedRectangle(cornerRadius: 5)
                         .fill(isHovered ? AppColors.hover : Color.clear)

--- a/ArcBox/Components/StatusBadge.swift
+++ b/ArcBox/Components/StatusBadge.swift
@@ -9,7 +9,7 @@ struct StatusBadge: View {
         HStack(spacing: 6) {
             Circle()
                 .fill(color)
-                .frame(width: 8, height: 8)
+                .frame(width: AppMetrics.statusDot, height: AppMetrics.statusDot)
             Text(label)
                 .font(.system(size: 13))
                 .foregroundStyle(color)

--- a/ArcBox/Models/ContainerModel.swift
+++ b/ArcBox/Models/ContainerModel.swift
@@ -118,18 +118,6 @@ struct ContainerViewModel: Identifiable, Hashable {
         return ports.map { "\($0.hostPort):\($0.containerPort)" }.joined(separator: ", ")
     }
 
-    var createdAgo: String {
-        let interval = Date().timeIntervalSince(createdAt)
-        let days = Int(interval / 86400)
-        let hours = Int(interval / 3600)
-        let minutes = Int(interval / 60)
-
-        if days > 0 { return "\(days)d ago" }
-        if hours > 0 { return "\(hours)h ago" }
-        if minutes > 0 { return "\(minutes)m ago" }
-        return "just now"
-    }
-
     var uptimeDisplay: String {
         let interval = max(0, Date().timeIntervalSince(createdAt))
         let days = Int(interval / 86400)

--- a/ArcBox/Theme/AppMetrics.swift
+++ b/ArcBox/Theme/AppMetrics.swift
@@ -1,0 +1,62 @@
+import CoreGraphics
+
+/// Dimensions that must agree across files.
+///
+/// This is deliberately not an inventory of every number in the app. A size
+/// earns a name here only when more than one file draws the *same* element and
+/// they would visibly disagree if the numbers drifted apart — a row action that
+/// no longer lines up with its neighbour, a sheet that is narrower than the one
+/// before it. Sizes local to a single view stay at their call site, where they
+/// are easier to read than an indirection.
+enum AppMetrics {
+
+    // MARK: - List rows
+
+    /// Height of a row in every resource list.
+    static let rowHeight: CGFloat = 44
+
+    /// The rounded icon tile at a row's leading edge.
+    static let rowIcon: CGFloat = 32
+
+    /// Trailing row controls. `IconButton` sets it, and the progress spinners
+    /// and plain glyphs that sit beside one must match or the row jitters as
+    /// state changes swap them in and out.
+    static let rowActionButton: CGFloat = 26
+
+    /// The state dot beside a resource's name.
+    ///
+    /// The menu bar and the activity strip draw a 7pt dot and the container and
+    /// machine rows a 12pt one; those are left alone rather than folded in
+    /// here, since collapsing them is a visual decision and not a refactor.
+    static let statusDot: CGFloat = 8
+
+    // MARK: - Sheets
+
+    /// Width of a create/pull sheet. `NewNetworkSheet` (640) and
+    /// `MachineCreateSheet` (440) predate this and still set their own.
+    static let sheetWidth: CGFloat = 480
+
+    /// The sheet's own title bar, above the form.
+    static let sheetTitleBarHeight: CGFloat = 44
+
+    /// The close button in that title bar.
+    static let sheetCloseButton: CGFloat = 24
+
+    // MARK: - Detail views
+
+    /// Width budget for one segment of a detail view's tab bar.
+    ///
+    /// `DetailTabPicker` multiplies this by the tab count instead of each view
+    /// carrying a hand-tuned total. 80 is at or above every per-segment width
+    /// that shipped before it (the tightest was 70, for the six-tab sandbox
+    /// view, and it fit "Snapshots"), so no label loses room.
+    static let detailTabSegment: CGFloat = 80
+
+    /// The shell picker above a terminal tab.
+    static let shellPickerWidth: CGFloat = 140
+
+    // MARK: - Settings
+
+    static let settingsPaneWidth: CGFloat = 500
+    static let settingsPaneHeight: CGFloat = 600
+}

--- a/ArcBox/ViewModels/Containers/ContainerTypes.swift
+++ b/ArcBox/ViewModels/Containers/ContainerTypes.swift
@@ -6,7 +6,7 @@ extension Notification.Name {
 }
 
 /// Detail panel tab for containers
-enum ContainerDetailTab: String, CaseIterable, Identifiable {
+enum ContainerDetailTab: String, @MainActor DetailTab {
     case info = "Info"
     case logs = "Logs"
     case terminal = "Terminal"

--- a/ArcBox/ViewModels/Images/ImageTypes.swift
+++ b/ArcBox/ViewModels/Images/ImageTypes.swift
@@ -1,5 +1,5 @@
 /// Detail tab for images
-enum ImageDetailTab: String, CaseIterable, Identifiable {
+enum ImageDetailTab: String, @MainActor DetailTab {
     case info = "Info"
     case terminal = "Terminal"
     case files = "Files"

--- a/ArcBox/ViewModels/MachinesViewModel.swift
+++ b/ArcBox/ViewModels/MachinesViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import os
 
 /// Detail tab options for machines (matches container pattern)
-enum MachineDetailTab: String, CaseIterable, Identifiable {
+enum MachineDetailTab: String, @MainActor DetailTab {
     case info = "Info"
     case logs = "Logs"
     case terminal = "Terminal"

--- a/ArcBox/ViewModels/PodsViewModel.swift
+++ b/ArcBox/ViewModels/PodsViewModel.swift
@@ -2,7 +2,7 @@ import K8sClient
 import SwiftUI
 
 /// Detail tab for pods
-enum PodDetailTab: String, CaseIterable, Identifiable {
+enum PodDetailTab: String, @MainActor DetailTab {
     case info = "Info"
     case logs = "Logs"
     case terminal = "Terminal"

--- a/ArcBox/ViewModels/Sandboxes/SandboxesViewModel.swift
+++ b/ArcBox/ViewModels/Sandboxes/SandboxesViewModel.swift
@@ -3,7 +3,7 @@ import OSLog
 import SwiftUI
 
 /// Detail tab for sandboxes
-enum SandboxDetailTab: String, CaseIterable, Identifiable {
+enum SandboxDetailTab: String, @MainActor DetailTab {
     case info = "Info"
     case terminal = "Terminal"
     case files = "Files"

--- a/ArcBox/ViewModels/ServicesViewModel.swift
+++ b/ArcBox/ViewModels/ServicesViewModel.swift
@@ -2,7 +2,7 @@ import K8sClient
 import SwiftUI
 
 /// Detail tab for services
-enum ServiceDetailTab: String, CaseIterable, Identifiable {
+enum ServiceDetailTab: String, @MainActor DetailTab {
     case info = "Info"
 
     var id: String { rawValue }

--- a/ArcBox/ViewModels/TemplatesViewModel.swift
+++ b/ArcBox/ViewModels/TemplatesViewModel.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Detail tab for templates
-enum TemplateDetailTab: String, CaseIterable, Identifiable {
+enum TemplateDetailTab: String, @MainActor DetailTab {
     case info = "Info"
     case sandboxes = "Sandboxes"
 

--- a/ArcBox/ViewModels/Volumes/VolumeTypes.swift
+++ b/ArcBox/ViewModels/Volumes/VolumeTypes.swift
@@ -1,5 +1,5 @@
 /// Detail tab for volumes
-enum VolumeDetailTab: String, CaseIterable, Identifiable {
+enum VolumeDetailTab: String, @MainActor DetailTab {
     case info = "Info"
     case files = "Files"
 

--- a/ArcBox/Views/Containers/ContainerDetailView.swift
+++ b/ArcBox/Views/Containers/ContainerDetailView.swift
@@ -37,15 +37,7 @@ struct ContainerDetailView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .toolbar {
-            ToolbarItem(placement: .principal) {
-                Picker("Tab", selection: $vm.activeTab) {
-                    ForEach(ContainerDetailTab.allCases) { tab in
-                        Text(tab.rawValue).tag(tab)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .frame(maxWidth: 300)
-            }
+            DetailTabPicker(selection: $vm.activeTab)
         }
     }
 }

--- a/ArcBox/Views/Containers/ContainerGroupView.swift
+++ b/ArcBox/Views/Containers/ContainerGroupView.swift
@@ -67,7 +67,7 @@ struct ContainerGroupView: View {
                         if isAnyTransitioning {
                             ProgressView()
                                 .controlSize(.small)
-                                .frame(width: 26, height: 26)
+                                .frame(width: AppMetrics.rowActionButton, height: AppMetrics.rowActionButton)
                         } else {
                             IconButton(
                                 symbol: hasAnyRunning ? "stop.fill" : "play.fill",
@@ -83,7 +83,7 @@ struct ContainerGroupView: View {
                     }
                 }
             }
-            .frame(height: 44)
+            .frame(height: AppMetrics.rowHeight)
             .padding(.horizontal, 12)
             .background(
                 RoundedRectangle(cornerRadius: 6)

--- a/ArcBox/Views/Containers/ContainerRowView.swift
+++ b/ArcBox/Views/Containers/ContainerRowView.swift
@@ -122,7 +122,7 @@ struct ContainerRowView: View {
                                     .foregroundStyle(
                                         isSelected ? AppColors.onAccent : AppColors.textSecondary
                                     )
-                                    .frame(width: 26, height: 26)
+                                    .frame(width: AppMetrics.rowActionButton, height: AppMetrics.rowActionButton)
                             }
                             .menuStyle(.borderlessButton)
                             .menuIndicator(.hidden)
@@ -133,7 +133,7 @@ struct ContainerRowView: View {
                     if container.isTransitioning {
                         ProgressView()
                             .controlSize(.small)
-                            .frame(width: 26, height: 26)
+                            .frame(width: AppMetrics.rowActionButton, height: AppMetrics.rowActionButton)
                     } else {
                         IconButton(
                             symbol: container.isRunning ? "stop.fill" : "play.fill",
@@ -153,7 +153,7 @@ struct ContainerRowView: View {
         }
         .padding(.horizontal, 12)
         .padding(.leading, indented ? 28 : 0)
-        .frame(height: 44)
+        .frame(height: AppMetrics.rowHeight)
         .background(
             RoundedRectangle(cornerRadius: 6)
                 .fill(

--- a/ArcBox/Views/Containers/NewContainerSheet.swift
+++ b/ArcBox/Views/Containers/NewContainerSheet.swift
@@ -82,13 +82,13 @@ struct NewContainerSheet: View {
                         Image(systemName: "xmark")
                             .font(.system(size: 12))
                             .foregroundStyle(AppColors.textSecondary)
-                            .frame(width: 24, height: 24)
+                            .frame(width: AppMetrics.sheetCloseButton, height: AppMetrics.sheetCloseButton)
                     }
                 )
                 .buttonStyle(.plain)
             }
             .padding(.horizontal, 16)
-            .frame(height: 44)
+            .frame(height: AppMetrics.sheetTitleBarHeight)
             .overlay(alignment: .bottom) { Divider() }
 
             // Scrollable form
@@ -197,6 +197,6 @@ struct NewContainerSheet: View {
             .padding(.vertical, 12)
             .overlay(alignment: .top) { Divider() }
         }
-        .frame(width: 480, height: 560)
+        .frame(width: AppMetrics.sheetWidth, height: 560)
     }
 }

--- a/ArcBox/Views/Containers/Tabs/ContainerTerminalTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerTerminalTab.swift
@@ -30,7 +30,7 @@ struct ContainerTerminalTab: View {
                         }
                     }
                     .pickerStyle(.menu)
-                    .frame(width: 140)
+                    .frame(width: AppMetrics.shellPickerWidth)
                     .disabled(session.state == .connected)
 
                     Spacer()
@@ -150,7 +150,7 @@ struct ContainerTerminalTab: View {
                 HStack(spacing: 6) {
                     Circle()
                         .fill(container.state.color)
-                        .frame(width: 8, height: 8)
+                        .frame(width: AppMetrics.statusDot, height: AppMetrics.statusDot)
                     Text(container.state.label)
                         .font(.system(size: 13))
                         .foregroundStyle(AppColors.textSecondary)

--- a/ArcBox/Views/Images/ImageDetailView.swift
+++ b/ArcBox/Views/Images/ImageDetailView.swift
@@ -79,15 +79,7 @@ struct ImageDetailView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .toolbar {
-            ToolbarItem(placement: .principal) {
-                Picker("Tab", selection: $vm.activeTab) {
-                    ForEach(ImageDetailTab.allCases) { tab in
-                        Text(tab.rawValue).tag(tab)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .frame(maxWidth: 250)
-            }
+            DetailTabPicker(selection: $vm.activeTab)
         }
     }
 }

--- a/ArcBox/Views/Images/ImageRowView.swift
+++ b/ArcBox/Views/Images/ImageRowView.swift
@@ -75,7 +75,7 @@ struct ImageRowView: View {
             }
         }
         .padding(.horizontal, 12)
-        .frame(height: 44)
+        .frame(height: AppMetrics.rowHeight)
         .background(
             RoundedRectangle(cornerRadius: 6)
                 .fill(

--- a/ArcBox/Views/Images/PullImageSheet.swift
+++ b/ArcBox/Views/Images/PullImageSheet.swift
@@ -64,7 +64,7 @@ struct PullImageSheet: View {
             HStack {
                 Button("?") {}
                     .buttonStyle(.plain)
-                    .frame(width: 24, height: 24)
+                    .frame(width: AppMetrics.sheetCloseButton, height: AppMetrics.sheetCloseButton)
 
                 Button("Import...") {
                     let panel = NSOpenPanel()
@@ -108,6 +108,6 @@ struct PullImageSheet: View {
             .padding(.vertical, 12)
             .overlay(alignment: .top) { Divider() }
         }
-        .frame(width: 480, height: 270)
+        .frame(width: AppMetrics.sheetWidth, height: 270)
     }
 }

--- a/ArcBox/Views/Images/Tabs/ImageTerminalTab.swift
+++ b/ArcBox/Views/Images/Tabs/ImageTerminalTab.swift
@@ -27,7 +27,7 @@ struct ImageTerminalTab: View {
                     }
                 }
                 .pickerStyle(.menu)
-                .frame(width: 140)
+                .frame(width: AppMetrics.shellPickerWidth)
                 .disabled(session.state == .connected)
 
                 Spacer()

--- a/ArcBox/Views/Kubernetes/PodDetailView.swift
+++ b/ArcBox/Views/Kubernetes/PodDetailView.swift
@@ -45,15 +45,7 @@ struct PodDetailView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .toolbar {
-            ToolbarItem(placement: .principal) {
-                Picker("Tab", selection: $vm.activeTab) {
-                    ForEach(PodDetailTab.allCases) { tab in
-                        Text(tab.rawValue).tag(tab)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .frame(maxWidth: 250)
-            }
+            DetailTabPicker(selection: $vm.activeTab)
         }
     }
 }

--- a/ArcBox/Views/Kubernetes/PodRowView.swift
+++ b/ArcBox/Views/Kubernetes/PodRowView.swift
@@ -14,7 +14,7 @@ struct PodRowView: View {
             // Pod icon
             RoundedRectangle(cornerRadius: 6)
                 .fill(AppColors.iconBackground)
-                .frame(width: 32, height: 32)
+                .frame(width: AppMetrics.rowIcon, height: AppMetrics.rowIcon)
                 .overlay {
                     Image(systemName: "cube")
                         .font(.system(size: 14))
@@ -37,10 +37,10 @@ struct PodRowView: View {
             // Phase indicator
             Circle()
                 .fill(pod.phase.color)
-                .frame(width: 8, height: 8)
+                .frame(width: AppMetrics.statusDot, height: AppMetrics.statusDot)
         }
         .padding(.horizontal, 8)
-        .frame(height: 44)
+        .frame(height: AppMetrics.rowHeight)
         .background(
             RoundedRectangle(cornerRadius: 6)
                 .fill(

--- a/ArcBox/Views/Kubernetes/ServiceDetailView.swift
+++ b/ArcBox/Views/Kubernetes/ServiceDetailView.swift
@@ -35,15 +35,7 @@ struct ServiceDetailView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .toolbar {
-            ToolbarItem(placement: .principal) {
-                Picker("Tab", selection: $vm.activeTab) {
-                    ForEach(ServiceDetailTab.allCases) { tab in
-                        Text(tab.rawValue).tag(tab)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .frame(maxWidth: 120)
-            }
+            DetailTabPicker(selection: $vm.activeTab)
         }
     }
 }

--- a/ArcBox/Views/Kubernetes/ServiceRowView.swift
+++ b/ArcBox/Views/Kubernetes/ServiceRowView.swift
@@ -14,7 +14,7 @@ struct ServiceRowView: View {
             // Service icon
             RoundedRectangle(cornerRadius: 6)
                 .fill(AppColors.iconBackground)
-                .frame(width: 32, height: 32)
+                .frame(width: AppMetrics.rowIcon, height: AppMetrics.rowIcon)
                 .overlay {
                     Image(systemName: "network")
                         .font(.system(size: 14))
@@ -35,7 +35,7 @@ struct ServiceRowView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.horizontal, 8)
-        .frame(height: 44)
+        .frame(height: AppMetrics.rowHeight)
         .background(
             RoundedRectangle(cornerRadius: 6)
                 .fill(

--- a/ArcBox/Views/Machines/MachineCreateSheet.swift
+++ b/ArcBox/Views/Machines/MachineCreateSheet.swift
@@ -44,13 +44,13 @@ struct MachineCreateSheet: View {
                         Image(systemName: "xmark")
                             .font(.system(size: 12))
                             .foregroundStyle(AppColors.textSecondary)
-                            .frame(width: 24, height: 24)
+                            .frame(width: AppMetrics.sheetCloseButton, height: AppMetrics.sheetCloseButton)
                     }
                 )
                 .buttonStyle(.plain)
             }
             .padding(.horizontal, 16)
-            .frame(height: 44)
+            .frame(height: AppMetrics.sheetTitleBarHeight)
             .overlay(alignment: .bottom) { Divider() }
 
             Form {

--- a/ArcBox/Views/Machines/MachineDetailView.swift
+++ b/ArcBox/Views/Machines/MachineDetailView.swift
@@ -35,15 +35,7 @@ struct MachineDetailView: View {
             await vm.loadMachineDetails(id, client: client)
         }
         .toolbar {
-            ToolbarItem(placement: .principal) {
-                Picker("Tab", selection: $vm.activeTab) {
-                    ForEach(MachineDetailTab.allCases) { tab in
-                        Text(tab.rawValue).tag(tab)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .frame(maxWidth: 300)
-            }
+            DetailTabPicker(selection: $vm.activeTab)
         }
     }
 }

--- a/ArcBox/Views/Machines/MachineRowView.swift
+++ b/ArcBox/Views/Machines/MachineRowView.swift
@@ -30,7 +30,7 @@ struct MachineRowView: View {
             ZStack(alignment: .bottomTrailing) {
                 RoundedRectangle(cornerRadius: 6)
                     .fill(AppColors.iconBackground)
-                    .frame(width: 32, height: 32)
+                    .frame(width: AppMetrics.rowIcon, height: AppMetrics.rowIcon)
                     .overlay {
                         Image(systemName: "desktopcomputer")
                             .font(.system(size: 16))
@@ -91,7 +91,7 @@ struct MachineRowView: View {
             }
         }
         .padding(.horizontal, 8)
-        .frame(height: 44)
+        .frame(height: AppMetrics.rowHeight)
         .background(
             RoundedRectangle(cornerRadius: 6)
                 .fill(

--- a/ArcBox/Views/Machines/Tabs/MachineTerminalTab.swift
+++ b/ArcBox/Views/Machines/Tabs/MachineTerminalTab.swift
@@ -67,7 +67,7 @@ struct MachineTerminalTab: View {
                 }
             }
             .pickerStyle(.menu)
-            .frame(width: 140)
+            .frame(width: AppMetrics.shellPickerWidth)
             .disabled(session.state == .connected)
 
             Spacer()

--- a/ArcBox/Views/Networks/NetworkRowView.swift
+++ b/ArcBox/Views/Networks/NetworkRowView.swift
@@ -16,7 +16,7 @@ struct NetworkRowView: View {
             // Network icon
             RoundedRectangle(cornerRadius: 6)
                 .fill(AppColors.iconBackground)
-                .frame(width: 32, height: 32)
+                .frame(width: AppMetrics.rowIcon, height: AppMetrics.rowIcon)
                 .overlay {
                     Image(systemName: network.isSystem ? "globe" : "link")
                         .font(.system(size: 14))
@@ -46,7 +46,7 @@ struct NetworkRowView: View {
             }
         }
         .padding(.horizontal, 12)
-        .frame(height: 44)
+        .frame(height: AppMetrics.rowHeight)
         .background(
             RoundedRectangle(cornerRadius: 6)
                 .fill(

--- a/ArcBox/Views/Networks/Tabs/NetworkContainersTab.swift
+++ b/ArcBox/Views/Networks/Tabs/NetworkContainersTab.swift
@@ -128,7 +128,7 @@ struct NetworkContainerRow: View {
                 HStack(spacing: 6) {
                     Circle()
                         .fill(entry.isRunning ? Color.green : Color.gray)
-                        .frame(width: 8, height: 8)
+                        .frame(width: AppMetrics.statusDot, height: AppMetrics.statusDot)
                     Text(entry.isRunning ? "Running" : "Stopped")
                         .font(.system(size: 12))
                         .foregroundStyle(AppColors.textSecondary)

--- a/ArcBox/Views/Sandboxes/NewSandboxSheet.swift
+++ b/ArcBox/Views/Sandboxes/NewSandboxSheet.swift
@@ -60,13 +60,13 @@ struct NewSandboxSheet: View {
                         Image(systemName: "xmark")
                             .font(.system(size: 12))
                             .foregroundStyle(AppColors.textSecondary)
-                            .frame(width: 24, height: 24)
+                            .frame(width: AppMetrics.sheetCloseButton, height: AppMetrics.sheetCloseButton)
                     }
                 )
                 .buttonStyle(.plain)
             }
             .padding(.horizontal, 16)
-            .frame(height: 44)
+            .frame(height: AppMetrics.sheetTitleBarHeight)
             .overlay(alignment: .bottom) { Divider() }
 
             // Scrollable form
@@ -136,7 +136,7 @@ struct NewSandboxSheet: View {
             .padding(.vertical, 12)
             .overlay(alignment: .top) { Divider() }
         }
-        .frame(width: 480, height: 540)
+        .frame(width: AppMetrics.sheetWidth, height: 540)
         .task {
             // Populate the image picker even when the Images view hasn't been
             // opened yet; loadImages no-ops if the Docker client isn't ready.

--- a/ArcBox/Views/Sandboxes/SandboxDetailView.swift
+++ b/ArcBox/Views/Sandboxes/SandboxDetailView.swift
@@ -49,15 +49,7 @@ struct SandboxDetailView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .toolbar {
-            ToolbarItem(placement: .principal) {
-                Picker("Tab", selection: $vm.activeTab) {
-                    ForEach(SandboxDetailTab.allCases) { tab in
-                        Text(tab.rawValue).tag(tab)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .frame(maxWidth: 420)
-            }
+            DetailTabPicker(selection: $vm.activeTab)
         }
         .task(id: vm.selectedID) {
             if let id = vm.selectedID {

--- a/ArcBox/Views/Sandboxes/SandboxMonitoringView.swift
+++ b/ArcBox/Views/Sandboxes/SandboxMonitoringView.swift
@@ -103,7 +103,7 @@ struct MonitoringChart: View {
                     // End dot
                     Circle()
                         .fill(AppColors.running)
-                        .frame(width: 8, height: 8)
+                        .frame(width: AppMetrics.statusDot, height: AppMetrics.statusDot)
                         .position(x: geo.size.width - 4, y: geo.size.height - 2)
                 }
             }

--- a/ArcBox/Views/Sandboxes/SandboxRowView.swift
+++ b/ArcBox/Views/Sandboxes/SandboxRowView.swift
@@ -27,7 +27,7 @@ struct SandboxRowView: View {
             // Sandbox icon
             RoundedRectangle(cornerRadius: 6)
                 .fill(AppColors.iconBackground)
-                .frame(width: 32, height: 32)
+                .frame(width: AppMetrics.rowIcon, height: AppMetrics.rowIcon)
                 .overlay {
                     Image(systemName: "square.stack.3d.up")
                         .font(.system(size: 14))
@@ -71,7 +71,7 @@ struct SandboxRowView: View {
             }
         }
         .padding(.horizontal, 8)
-        .frame(height: 44)
+        .frame(height: AppMetrics.rowHeight)
         .background(
             RoundedRectangle(cornerRadius: 6)
                 .fill(

--- a/ArcBox/Views/Sandboxes/Tabs/SandboxTerminalTab.swift
+++ b/ArcBox/Views/Sandboxes/Tabs/SandboxTerminalTab.swift
@@ -26,7 +26,7 @@ struct SandboxTerminalTab: View {
                     }
                 }
                 .pickerStyle(.menu)
-                .frame(width: 140)
+                .frame(width: AppMetrics.shellPickerWidth)
                 .disabled(session.state == .connected)
 
                 Spacer()

--- a/ArcBox/Views/Settings/GeneralSettingsView.swift
+++ b/ArcBox/Views/Settings/GeneralSettingsView.swift
@@ -260,5 +260,5 @@ struct GeneralSettingsView: View {
         .environment(ContainersViewModel())
         .environment(ImagesViewModel())
         .environment(UpdaterSettingsModel(updater: updater))
-        .frame(width: 500, height: 400)
+        .frame(width: AppMetrics.settingsPaneWidth, height: 400)
 }

--- a/ArcBox/Views/Settings/NetworkSettingsView.swift
+++ b/ArcBox/Views/Settings/NetworkSettingsView.swift
@@ -98,5 +98,5 @@ struct NetworkSettingsView: View {
 
 #Preview {
     NetworkSettingsView()
-        .frame(width: 500, height: 600)
+        .frame(width: AppMetrics.settingsPaneWidth, height: AppMetrics.settingsPaneHeight)
 }

--- a/ArcBox/Views/Settings/StorageSettingsView.swift
+++ b/ArcBox/Views/Settings/StorageSettingsView.swift
@@ -208,5 +208,5 @@ struct StorageSettingsView: View {
 
 #Preview {
     StorageSettingsView()
-        .frame(width: 500, height: 600)
+        .frame(width: AppMetrics.settingsPaneWidth, height: AppMetrics.settingsPaneHeight)
 }

--- a/ArcBox/Views/Settings/SystemSettingsView.swift
+++ b/ArcBox/Views/Settings/SystemSettingsView.swift
@@ -236,5 +236,5 @@ struct SystemSettingsView: View {
     SystemSettingsView()
         .environment(DaemonManager())
         .environment(SystemVmBackendModel())
-        .frame(width: 500, height: 600)
+        .frame(width: AppMetrics.settingsPaneWidth, height: AppMetrics.settingsPaneHeight)
 }

--- a/ArcBox/Views/Templates/TemplateDetailView.swift
+++ b/ArcBox/Views/Templates/TemplateDetailView.swift
@@ -41,15 +41,7 @@ struct TemplateDetailView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .toolbar {
-            ToolbarItem(placement: .principal) {
-                Picker("Tab", selection: $vm.activeTab) {
-                    ForEach(TemplateDetailTab.allCases) { tab in
-                        Text(tab.rawValue).tag(tab)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .frame(maxWidth: 200)
-            }
+            DetailTabPicker(selection: $vm.activeTab)
         }
     }
 }

--- a/ArcBox/Views/Templates/TemplateRowView.swift
+++ b/ArcBox/Views/Templates/TemplateRowView.swift
@@ -13,7 +13,7 @@ struct TemplateRowView: View {
             // Template icon
             RoundedRectangle(cornerRadius: 6)
                 .fill(AppColors.iconBackground)
-                .frame(width: 32, height: 32)
+                .frame(width: AppMetrics.rowIcon, height: AppMetrics.rowIcon)
                 .overlay {
                     Image(systemName: "doc.on.doc")
                         .font(.system(size: 14))
@@ -43,7 +43,7 @@ struct TemplateRowView: View {
             }
         }
         .padding(.horizontal, 8)
-        .frame(height: 44)
+        .frame(height: AppMetrics.rowHeight)
         .background(
             RoundedRectangle(cornerRadius: 6)
                 .fill(

--- a/ArcBox/Views/Volumes/NewVolumeSheet.swift
+++ b/ArcBox/Views/Volumes/NewVolumeSheet.swift
@@ -48,7 +48,7 @@ struct NewVolumeSheet: View {
             HStack {
                 Button("?") {}
                     .buttonStyle(.plain)
-                    .frame(width: 24, height: 24)
+                    .frame(width: AppMetrics.sheetCloseButton, height: AppMetrics.sheetCloseButton)
 
                 Button("Import...") {
                     let panel = NSOpenPanel()
@@ -89,6 +89,6 @@ struct NewVolumeSheet: View {
             .padding(.vertical, 12)
             .overlay(alignment: .top) { Divider() }
         }
-        .frame(width: 480, height: 240)
+        .frame(width: AppMetrics.sheetWidth, height: 240)
     }
 }

--- a/ArcBox/Views/Volumes/VolumeDetailView.swift
+++ b/ArcBox/Views/Volumes/VolumeDetailView.swift
@@ -40,15 +40,7 @@ struct VolumeDetailView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .toolbar {
-            ToolbarItem(placement: .principal) {
-                Picker("Tab", selection: $vm.activeTab) {
-                    ForEach(VolumeDetailTab.allCases) { tab in
-                        Text(tab.rawValue).tag(tab)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .frame(maxWidth: 200)
-            }
+            DetailTabPicker(selection: $vm.activeTab)
         }
     }
 }

--- a/ArcBox/Views/Volumes/VolumeRowView.swift
+++ b/ArcBox/Views/Volumes/VolumeRowView.swift
@@ -16,7 +16,7 @@ struct VolumeRowView: View {
             // Volume icon
             RoundedRectangle(cornerRadius: 6)
                 .fill(AppColors.iconBackground)
-                .frame(width: 32, height: 32)
+                .frame(width: AppMetrics.rowIcon, height: AppMetrics.rowIcon)
                 .overlay {
                     Image(systemName: "externaldrive")
                         .font(.system(size: 14))
@@ -46,7 +46,7 @@ struct VolumeRowView: View {
             }
         }
         .padding(.horizontal, 12)
-        .frame(height: 44)
+        .frame(height: AppMetrics.rowHeight)
         .background(
             RoundedRectangle(cornerRadius: 6)
                 .fill(

--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,14 @@ PROVISIONING_PROFILE ?=
 
 ABCTL := $(ARCBOX_DIR)/target/release/abctl
 
-.PHONY: build test format lint lint-xtask test-xtask generate-xcodeproj bump-arcbox verify-arcbox-protobuf build-rust prefetch dmg dmg-signed dmg-release clean help
+.PHONY: build test resolve format lint lint-xtask test-xtask generate-xcodeproj bump-arcbox verify-arcbox-protobuf build-rust prefetch dmg dmg-signed dmg-release clean help
 
 help:
 	@echo "ArcBox build targets:"
 	@echo ""
 	@echo "  make build          Build the Swift app (Debug, no Rust binaries)"
 	@echo "  make test           Build and run the test suite"
+	@echo "  make resolve        Update Package.resolved after a Package.swift change"
 	@echo "  make format         Apply swift-format in place"
 	@echo "  make lint           Run swift-format --strict and swiftlint (as CI does)"
 	@echo "  make lint-xtask     Run cargo fmt --check and clippy -D warnings on xtask/"
@@ -95,6 +96,11 @@ DESTINATION ?= platform=macOS
 # SKIP_RUST_BUILD=1: the embed phase pulls prebuilt binaries from ../arcbox.
 # These targets compile and test Swift; use `make dmg-signed` for a bundle whose
 # daemon survives launch (`make dmg` ad-hoc signs it and drops its entitlements).
+#
+# `-onlyUsePackageVersionsFromResolvedFile`: build the versions in
+# Package.resolved or fail. Without it a manifest edit silently re-resolves and
+# the build runs against dependencies nobody reviewed, leaving the committed
+# lockfile stale. Run `make resolve` after changing any Package.swift.
 XCODEBUILD_FLAGS = \
 	-project ArcBox.xcodeproj \
 	-scheme ArcBox \
@@ -102,6 +108,7 @@ XCODEBUILD_FLAGS = \
 	-destination '$(DESTINATION)' \
 	-derivedDataPath .build/DerivedData \
 	-clonedSourcePackagesDirPath .build/SourcePackages \
+	-onlyUsePackageVersionsFromResolvedFile \
 	-skipPackagePluginValidation \
 	-skipMacroValidation \
 	$(XCODEBUILD_EXTRA) \
@@ -114,6 +121,14 @@ build:
 
 test:
 	$(XCODE_ENV) xcodebuild test $(XCODEBUILD_FLAGS)
+
+# The one command allowed to move Package.resolved. Commit the result with the
+# manifest change that motivated it.
+resolve:
+	$(XCODE_ENV) xcodebuild -resolvePackageDependencies \
+		-project ArcBox.xcodeproj \
+		-scheme ArcBox \
+		-clonedSourcePackagesDirPath .build/SourcePackages
 
 # Feed swift-format the tracked sources rather than walking directories: a
 # local `Packages/*/.build/checkouts` holds vendored third-party code that is

--- a/xtask/src/commands/macos/dmg.rs
+++ b/xtask/src/commands/macos/dmg.rs
@@ -150,6 +150,10 @@ fn build_swift_app(
         .arg("-clonedSourcePackagesDirPath")
         .arg(&spm_clones)
         .arg("-skipPackagePluginValidation")
+        // A release must ship the dependency versions that were reviewed. Without
+        // this, a stale Package.resolved re-resolves silently and the shipped
+        // binary links something nobody approved.
+        .arg("-onlyUsePackageVersionsFromResolvedFile")
         .arg("ARCHS=arm64")
         .arg(format!("ARCBOX_DIR={}", arcbox_dir.display()))
         .arg(format!("CURRENT_PROJECT_VERSION={build_number}"));


### PR DESCRIPTION
Three release-readiness audit items. Unrelated to each other, but each is small
enough that separate PRs would cost more review attention than they save.

## ABXD-72 — fail the build when `Package.resolved` is out of date

Every build path resolved SwiftPM dependencies with automatic resolution
enabled, so editing a `Package.swift` without committing the regenerated
lockfile silently built against whatever the resolver picked. The committed
lockfile was documentation, not a constraint.

`-onlyUsePackageVersionsFromResolvedFile` now goes on all three paths: the
shared Makefile flags (`make build`/`make test`, which the PR workflow calls),
the PR workflow's own resolve step, and the xtask release build. The resolve
step needed it too — unpinned, it would have repaired a stale lockfile before
the gated build ever saw the drift.

`make resolve` is the one command allowed to move the lockfile.

Verified both directions locally: a floor above the pin fails with

> an out-of-date resolved file was detected at …, which is not allowed when
> automatic dependency resolution is disabled

and the tree as committed resolves clean.

The issue asked for `.exact()` pins in the manifests. That is not the right
fix here — exact pins in a library manifest make version conflicts unresolvable
for any consumer and block `swift package update`, and with the lockfile now
enforced they buy nothing. Manifests keep `from:`.

## ABXD-58 — derive the detail tab widths, name the shared dimensions

Eight detail views each carried their own copy of the toolbar tab bar,
identical but for the enum and a hand-fitted width:

| view | tabs | was |
|---|---|---|
| Service | 1 | 120 |
| Volume / Template | 2 | 200 |
| Pod / Image | 3 | 250 |
| Container / Machine | 4 | 300 |
| Sandbox | 6 | 420 |

The deltas are 80/50/50/60 per added tab — fitted by eye, so adding a tab meant
re-tuning a number that gave no sign it needed re-tuning. `DetailTabPicker`
takes the width from the tab count instead, at 80pt per segment: at or above
every per-segment width that shipped before (the tightest was 70, on the
six-tab sandbox view, and it fit "Snapshots").

`AppMetrics` collects the dimensions more than one file draws and would
visibly disagree on if they drifted — row height and icon tile, the row action
slot that progress spinners must line up with, the status dot, sheet width and
title bar, the shell picker, the settings pane.

Deliberately **not** unified, because the value histogram lies:

- The three `44`s in the create sheets are title bars, not list rows.
- Of eight `24`pt squares only four are the sheet close button; the others are
  an export tile, a progress slot, and a copy button.
- One of the two `140`s is a table column, not a shell picker.

Also left alone, because collapsing them is a visual decision and not a
refactor: the 7pt status dots in the menu bar and activity strip against the
8pt one elsewhere, the 12pt dots in the container and machine rows, and the
400pt-tall General settings pane among three 600s.

## ABXD-57 — drop the unused `createdAgo` formatter

`ContainerViewModel.createdAgo` had no call sites; the info tab switched to
`Up \(uptimeDisplay)` some time ago. It was the last relative-time formatter
disagreeing with the shared one ("1d ago" vs "1 day ago"), so deleting it
settles the inconsistency with no visible change. `uptimeDisplay` stays — it
answers a different question and its compact form is deliberate.

## Verification

`make build`, `make test` (178 tests, 0 failures), `make lint` (0 violations),
and `make generate-xcodeproj` all clean; the pbxproj diff is 8 lines, exactly
the two new files.

Refs ABXD-57, ABXD-58, ABXD-72