### PR TITLE
feat(onboarding): add guided first-run setup

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		47F7DA566708A3959A5AEB8D /* SystemVmBackendModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BC46E06601AA9D330AF049 /* SystemVmBackendModel.swift */; };
 		48014023336A8AD5D1B21A27 /* ContainerLogsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB364896F740E811FBE1B04D /* ContainerLogsTab.swift */; };
 		4B14BB17843A552B8D1B51BA /* ExternalTerminalDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BE672A52785F040AC6CEB2 /* ExternalTerminalDiscovery.swift */; };
+		4C3BC465BFE58BF0D59AFE78 /* OnboardingWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 915561BEEE49F5E27F4B0D40 /* OnboardingWindowController.swift */; };
 		4D2029E55A7979B8BD9EE89A /* ContainersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610512C9106BB92A47DC044 /* ContainersViewModelTests.swift */; };
 		4D2FB362066EF19A8C5983F1 /* DockerClient in Frameworks */ = {isa = PBXBuildFile; productRef = 984278376FF4860E6FADC66F /* DockerClient */; };
 		50CCDEFCA186BCD1E99D291F /* ChangelogParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBEBBF08F0E4AC45D9C0BB83 /* ChangelogParser.swift */; };
@@ -175,6 +176,7 @@
 		A75C60F77B89D7AEE365BC2E /* VolumeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF2337ED21F8382F7ABB29A /* VolumeModel.swift */; };
 		A7E66915A83CDD9FF95EF09F /* MachineEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81FCCED6F39D73E946107243 /* MachineEmptyStateView.swift */; };
 		A8374C7CC46723B1764B2F43 /* KeychainTokenStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DFEA7126F89956523019B4 /* KeychainTokenStoreTests.swift */; };
+		A9BC7D2040EC032EBBC709E4 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747AB46D7603C23FB9112444 /* OnboardingView.swift */; };
 		A9E1DA5DBCAC015D9C41FF18 /* SandboxesViewModel+Snapshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2D773B0312F0D5695D0ADA /* SandboxesViewModel+Snapshots.swift */; };
 		AA8A34E11EF00EBFB5AC1090 /* MachinesViewModel+GRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB1B1CD1D5E0E961CD17118 /* MachinesViewModel+GRPC.swift */; };
 		AAC2BE593C229A83757CCD23 /* LiquidGlass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3572105F94A4F2399F9446D4 /* LiquidGlass.swift */; };
@@ -222,6 +224,7 @@
 		D786BBF78698824ED9F5E048 /* ComingSoonPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE64C34A555B2A5BA02AD9FA /* ComingSoonPanel.swift */; };
 		DA5B57293BC69B7D95AABBA8 /* ActivityRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0201CD86DCD5E042D07FF66F /* ActivityRow.swift */; };
 		DB19F0073D84ED7A7C937D49 /* ContainersListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80010452354615CAC08FAF1D /* ContainersListViewControllerTests.swift */; };
+		DB5CE5663EE824474F0739FF /* OnboardingWindowControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A517313E1085B62A40075622 /* OnboardingWindowControllerTests.swift */; };
 		DC9E1747A0F6F6574688BBD0 /* arcbox.version in Resources */ = {isa = PBXBuildFile; fileRef = AC70A79B919D909CF6D811B4 /* arcbox.version */; };
 		DDF9F74BA0638A51322686DE /* PodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF5B0B3EC77FB12D8B4EA6A /* PodsViewModel.swift */; };
 		E0C997A42E6F8D8B4D9C26FF /* ImagesListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35969670AC4F826B4A3BB567 /* ImagesListViewControllerTests.swift */; };
@@ -376,6 +379,7 @@
 		7058C8975F3F2684714E24E2 /* SleepWakeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepWakeManager.swift; sourceTree = "<group>"; };
 		71DF8E5C8AADE1AD5C60F457 /* OIDCClientConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OIDCClientConfigurationTests.swift; sourceTree = "<group>"; };
 		738233A82C7BAA825F73EE2F /* GuestExportFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestExportFixture.swift; sourceTree = "<group>"; };
+		747AB46D7603C23FB9112444 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		7607A876F6C88A440DA53BE1 /* SidebarAccountButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarAccountButton.swift; sourceTree = "<group>"; };
 		769B6260DD087F5B16E7407D /* MachinesListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachinesListViewControllerTests.swift; sourceTree = "<group>"; };
 		77BE672A52785F040AC6CEB2 /* ExternalTerminalDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalTerminalDiscovery.swift; sourceTree = "<group>"; };
@@ -408,6 +412,7 @@
 		8ECCF18CC36CC3579EE2B5B9 /* MachinesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachinesView.swift; sourceTree = "<group>"; };
 		903FA72CEF39142ADA5CA378 /* NewVolumeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewVolumeSheet.swift; sourceTree = "<group>"; };
 		9101DCB26B0BB5B8DE4CAE70 /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
+		915561BEEE49F5E27F4B0D40 /* OnboardingWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWindowController.swift; sourceTree = "<group>"; };
 		920C9CA81449FA23CEC17EF6 /* SandboxFilesTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxFilesTab.swift; sourceTree = "<group>"; };
 		9234FC5BCCDDCBF441A94880 /* UpdaterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterDelegate.swift; sourceTree = "<group>"; };
 		93968609F8E058EAC838DD18 /* UpdaterSettingsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterSettingsModel.swift; sourceTree = "<group>"; };
@@ -425,6 +430,7 @@
 		A2B92BFA23F4133B8488DDD8 /* Local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Local.xcconfig; sourceTree = "<group>"; };
 		A37BB3605830EBE3A1625452 /* PodModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodModel.swift; sourceTree = "<group>"; };
 		A45A5AAA9B74A59E7543D8D0 /* LocalRootFSOutlineCoordinator+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalRootFSOutlineCoordinator+Actions.swift"; sourceTree = "<group>"; };
+		A517313E1085B62A40075622 /* OnboardingWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWindowControllerTests.swift; sourceTree = "<group>"; };
 		A70BE1C3890C5F6A96C6BCBD /* ContainersViewModel+GRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContainersViewModel+GRPC.swift"; sourceTree = "<group>"; };
 		A764F03F9EA5C3149B777338 /* SandboxesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxesViewModel.swift; sourceTree = "<group>"; };
 		A80B0A0F4FC2E7ECA0B844DD /* ContainerFilesTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerFilesTab.swift; sourceTree = "<group>"; };
@@ -714,6 +720,7 @@
 				1C649765AA76CFCBFC3302DA /* DeepLinkRouter.swift */,
 				794F192F207790B1A137A816 /* EnvironmentValues+Clients.swift */,
 				C396CA9355FFB5ACB7DD1D32 /* MainWindowController.swift */,
+				915561BEEE49F5E27F4B0D40 /* OnboardingWindowController.swift */,
 				D6F75C788ADEDBC9B1F007E3 /* QuitWindowController.swift */,
 				DB9FDA2F6F3036772AC0B23C /* SettingsWindowController.swift */,
 				E217254D0827A011E01C3F05 /* StatusItemController.swift */,
@@ -759,6 +766,7 @@
 				9AAA79DD504AA68C0CF27A7E /* Machines */,
 				0519B44E047B9175695BEB9D /* MenuBar */,
 				1B2068276E193C5409B45A9A /* Networks */,
+				7D67538045DC5ABA446A6F68 /* Onboarding */,
 				EAC6176638594B6D1458C90D /* Sandboxes */,
 				36146B8720F5A0DE35FA0026 /* Settings */,
 				1953A7C4A7DE99DBA4B29185 /* Shared */,
@@ -857,6 +865,14 @@
 				2D053B8542825698996A16FE /* ArcBoxTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		7D67538045DC5ABA446A6F68 /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				747AB46D7603C23FB9112444 /* OnboardingView.swift */,
+			);
+			path = Onboarding;
 			sourceTree = "<group>";
 		};
 		7D89C26DD9B6BEB015B28923 /* Images */ = {
@@ -1130,6 +1146,7 @@
 				2110402B2013A53E306B4E43 /* MainWindowControllerTests.swift */,
 				0FA3C6B6F10198DFC435A33E /* NetworkDetailViewControllerTests.swift */,
 				FA27F4AC273B14038EDB6593 /* NetworksListViewControllerTests.swift */,
+				A517313E1085B62A40075622 /* OnboardingWindowControllerTests.swift */,
 				B084B3E5BD66E2DA018764E8 /* QuitWindowControllerTests.swift */,
 				B4BAE047B96D10B4716BA1A2 /* VolumesListViewControllerTests.swift */,
 			);
@@ -1440,6 +1457,8 @@
 				72CCF0BC7FEAEB988595757C /* NewNetworkSheet.swift in Sources */,
 				B29A0911581DF9A70350B726 /* NewSandboxSheet.swift in Sources */,
 				D745D0D7EF5FF65174C47F28 /* NewVolumeSheet.swift in Sources */,
+				A9BC7D2040EC032EBBC709E4 /* OnboardingView.swift in Sources */,
+				4C3BC465BFE58BF0D59AFE78 /* OnboardingWindowController.swift in Sources */,
 				97B9638AA9C685C6DB2780B4 /* PerformanceTracing.swift in Sources */,
 				B8F04FD5D42B1934B13D9D3A /* PodDetailView.swift in Sources */,
 				73E1E5FC3E40AD0760A21AC0 /* PodModel.swift in Sources */,
@@ -1548,6 +1567,7 @@
 				F6386D2A578AD21E751CFC57 /* OIDCAuthorizationURLBuilderTests.swift in Sources */,
 				D6C6DEA33D73FF969786C018 /* OIDCClientConfigurationTests.swift in Sources */,
 				B6AB384B22968963098E96F3 /* OIDCClientTests.swift in Sources */,
+				DB5CE5663EE824474F0739FF /* OnboardingWindowControllerTests.swift in Sources */,
 				98E7A55FC92F874A28D762FD /* PKCETests.swift in Sources */,
 				D4ECBBCAC3D4631041F292D5 /* QuitWindowControllerTests.swift in Sources */,
 				1CB8AE8C16D0C333B7C0B32F /* ResourceStatsTests.swift in Sources */,

--- a/ArcBox/App/AppDelegate.swift
+++ b/ArcBox/App/AppDelegate.swift
@@ -58,7 +58,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         if menuItem.action == #selector(checkForUpdates(_:)) {
             return coordinator?.canCheckForUpdates == true
         }
-        if menuItem.action == #selector(showSettings(_:)) {
+        if menuItem.action == #selector(showSettings(_:))
+            || menuItem.action == #selector(showGettingStarted(_:))
+        {
             return coordinator?.canUseMainInterface == true
         }
         return true
@@ -76,6 +78,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         coordinator?.checkForUpdates()
     }
 
+    @objc private func showGettingStarted(_ sender: Any?) {
+        coordinator?.showGettingStarted()
+    }
+
     private func installMainMenu() {
         let mainMenu = NSMenu()
         let appItem = NSMenuItem()
@@ -83,12 +89,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         let editItem = NSMenuItem()
         let viewItem = NSMenuItem()
         let windowItem = NSMenuItem()
+        let helpItem = NSMenuItem()
 
         mainMenu.addItem(appItem)
         mainMenu.addItem(fileItem)
         mainMenu.addItem(editItem)
         mainMenu.addItem(viewItem)
         mainMenu.addItem(windowItem)
+        mainMenu.addItem(helpItem)
 
         appItem.submenu = makeApplicationMenu()
         fileItem.submenu = makeFileMenu()
@@ -96,9 +104,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         viewItem.submenu = makeViewMenu()
         let windowMenu = makeWindowMenu()
         windowItem.submenu = windowMenu
+        let helpMenu = makeHelpMenu()
+        helpItem.submenu = helpMenu
 
         NSApp.mainMenu = mainMenu
         NSApp.windowsMenu = windowMenu
+        NSApp.helpMenu = helpMenu
     }
 
     private func makeApplicationMenu() -> NSMenu {
@@ -209,6 +220,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
                 "Bring All to Front",
                 action: #selector(NSApplication.arrangeInFront(_:)),
                 target: NSApp
+            ))
+        return menu
+    }
+
+    private func makeHelpMenu() -> NSMenu {
+        let menu = NSMenu(title: "Help")
+        menu.addItem(
+            item(
+                "Getting Started with ArcBox",
+                action: #selector(showGettingStarted(_:))
             ))
         return menu
     }

--- a/ArcBox/App/AppDelegate.swift
+++ b/ArcBox/App/AppDelegate.swift
@@ -58,6 +58,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         if menuItem.action == #selector(checkForUpdates(_:)) {
             return coordinator?.canCheckForUpdates == true
         }
+        if menuItem.action == #selector(showSettings(_:)) {
+            return coordinator?.canUseMainInterface == true
+        }
         return true
     }
 

--- a/ArcBox/App/AppPreferences.swift
+++ b/ArcBox/App/AppPreferences.swift
@@ -1,8 +1,32 @@
 import Foundation
 
 enum AppPreferences {
+    private static let onboardingCompletedKey = "hasCompletedOnboarding"
+    private static let onboardingInitializedKey = "hasInitializedOnboardingPreference"
+    // Sparkle has persisted this key since before onboarding existed, so it
+    // distinguishes an upgrade from a genuinely new installation.
+    private static let sparkleHasLaunchedBeforeKey = "SUHasLaunchedBefore"
+
     static func registerDefaults(in userDefaults: UserDefaults = .standard) {
+        let hasLaunchOverride =
+            userDefaults.volatileDomain(forName: UserDefaults.argumentDomain)[
+                onboardingCompletedKey
+            ] != nil
+        if !userDefaults.bool(forKey: onboardingInitializedKey) {
+            let hasLaunchedBefore = userDefaults.bool(forKey: sparkleHasLaunchedBeforeKey)
+            // Argument-domain values are intentionally temporary; initialize
+            // the stored value from the pre-existing Sparkle marker instead.
+            let hasCompletedOnboarding =
+                hasLaunchOverride
+                ? hasLaunchedBefore
+                : userDefaults.bool(forKey: onboardingCompletedKey) || hasLaunchedBefore
+            userDefaults.set(hasCompletedOnboarding, forKey: onboardingCompletedKey)
+            userDefaults.set(true, forKey: onboardingInitializedKey)
+        }
+
         userDefaults.register(defaults: [
+            onboardingCompletedKey: false,
+            onboardingInitializedKey: false,
             "showInMenuBar": false,
             "updateChannel": "stable",
             "activity.containerColumns": Data(),
@@ -14,5 +38,13 @@ enum AppPreferences {
             "switchDockerContextAutomatically": true,
             "pauseContainersWhileSleeping": true,
         ])
+    }
+
+    static func hasCompletedOnboarding(in userDefaults: UserDefaults = .standard) -> Bool {
+        userDefaults.bool(forKey: onboardingCompletedKey)
+    }
+
+    static func markOnboardingCompleted(in userDefaults: UserDefaults = .standard) {
+        userDefaults.set(true, forKey: onboardingCompletedKey)
     }
 }

--- a/ArcBox/App/ApplicationCoordinator.swift
+++ b/ArcBox/App/ApplicationCoordinator.swift
@@ -33,6 +33,7 @@ final class ApplicationCoordinator: NSObject {
     private(set) var startupOrchestrator: StartupOrchestrator?
 
     private var mainWindowController: MainWindowController?
+    private var onboardingWindowController: OnboardingWindowController?
     private var settingsWindowController: SettingsWindowController?
     private var statusItemController: StatusItemController?
     private var quitWindowController: QuitWindowController?
@@ -45,10 +46,14 @@ final class ApplicationCoordinator: NSObject {
     private var lastValidNavigation: NavItem = .containers
     private var lastShowInMenuBar: Bool
     private var lastUpdateChannel: String
+    private var isOnboarding: Bool
+    private var shouldOpenSandboxesAfterOnboarding: Bool
+    private var deepLinksConfigured = false
     private var started = false
     private(set) var isTerminating = false
 
     override init() {
+        let hasCompletedOnboarding = AppPreferences.hasCompletedOnboarding()
         updaterController = SPUStandardUpdaterController(
             startingUpdater: true,
             updaterDelegate: updaterDelegate,
@@ -57,11 +62,17 @@ final class ApplicationCoordinator: NSObject {
         updaterSettings = UpdaterSettingsModel(updater: updaterController.updater)
         lastShowInMenuBar = UserDefaults.standard.bool(forKey: "showInMenuBar")
         lastUpdateChannel = UserDefaults.standard.string(forKey: "updateChannel") ?? "stable"
+        isOnboarding = !hasCompletedOnboarding
+        shouldOpenSandboxesAfterOnboarding = !hasCompletedOnboarding
         super.init()
     }
 
     var canCheckForUpdates: Bool {
         updaterController.updater.canCheckForUpdates
+    }
+
+    var canUseMainInterface: Bool {
+        !isTerminating && !isOnboarding
     }
 
     func start() {
@@ -73,10 +84,13 @@ final class ApplicationCoordinator: NSObject {
             onClientsNeeded: { [unowned self] in try initClientsAndReturn() }
         )
         startupOrchestrator = orchestrator
+        observeStartupPhase()
 
         installWindows()
         observeNavigation()
-        configureDeepLinks()
+        if !isOnboarding {
+            configureDeepLinks()
+        }
         observeDaemonState()
         _ = NotificationCenter.default.addObserver(
             forName: UserDefaults.didChangeNotification,
@@ -92,11 +106,8 @@ final class ApplicationCoordinator: NSObject {
             await self?.authSession.loadUserInfo()
         }
 
-        startupTask = Task { [weak self] in
-            guard let self else { return }
-            let startedAt = CFAbsoluteTimeGetCurrent()
-            await orchestrator.start()
-            captureStartupResult(orchestrator, startedAt: startedAt)
+        if !isOnboarding {
+            startRuntimeIfNeeded()
         }
     }
 
@@ -107,6 +118,10 @@ final class ApplicationCoordinator: NSObject {
 
     func showMainWindow() {
         guard !isTerminating else { return }
+        guard !isOnboarding else {
+            showOnboarding()
+            return
+        }
         activate()
         mainWindowController?.window?.deminiaturize(nil)
         mainWindowController?.showWindow(nil)
@@ -115,6 +130,10 @@ final class ApplicationCoordinator: NSObject {
 
     func showSettings(tab: SettingsTab? = nil) {
         guard !isTerminating else { return }
+        guard !isOnboarding else {
+            showOnboarding()
+            return
+        }
         if let tab {
             appVM.settingsTab = tab
         }
@@ -196,10 +215,12 @@ final class ApplicationCoordinator: NSObject {
         mainWindowController = MainWindowController(contentViewController: mainHost)
         settingsWindowController = SettingsWindowController(contentViewController: settingsHost)
         statusItemController = StatusItemController(contentViewController: menuBarHost)
-        statusItemController?.setVisible(lastShowInMenuBar)
+        statusItemController?.setVisible(!isOnboarding && lastShowInMenuBar)
     }
 
     private func configureDeepLinks() {
+        guard !deepLinksConfigured else { return }
+        deepLinksConfigured = true
         deepLinkRouter.configure(
             .init(
                 appVM: appVM,
@@ -214,6 +235,93 @@ final class ApplicationCoordinator: NSObject {
                     Task { await self?.authSession.handleAuthorizationCallback(url) }
                 }
             ))
+    }
+
+    private func startRuntimeIfNeeded(allowingAdministratorPrompt: Bool = false) {
+        guard !isTerminating, startupTask == nil, let orchestrator = startupOrchestrator else {
+            return
+        }
+
+        startupTask = Task { [weak self] in
+            guard let self else { return }
+            let startedAt = CFAbsoluteTimeGetCurrent()
+            await orchestrator.start(
+                allowingAdministratorPrompt: allowingAdministratorPrompt
+            )
+            captureStartupResult(orchestrator, startedAt: startedAt)
+            startupTask = nil
+        }
+    }
+
+    private func showOnboarding(startingAt initialStep: OnboardingStep? = nil) {
+        guard !isTerminating, let orchestrator = startupOrchestrator else { return }
+
+        isOnboarding = true
+        mainWindowController?.window?.orderOut(nil)
+        settingsWindowController?.window?.orderOut(nil)
+        statusItemController?.setVisible(false)
+
+        if onboardingWindowController == nil {
+            let host = NSHostingController(
+                rootView: OnboardingView(
+                    orchestrator: orchestrator,
+                    initialStep: initialStep ?? .welcome,
+                    onStart: { [weak self] in
+                        self?.startRuntimeIfNeeded(allowingAdministratorPrompt: true)
+                    },
+                    onComplete: { [weak self] in
+                        self?.completeOnboarding()
+                    },
+                    onQuit: { [weak self] in
+                        self?.requestQuit()
+                    }
+                ))
+            onboardingWindowController = OnboardingWindowController(
+                contentViewController: host,
+                onClose: { [weak self] in
+                    self?.requestQuit()
+                }
+            )
+        }
+
+        activate()
+        onboardingWindowController?.show()
+    }
+
+    private func completeOnboarding() {
+        guard !isTerminating, startupOrchestrator?.isReady == true else { return }
+
+        AppPreferences.markOnboardingCompleted()
+        isOnboarding = false
+        onboardingWindowController?.window?.orderOut(nil)
+        onboardingWindowController = nil
+
+        if shouldOpenSandboxesAfterOnboarding {
+            appVM.navigate(to: .sandboxes)
+            shouldOpenSandboxesAfterOnboarding = false
+        }
+
+        statusItemController?.setVisible(lastShowInMenuBar)
+        showMainWindow()
+        configureDeepLinks()
+    }
+
+    private func observeStartupPhase() {
+        guard let orchestrator = startupOrchestrator else { return }
+        withObservationTracking {
+            _ = orchestrator.phase
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                self?.startupPhaseDidChange()
+            }
+        }
+    }
+
+    private func startupPhaseDidChange() {
+        guard !isTerminating else { return }
+        observeStartupPhase()
+        guard startupOrchestrator?.phase == .requiresAdministratorApproval else { return }
+        showOnboarding(startingAt: .permission)
     }
 
     private func observeDaemonState() {
@@ -420,7 +528,7 @@ final class ApplicationCoordinator: NSObject {
         let showInMenuBar = defaults.bool(forKey: "showInMenuBar")
         if showInMenuBar != lastShowInMenuBar {
             lastShowInMenuBar = showInMenuBar
-            statusItemController?.setVisible(showInMenuBar)
+            statusItemController?.setVisible(!isOnboarding && showInMenuBar)
         }
 
         let updateChannel = defaults.string(forKey: "updateChannel") ?? "stable"

--- a/ArcBox/App/ApplicationCoordinator.swift
+++ b/ArcBox/App/ApplicationCoordinator.swift
@@ -48,7 +48,6 @@ final class ApplicationCoordinator: NSObject {
     private var lastShowInMenuBar: Bool
     private var lastUpdateChannel: String
     private var isOnboarding: Bool
-    private var shouldOpenSandboxesAfterOnboarding: Bool
     private var deepLinksConfigured = false
     private var started = false
     private(set) var isTerminating = false
@@ -64,7 +63,6 @@ final class ApplicationCoordinator: NSObject {
         lastShowInMenuBar = UserDefaults.standard.bool(forKey: "showInMenuBar")
         lastUpdateChannel = UserDefaults.standard.string(forKey: "updateChannel") ?? "stable"
         isOnboarding = !hasCompletedOnboarding
-        shouldOpenSandboxesAfterOnboarding = !hasCompletedOnboarding
         super.init()
     }
 
@@ -325,11 +323,6 @@ final class ApplicationCoordinator: NSObject {
         isOnboarding = false
         onboardingWindowController?.window?.orderOut(nil)
         onboardingWindowController = nil
-
-        if shouldOpenSandboxesAfterOnboarding {
-            appVM.navigate(to: .sandboxes)
-            shouldOpenSandboxesAfterOnboarding = false
-        }
 
         statusItemController?.setVisible(lastShowInMenuBar)
         showMainWindow()

--- a/ArcBox/App/ApplicationCoordinator.swift
+++ b/ArcBox/App/ApplicationCoordinator.swift
@@ -34,6 +34,7 @@ final class ApplicationCoordinator: NSObject {
 
     private var mainWindowController: MainWindowController?
     private var onboardingWindowController: OnboardingWindowController?
+    private var gettingStartedWindowController: OnboardingWindowController?
     private var settingsWindowController: SettingsWindowController?
     private var statusItemController: StatusItemController?
     private var quitWindowController: QuitWindowController?
@@ -149,6 +150,33 @@ final class ApplicationCoordinator: NSObject {
         showAboutWindow()
     }
 
+    func showGettingStarted() {
+        guard canUseMainInterface, let orchestrator = startupOrchestrator else { return }
+
+        if gettingStartedWindowController?.window?.isVisible != true {
+            let host = NSHostingController(
+                rootView: OnboardingView(
+                    orchestrator: orchestrator,
+                    initialStep: .welcome,
+                    isReplay: true,
+                    onStart: {},
+                    onComplete: { [weak self] in
+                        self?.gettingStartedWindowController?.window?.performClose(nil)
+                    },
+                    onQuit: {}
+                ))
+            gettingStartedWindowController = OnboardingWindowController(
+                title: "Getting Started with ArcBox",
+                contentViewController: host,
+                allowsClosing: true,
+                onClose: {}
+            )
+        }
+
+        activate()
+        gettingStartedWindowController?.show()
+    }
+
     func checkForUpdates() {
         guard !isTerminating else { return }
         updaterController.updater.checkForUpdates()
@@ -259,6 +287,8 @@ final class ApplicationCoordinator: NSObject {
         isOnboarding = true
         mainWindowController?.window?.orderOut(nil)
         settingsWindowController?.window?.orderOut(nil)
+        gettingStartedWindowController?.window?.orderOut(nil)
+        gettingStartedWindowController = nil
         statusItemController?.setVisible(false)
 
         if onboardingWindowController == nil {

--- a/ArcBox/App/OnboardingWindowController.swift
+++ b/ArcBox/App/OnboardingWindowController.swift
@@ -4,9 +4,16 @@ import AppKit
 final class OnboardingWindowController: NSWindowController, NSWindowDelegate {
     static let windowSize = NSSize(width: 760, height: 600)
 
+    private let allowsClosing: Bool
     private let onClose: () -> Void
 
-    init(contentViewController: NSViewController, onClose: @escaping () -> Void) {
+    init(
+        title: String = "Welcome to ArcBox",
+        contentViewController: NSViewController,
+        allowsClosing: Bool = false,
+        onClose: @escaping () -> Void
+    ) {
+        self.allowsClosing = allowsClosing
         self.onClose = onClose
 
         let window = NSWindow(
@@ -15,7 +22,7 @@ final class OnboardingWindowController: NSWindowController, NSWindowDelegate {
             backing: .buffered,
             defer: false
         )
-        window.title = "Welcome to ArcBox"
+        window.title = title
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
         window.contentViewController = contentViewController
@@ -42,6 +49,7 @@ final class OnboardingWindowController: NSWindowController, NSWindowDelegate {
     }
 
     func windowShouldClose(_ sender: NSWindow) -> Bool {
+        guard !allowsClosing else { return true }
         onClose()
         return false
     }

--- a/ArcBox/App/OnboardingWindowController.swift
+++ b/ArcBox/App/OnboardingWindowController.swift
@@ -1,0 +1,48 @@
+import AppKit
+
+@MainActor
+final class OnboardingWindowController: NSWindowController, NSWindowDelegate {
+    static let windowSize = NSSize(width: 760, height: 600)
+
+    private let onClose: () -> Void
+
+    init(contentViewController: NSViewController, onClose: @escaping () -> Void) {
+        self.onClose = onClose
+
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: Self.windowSize),
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Welcome to ArcBox"
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.contentViewController = contentViewController
+        window.isReleasedWhenClosed = false
+        window.isRestorable = false
+        window.tabbingMode = .disallowed
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.setFrame(NSRect(origin: .zero, size: Self.windowSize), display: false)
+        window.center()
+
+        super.init(window: window)
+        window.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func show() {
+        showWindow(nil)
+        window?.makeKeyAndOrderFront(nil)
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        onClose()
+        return false
+    }
+}

--- a/ArcBox/Views/Onboarding/OnboardingView.swift
+++ b/ArcBox/Views/Onboarding/OnboardingView.swift
@@ -85,60 +85,63 @@ struct OnboardingView: View {
                 .resizable()
                 .interpolation(.high)
                 .scaledToFit()
-                .frame(width: 88, height: 88)
+                .frame(width: 72, height: 72)
                 .accessibilityHidden(true)
 
             VStack(spacing: 6) {
                 Text("Welcome to ArcBox")
                     .font(.system(size: 28, weight: .semibold))
 
-                Text("Disposable Linux environments, ready in seconds.")
-                    .font(.system(size: 15))
-                    .foregroundStyle(AppColors.textSecondary)
+                Text(
+                    "Containers, Kubernetes, Linux VMs, and sandboxes — together on your Mac."
+                )
+                .font(.system(size: 15))
+                .foregroundStyle(AppColors.textSecondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
             }
 
-            sandboxCard
+            capabilitiesPanel
                 .padding(.top, 4)
         }
         .frame(maxWidth: 536)
         .accessibilityElement(children: .contain)
     }
 
-    private var sandboxCard: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack(spacing: 16) {
-                Image(systemName: "server.rack")
-                    .font(.system(size: 24, weight: .medium))
-                    .foregroundStyle(Color.accentColor)
-                    .frame(width: 56, height: 56)
-                    .background(
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .fill(AppColors.iconBackground)
-                    )
-                    .accessibilityHidden(true)
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Sandboxes")
-                        .font(.system(size: 18, weight: .semibold))
-                    Text(
-                        "Create isolated environments, then inspect and control them without leaving ArcBox."
-                    )
-                    .font(.system(size: 13))
-                    .foregroundStyle(AppColors.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                }
+    private var capabilitiesPanel: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 0) {
+                capabilityCell(
+                    "Containers",
+                    symbol: NavItem.containers.sfSymbol,
+                    detail: "Run Docker and Compose workloads."
+                )
+                Divider()
+                capabilityCell(
+                    "Kubernetes",
+                    symbol: NavItem.pods.sfSymbol,
+                    detail: "Manage local pods and services."
+                )
             }
 
-            HStack(spacing: 18) {
-                featureLabel("Terminal", symbol: "terminal")
-                featureLabel("Files", symbol: "folder")
-                featureLabel("Ports", symbol: "network")
-                featureLabel("Snapshots", symbol: "clock.arrow.circlepath")
-                featureLabel("Events", symbol: "list.bullet.rectangle")
+            Divider()
+
+            HStack(spacing: 0) {
+                capabilityCell(
+                    "Linux VMs",
+                    symbol: NavItem.machines.sfSymbol,
+                    detail: "Full Linux machines with terminal and files."
+                )
+                Divider()
+                capabilityCell(
+                    "Sandboxes",
+                    symbol: NavItem.sandboxes.sfSymbol,
+                    detail: "Disposable microVMs with ports and snapshots."
+                )
             }
         }
-        .padding(20)
         .background(cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
         .overlay(cardBorder)
     }
 
@@ -217,7 +220,7 @@ struct OnboardingView: View {
                 Text("ArcBox is ready")
                     .font(.system(size: 24, weight: .semibold))
 
-                Text("Your Sandboxes and system integrations are ready to use.")
+                Text("ArcBox and its local runtime are ready to use.")
                     .font(.system(size: 14))
                     .foregroundStyle(AppColors.textSecondary)
             }
@@ -308,10 +311,30 @@ struct OnboardingView: View {
         )
     }
 
-    private func featureLabel(_ title: String, symbol: String) -> some View {
-        Label(title, systemImage: symbol)
-            .font(.system(size: 12))
-            .foregroundStyle(AppColors.textSecondary)
+    private func capabilityCell(_ title: String, symbol: String, detail: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: symbol)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 36, height: 36)
+                .background(
+                    RoundedRectangle(cornerRadius: 9, style: .continuous)
+                        .fill(AppColors.iconBackground)
+                )
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.system(size: 15, weight: .semibold))
+                Text(detail)
+                    .font(.system(size: 12))
+                    .foregroundStyle(AppColors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, minHeight: 100, alignment: .topLeading)
+        .accessibilityElement(children: .combine)
     }
 
     private func primaryButton(_ title: String, action: @escaping () -> Void) -> some View {

--- a/ArcBox/Views/Onboarding/OnboardingView.swift
+++ b/ArcBox/Views/Onboarding/OnboardingView.swift
@@ -10,6 +10,7 @@ enum OnboardingStep: Hashable {
 
 struct OnboardingView: View {
     let orchestrator: StartupOrchestrator
+    let isReplay: Bool
     let onStart: () -> Void
     let onComplete: () -> Void
     let onQuit: () -> Void
@@ -22,11 +23,13 @@ struct OnboardingView: View {
     init(
         orchestrator: StartupOrchestrator,
         initialStep: OnboardingStep,
+        isReplay: Bool = false,
         onStart: @escaping () -> Void,
         onComplete: @escaping () -> Void,
         onQuit: @escaping () -> Void
     ) {
         self.orchestrator = orchestrator
+        self.isReplay = isReplay
         self.onStart = onStart
         self.onComplete = onComplete
         self.onQuit = onQuit
@@ -147,8 +150,12 @@ struct OnboardingView: View {
                 .accessibilityHidden(true)
 
             VStack(spacing: 8) {
-                Text("Allow ArcBox to finish system setup")
-                    .font(.system(size: 24, weight: .semibold))
+                Text(
+                    isReplay
+                        ? "Why ArcBox may ask for administrator access"
+                        : "Allow ArcBox to finish system setup"
+                )
+                .font(.system(size: 24, weight: .semibold))
 
                 Text(
                     "ArcBox and its runtime normally run as your user. "
@@ -261,9 +268,13 @@ struct OnboardingView: View {
 
                 Spacer()
 
-                primaryButton("Continue to macOS") {
-                    move(to: .setup, forward: true)
-                    onStart()
+                if isReplay {
+                    primaryButton("Done", action: onComplete)
+                } else {
+                    primaryButton("Continue to macOS") {
+                        move(to: .setup, forward: true)
+                        onStart()
+                    }
                 }
             case .setup:
                 if orchestrator.isReady {

--- a/ArcBox/Views/Onboarding/OnboardingView.swift
+++ b/ArcBox/Views/Onboarding/OnboardingView.swift
@@ -1,0 +1,344 @@
+import AppKit
+import ArcBoxClient
+import SwiftUI
+
+enum OnboardingStep: Hashable {
+    case welcome
+    case permission
+    case setup
+}
+
+struct OnboardingView: View {
+    let orchestrator: StartupOrchestrator
+    let onStart: () -> Void
+    let onComplete: () -> Void
+    let onQuit: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @State private var step: OnboardingStep
+    @State private var movingForward = true
+
+    init(
+        orchestrator: StartupOrchestrator,
+        initialStep: OnboardingStep,
+        onStart: @escaping () -> Void,
+        onComplete: @escaping () -> Void,
+        onQuit: @escaping () -> Void
+    ) {
+        self.orchestrator = orchestrator
+        self.onStart = onStart
+        self.onComplete = onComplete
+        self.onQuit = onQuit
+        _step = State(initialValue: initialStep)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ZStack {
+                page
+                    .id(step)
+                    .transition(pageTransition)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.horizontal, 72)
+            .padding(.top, 44)
+            .padding(.bottom, 24)
+
+            Divider()
+
+            footer
+                .frame(height: 64)
+                .padding(.horizontal, 24)
+        }
+        .frame(
+            width: OnboardingWindowController.windowSize.width,
+            height: OnboardingWindowController.windowSize.height
+        )
+        .background {
+            if reduceTransparency {
+                Color(nsColor: .windowBackgroundColor)
+            } else {
+                Rectangle().fill(.regularMaterial)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var page: some View {
+        switch step {
+        case .welcome:
+            welcomePage
+        case .permission:
+            permissionPage
+        case .setup:
+            setupPage
+        }
+    }
+
+    private var welcomePage: some View {
+        VStack(spacing: 16) {
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .interpolation(.high)
+                .scaledToFit()
+                .frame(width: 88, height: 88)
+                .accessibilityHidden(true)
+
+            VStack(spacing: 6) {
+                Text("Welcome to ArcBox")
+                    .font(.system(size: 28, weight: .semibold))
+
+                Text("Disposable Linux environments, ready in seconds.")
+                    .font(.system(size: 15))
+                    .foregroundStyle(AppColors.textSecondary)
+            }
+
+            sandboxCard
+                .padding(.top, 4)
+        }
+        .frame(maxWidth: 536)
+        .accessibilityElement(children: .contain)
+    }
+
+    private var sandboxCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 16) {
+                Image(systemName: "server.rack")
+                    .font(.system(size: 24, weight: .medium))
+                    .foregroundStyle(Color.accentColor)
+                    .frame(width: 56, height: 56)
+                    .background(
+                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                            .fill(AppColors.iconBackground)
+                    )
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Sandboxes")
+                        .font(.system(size: 18, weight: .semibold))
+                    Text(
+                        "Create isolated environments, then inspect and control them without leaving ArcBox."
+                    )
+                    .font(.system(size: 13))
+                    .foregroundStyle(AppColors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            HStack(spacing: 18) {
+                featureLabel("Terminal", symbol: "terminal")
+                featureLabel("Files", symbol: "folder")
+                featureLabel("Ports", symbol: "network")
+                featureLabel("Snapshots", symbol: "clock.arrow.circlepath")
+                featureLabel("Events", symbol: "list.bullet.rectangle")
+            }
+        }
+        .padding(20)
+        .background(cardBackground)
+        .overlay(cardBorder)
+    }
+
+    private var permissionPage: some View {
+        VStack(spacing: 18) {
+            Image(systemName: "lock.shield")
+                .font(.system(size: 50, weight: .regular))
+                .foregroundStyle(Color.accentColor)
+                .accessibilityHidden(true)
+
+            VStack(spacing: 8) {
+                Text("Allow ArcBox to finish system setup")
+                    .font(.system(size: 24, weight: .semibold))
+
+                Text(
+                    "ArcBox and its runtime normally run as your user. "
+                        + "When system integration needs installing or updating, macOS may ask "
+                        + "you to approve a small privileged helper."
+                )
+                .font(.system(size: 14))
+                .foregroundStyle(AppColors.textSecondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(alignment: .leading, spacing: 14) {
+                PermissionRow(
+                    symbol: "network",
+                    title: "Container networking and local names",
+                    detail: "Adds routes and resolves *.arcbox.local addresses."
+                )
+                PermissionRow(
+                    symbol: "terminal",
+                    title: "Docker and command-line integration",
+                    detail: "Provides the standard Docker socket and ArcBox CLI tools."
+                )
+
+                Divider()
+
+                Label {
+                    Text("Your password stays with macOS. ArcBox never sees, stores, or sends it.")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(AppColors.textSecondary)
+                } icon: {
+                    Image(systemName: "checkmark.shield")
+                        .foregroundStyle(AppColors.running)
+                }
+            }
+            .padding(20)
+            .background(cardBackground)
+            .overlay(cardBorder)
+
+            Text(
+                "You may be asked again when the helper receives a security or compatibility update."
+            )
+            .font(.system(size: 11))
+            .foregroundStyle(AppColors.textMuted)
+            .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: 536)
+    }
+
+    @ViewBuilder
+    private var setupPage: some View {
+        if orchestrator.isReady {
+            VStack(spacing: 16) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 52))
+                    .foregroundStyle(AppColors.running)
+                    .accessibilityHidden(true)
+
+                Text("ArcBox is ready")
+                    .font(.system(size: 24, weight: .semibold))
+
+                Text("Your Sandboxes and system integrations are ready to use.")
+                    .font(.system(size: 14))
+                    .foregroundStyle(AppColors.textSecondary)
+            }
+            .transition(.opacity)
+        } else {
+            VStack(spacing: 14) {
+                Image(nsImage: NSApp.applicationIconImage)
+                    .resizable()
+                    .interpolation(.high)
+                    .scaledToFit()
+                    .frame(width: 64, height: 64)
+                    .accessibilityHidden(true)
+
+                VStack(spacing: 6) {
+                    Text("Setting up ArcBox")
+                        .font(.system(size: 24, weight: .semibold))
+                    Text("This usually takes less than a minute.")
+                        .font(.system(size: 14))
+                        .foregroundStyle(AppColors.textSecondary)
+                }
+
+                StartupProgressView(
+                    orchestrator: orchestrator,
+                    allowingAdministratorPrompt: true
+                )
+                .frame(width: 420, height: 190)
+            }
+            .transition(.opacity)
+        }
+    }
+
+    @ViewBuilder
+    private var footer: some View {
+        HStack {
+            switch step {
+            case .welcome:
+                Spacer()
+                primaryButton("Continue") {
+                    move(to: .permission, forward: true)
+                }
+            case .permission:
+                Button("Back") {
+                    move(to: .welcome, forward: false)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .keyboardShortcut(.cancelAction)
+
+                Spacer()
+
+                primaryButton("Continue to macOS") {
+                    move(to: .setup, forward: true)
+                    onStart()
+                }
+            case .setup:
+                if orchestrator.isReady {
+                    Spacer()
+                    primaryButton("Open ArcBox", action: onComplete)
+                } else {
+                    Button("Quit ArcBox", action: onQuit)
+                        .buttonStyle(.bordered)
+                        .controlSize(.large)
+                    Spacer()
+                }
+            }
+        }
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: 18, style: .continuous)
+            .fill(AppColors.surfaceCard)
+    }
+
+    private var cardBorder: some View {
+        RoundedRectangle(cornerRadius: 18, style: .continuous)
+            .stroke(AppColors.borderSubtle, lineWidth: 1)
+    }
+
+    private var pageTransition: AnyTransition {
+        guard !reduceMotion else { return .opacity }
+        return .asymmetric(
+            insertion: .offset(x: movingForward ? 12 : -12).combined(with: .opacity),
+            removal: .offset(x: movingForward ? -12 : 12).combined(with: .opacity)
+        )
+    }
+
+    private func featureLabel(_ title: String, symbol: String) -> some View {
+        Label(title, systemImage: symbol)
+            .font(.system(size: 12))
+            .foregroundStyle(AppColors.textSecondary)
+    }
+
+    private func primaryButton(_ title: String, action: @escaping () -> Void) -> some View {
+        Button(title, action: action)
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .frame(minWidth: 132)
+            .keyboardShortcut(.defaultAction)
+    }
+
+    private func move(to destination: OnboardingStep, forward: Bool) {
+        movingForward = forward
+        withAnimation(.easeInOut(duration: reduceMotion ? 0.12 : 0.2)) {
+            step = destination
+        }
+    }
+}
+
+private struct PermissionRow: View {
+    let symbol: String
+    let title: String
+    let detail: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: symbol)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 22)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 13, weight: .medium))
+                Text(detail)
+                    .font(.system(size: 12))
+                    .foregroundStyle(AppColors.textSecondary)
+            }
+        }
+    }
+}

--- a/ArcBox/Views/Shared/StartupProgressView.swift
+++ b/ArcBox/Views/Shared/StartupProgressView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// After startup completes, DaemonLoadingView handles daemon disconnect/stop.
 struct StartupProgressView: View {
     let orchestrator: StartupOrchestrator
+    var allowingAdministratorPrompt = false
 
     var body: some View {
         VStack(spacing: 16) {
@@ -30,7 +31,11 @@ struct StartupProgressView: View {
                             .multilineTextAlignment(.center)
 
                         Button("Retry") {
-                            Task { await orchestrator.retry() }
+                            Task {
+                                await orchestrator.retry(
+                                    allowingAdministratorPrompt: allowingAdministratorPrompt
+                                )
+                            }
                         }
                         .buttonStyle(.borderedProminent)
                         .controlSize(.small)

--- a/ArcBoxTests/AppPreferencesTests.swift
+++ b/ArcBoxTests/AppPreferencesTests.swift
@@ -13,6 +13,7 @@ final class AppPreferencesTests: XCTestCase {
         userDefaults.set(false, forKey: "switchDockerContextAutomatically")
         AppPreferences.registerDefaults(in: userDefaults)
 
+        XCTAssertFalse(AppPreferences.hasCompletedOnboarding(in: userDefaults))
         XCTAssertFalse(userDefaults.bool(forKey: "showInMenuBar"))
         XCTAssertEqual(userDefaults.string(forKey: "updateChannel"), "stable")
         XCTAssertEqual(userDefaults.data(forKey: "activity.containerColumns"), Data())
@@ -32,5 +33,63 @@ final class AppPreferencesTests: XCTestCase {
 
         userDefaults.removeObject(forKey: "switchDockerContextAutomatically")
         XCTAssertTrue(userDefaults.bool(forKey: "switchDockerContextAutomatically"))
+
+        AppPreferences.markOnboardingCompleted(in: userDefaults)
+        AppPreferences.registerDefaults(in: userDefaults)
+        XCTAssertTrue(
+            AppPreferences.hasCompletedOnboarding(in: userDefaults),
+            "registered defaults must not reset completed onboarding"
+        )
+    }
+
+    func testOnboardingMigrationDistinguishesExistingAndInterruptedFirstLaunches() throws {
+        let existingSuiteName = "AppPreferencesTests.existing.\(UUID().uuidString)"
+        let existingDefaults = try XCTUnwrap(UserDefaults(suiteName: existingSuiteName))
+        defer { existingDefaults.removePersistentDomain(forName: existingSuiteName) }
+        existingDefaults.set(true, forKey: "SUHasLaunchedBefore")
+
+        AppPreferences.registerDefaults(in: existingDefaults)
+
+        XCTAssertTrue(AppPreferences.hasCompletedOnboarding(in: existingDefaults))
+
+        let newSuiteName = "AppPreferencesTests.new.\(UUID().uuidString)"
+        let newDefaults = try XCTUnwrap(UserDefaults(suiteName: newSuiteName))
+        defer { newDefaults.removePersistentDomain(forName: newSuiteName) }
+
+        AppPreferences.registerDefaults(in: newDefaults)
+        newDefaults.set(true, forKey: "SUHasLaunchedBefore")
+        AppPreferences.registerDefaults(in: newDefaults)
+
+        XCTAssertFalse(
+            AppPreferences.hasCompletedOnboarding(in: newDefaults),
+            "quitting a first launch must not migrate past onboarding"
+        )
+    }
+
+    func testLaunchOverrideDoesNotCompleteOnboardingOnTheNextLaunch() throws {
+        let suiteName = "AppPreferencesTests.override.\(UUID().uuidString)"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let argumentDomain = UserDefaults.argumentDomain
+        let originalArguments = userDefaults.volatileDomain(forName: argumentDomain)
+        defer {
+            userDefaults.setVolatileDomain(originalArguments, forName: argumentDomain)
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+
+        userDefaults.setVolatileDomain(
+            originalArguments.merging(["hasCompletedOnboarding": true]) { _, new in new },
+            forName: argumentDomain
+        )
+        AppPreferences.registerDefaults(in: userDefaults)
+        XCTAssertTrue(AppPreferences.hasCompletedOnboarding(in: userDefaults))
+
+        userDefaults.set(true, forKey: "SUHasLaunchedBefore")
+        userDefaults.setVolatileDomain(originalArguments, forName: argumentDomain)
+        AppPreferences.registerDefaults(in: userDefaults)
+
+        XCTAssertFalse(
+            AppPreferences.hasCompletedOnboarding(in: userDefaults),
+            "a one-off launch override must not become the stored preference"
+        )
     }
 }

--- a/ArcBoxTests/OnboardingWindowControllerTests.swift
+++ b/ArcBoxTests/OnboardingWindowControllerTests.swift
@@ -1,0 +1,25 @@
+import AppKit
+import XCTest
+
+@testable import ArcBox
+
+@MainActor
+final class OnboardingWindowControllerTests: XCTestCase {
+    func testWindowIsFixedPurposeAndDoesNotRestore() throws {
+        let controller = OnboardingWindowController(
+            contentViewController: NSViewController(),
+            onClose: {}
+        )
+        let window = try XCTUnwrap(controller.window)
+
+        XCTAssertEqual(window.frame.size, OnboardingWindowController.windowSize)
+        XCTAssertEqual(window.title, "Welcome to ArcBox")
+        XCTAssertTrue(window.styleMask.contains(.titled))
+        XCTAssertTrue(window.styleMask.contains(.closable))
+        XCTAssertTrue(window.styleMask.contains(.fullSizeContentView))
+        XCTAssertFalse(window.styleMask.contains(.miniaturizable))
+        XCTAssertFalse(window.styleMask.contains(.resizable))
+        XCTAssertFalse(window.isRestorable)
+        XCTAssertEqual(window.tabbingMode, .disallowed)
+    }
+}

--- a/ArcBoxTests/OnboardingWindowControllerTests.swift
+++ b/ArcBoxTests/OnboardingWindowControllerTests.swift
@@ -22,4 +22,25 @@ final class OnboardingWindowControllerTests: XCTestCase {
         XCTAssertFalse(window.isRestorable)
         XCTAssertEqual(window.tabbingMode, .disallowed)
     }
+
+    func testCloseBehaviorMatchesWindowPurpose() throws {
+        var firstRunCloseRequested = false
+        let firstRunController = OnboardingWindowController(
+            contentViewController: NSViewController(),
+            onClose: { firstRunCloseRequested = true }
+        )
+        let firstRunWindow = try XCTUnwrap(firstRunController.window)
+
+        XCTAssertFalse(firstRunController.windowShouldClose(firstRunWindow))
+        XCTAssertTrue(firstRunCloseRequested)
+
+        let replayController = OnboardingWindowController(
+            contentViewController: NSViewController(),
+            allowsClosing: true,
+            onClose: { XCTFail("replay close must not request app termination") }
+        )
+        let replayWindow = try XCTUnwrap(replayController.window)
+
+        XCTAssertTrue(replayController.windowShouldClose(replayWindow))
+    }
 }

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Helper.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Helper.swift
@@ -5,7 +5,7 @@ extension DaemonManager {
     // MARK: - Helper Lifecycle
 
     /// Installs the privileged helper via `abctl _install` with a macOS
-    /// admin password prompt.
+    /// admin password prompt when the caller has explicitly allowed it.
     ///
     /// SMAppService.daemon() is unreliable — macOS registers the daemon
     /// as disabled without notifying the user, and System Settings provides
@@ -16,19 +16,21 @@ extension DaemonManager {
     /// Skips the password prompt when the installed helper's **own crate
     /// version** is already ≥ the bundled one. That version is independent of
     /// the arcbox workspace version, so ordinary runtime bumps do not force an
-    /// admin reinstall. Always refreshes user-space shell integration
-    /// (`~/.arcbox/bin` Docker CLI links + PATH) so terminals keep working even
-    /// when the privileged helper path is deferred or fails.
+    /// admin reinstall. Refreshes user-space shell integration
+    /// (`~/.arcbox/bin` Docker CLI links + PATH) only after the helper is known
+    /// to be sufficient.
     ///
     /// - Throws: when the helper is missing/outdated and the privileged install
     ///   fails or does not leave a matching binary on disk. Callers surface this
     ///   in the startup UI so the user can retry (password cancel used to be
     ///   silent, leaving `/usr/local/bin/docker*` unlinked forever).
+    /// - Parameter allowingAdministratorPrompt: `true` only after the user has
+    ///   explicitly chosen to continue to the macOS administrator prompt.
     ///
     /// Installed helper binary path (must match arcbox-constants privileged::HELPER_BINARY).
     nonisolated static let installedHelperPath = "/usr/local/libexec/arcbox-helper"
 
-    public func installHelper() async throws {
+    public func installHelper(allowingAdministratorPrompt: Bool = false) async throws {
         // Find abctl and helper in the app bundle.
         let bundle = Bundle.main.bundleURL
         let abctl = bundle.appendingPathComponent("Contents/MacOS/bin/abctl").path
@@ -65,6 +67,11 @@ extension DaemonManager {
             return
         }
 
+        guard allowingAdministratorPrompt else {
+            helperInstalled = false
+            throw HelperInstallError.approvalRequired
+        }
+
         ClientLog.daemon.info(
             """
             Installing helper via abctl _install \
@@ -76,10 +83,6 @@ extension DaemonManager {
         let installError = try await runPrivilegedHelperInstall(abctl: abctl, helper: helper)
         if let installError {
             helperInstalled = false
-            // Still refresh user-space PATH/CLI links — these do not need root
-            // and keep `docker` available via ~/.arcbox/bin when the user has
-            // shell integration sourced.
-            await installShellIntegration(abctl: abctl)
             throw installError
         }
 
@@ -97,7 +100,6 @@ extension DaemonManager {
         }
 
         helperInstalled = false
-        await installShellIntegration(abctl: abctl)
         throw HelperInstallError.versionMismatch(
             installed: postInstallVersion,
             expected: bundledVersion
@@ -277,6 +279,7 @@ func appleScriptStringLiteral(_ value: String) -> String {
 /// Failures while installing or verifying the privileged helper.
 public enum HelperInstallError: LocalizedError, Sendable, Equatable {
     case bundledBinaryMissing(String)
+    case approvalRequired
     case appleScriptUnavailable
     case userCanceled
     case installFailed(String)
@@ -286,6 +289,8 @@ public enum HelperInstallError: LocalizedError, Sendable, Equatable {
         switch self {
         case .bundledBinaryMissing(let name):
             return "Bundled \(name) is missing from the app. Reinstall ArcBox."
+        case .approvalRequired:
+            return "Administrator approval is required to install or update the helper service."
         case .appleScriptUnavailable:
             return "Could not start the administrator prompt to install the helper service."
         case .userCanceled:

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/StartupOrchestrator/StartupOrchestrator.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/StartupOrchestrator/StartupOrchestrator.swift
@@ -86,8 +86,11 @@ public final class StartupOrchestrator {
     ///
     /// Safe to call multiple times — resets state on each invocation.
     /// Guarded against concurrent execution.
+    ///
+    /// - Parameter allowingAdministratorPrompt: `true` only after the user has
+    ///   explicitly chosen to continue to the macOS administrator prompt.
     @available(macOS 15.0, *)
-    public func start() async {
+    public func start(allowingAdministratorPrompt: Bool = false) async {
         guard !isTerminating else { return }
         if let startupTask {
             await startupTask.value
@@ -95,7 +98,7 @@ public final class StartupOrchestrator {
         }
 
         let task = Task {
-            await runStartup()
+            await runStartup(allowingAdministratorPrompt: allowingAdministratorPrompt)
             startupTask = nil
         }
         startupTask = task
@@ -113,7 +116,7 @@ public final class StartupOrchestrator {
         await startupTask?.value
     }
 
-    private func runStartup() async {
+    private func runStartup(allowingAdministratorPrompt: Bool) async {
         guard !isCancellationRequested else { return }
 
         for step in StartupStep.allCases {
@@ -125,7 +128,9 @@ public final class StartupOrchestrator {
         // docker.sock convenience link. Failures used to be swallowed, leaving
         // an ancient helper on disk and no CLI tools on PATH.
         let helperOK = await runStep(.installHelper) {
-            try await self.daemonManager.installHelper()
+            try await self.daemonManager.installHelper(
+                allowingAdministratorPrompt: allowingAdministratorPrompt
+            )
         }
 
         guard !isCancellationRequested else { return }
@@ -239,9 +244,12 @@ public final class StartupOrchestrator {
     }
 
     /// Retry the startup sequence after a failure.
+    ///
+    /// - Parameter allowingAdministratorPrompt: `true` only when the retry is
+    ///   itself an explicit administrator-approval action.
     @available(macOS 15.0, *)
-    public func retry() async {
-        await start()
+    public func retry(allowingAdministratorPrompt: Bool = false) async {
+        await start(allowingAdministratorPrompt: allowingAdministratorPrompt)
     }
 
     /// Human-readable cause of a daemon `FAILED` setup phase, for the retryable
@@ -289,6 +297,10 @@ public final class StartupOrchestrator {
                 "\(step.label, privacy: .public) completed in \(elapsedMs, privacy: .public)ms")
             stepStatuses[step] = .completed
             return true
+        } catch HelperInstallError.approvalRequired {
+            stepStatuses[step] = .pending
+            phase = .requiresAdministratorApproval
+            return false
         } catch {
             if isCancellationRequested || error is CancellationError {
                 ClientLog.startup.info("\(step.label, privacy: .public) canceled")

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/StartupOrchestrator/StartupTypes.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/StartupOrchestrator/StartupTypes.swift
@@ -62,6 +62,7 @@ public enum StepStatus: Sendable, Equatable {
 /// Overall startup phase — drives the top-level UI state.
 public enum StartupPhase: Sendable, Equatable {
     case idle
+    case requiresAdministratorApproval
     case running(step: StartupStep)
     case completed
     case failed(step: StartupStep, message: String)

--- a/Packages/ArcBoxClient/Tests/ArcBoxClientTests/HelperInstallErrorTests.swift
+++ b/Packages/ArcBoxClient/Tests/ArcBoxClientTests/HelperInstallErrorTests.swift
@@ -4,6 +4,12 @@ import Testing
 @testable import ArcBoxClient
 
 struct HelperInstallErrorTests {
+    @Test func approvalRequiredMessageExplainsWhyStartupPaused() {
+        let message = HelperInstallError.approvalRequired.errorDescription ?? ""
+        #expect(message.contains("Administrator approval"))
+        #expect(message.contains("helper service"))
+    }
+
     @Test func userCanceledMessageMentionsRetryAndDocker() {
         let message = HelperInstallError.userCanceled.errorDescription ?? ""
         #expect(message.contains("Retry"))

--- a/docs/development.md
+++ b/docs/development.md
@@ -44,8 +44,9 @@ certificate because macOS rejects the daemon's virtualization entitlements under
 The script creates an isolated `.build/arcbox-<version>` worktree so every runtime binary matches
 [`arcbox.version`](../arcbox.version), without changing the neighboring ArcBox checkout. It rejects
 the wrong commit and any tracked or untracked, non-ignored source changes in that worktree.
-Use `./script/build_and_run.sh --verify` to also wait for the development LaunchAgent, socket, and
-bundled `abctl` connection.
+Use `./script/build_and_run.sh --verify` to skip onboarding for that launch and wait for the
+development LaunchAgent, socket, and bundled `abctl` connection. The launch override does not
+change the stored onboarding preference.
 
 To get the same behavior from Xcode's Run button, enable the full-debug settings documented at the
 bottom of `Local.xcconfig.example`. Codex exposes the same script as its project Run action.

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -64,7 +64,7 @@ case "$mode" in
     /usr/bin/log stream --info --style compact --predicate 'subsystem == "com.arcboxlabs.desktop"'
     ;;
   --verify | verify)
-    open_app
+    /usr/bin/open -n "$app_bundle" --args -hasCompletedOnboarding YES
     for _ in {1..30}; do
       if /usr/bin/pgrep -f "$app_binary" >/dev/null \
         && /bin/launchctl print "gui/$(/usr/bin/id -u)/$daemon_label" >/dev/null 2>&1 \


### PR DESCRIPTION
## Summary

- Add a fixed-purpose AppKit onboarding window with SwiftUI Welcome, permission explanation, setup progress, and ready states.
- Defer the main interface and runtime startup until the user explicitly continues; route missing or outdated helper states back through the permission flow.
- Gate the administrator prompt behind explicit consent, migrate existing users without replaying onboarding, and keep the development `--verify` override temporary.
- Buffer deep links during onboarding and hide main-window, Settings, and menu-bar entry points until setup completes.
- Present Containers, Kubernetes, Linux VMs, and Sandboxes with equal weight in one accessible 2×2 capability panel; new users now retain the default Containers landing instead of being forced into Sandboxes.
- Add **Help → Getting Started with ArcBox** as a separate replayable tutorial that keeps the main interface and runtime alive and never re-enters setup or invokes the administrator flow.

## Security and behavior

- The copy explains why ArcBox needs elevated setup and that macOS handles the password.
- A failed or cancelled helper install no longer applies shell integration before the helper is verified.
- Existing users continue normally, while a genuinely new or interrupted first launch still receives onboarding.
- The Help replay ends at **Done**; Done, the close button, and Command-W close only the tutorial window.
- The ready state describes the local runtime without claiming that optional Kubernetes has already been enabled.

## Validation

- `make lint`
- `make test` — 220 XCTest tests and 84 Swift Testing tests passed
- `./script/build_and_run.sh --verify` — full bundled resources, Developer ID daemon, LaunchAgent, socket, and bundled `abctl doctor` verified
- Manual macOS 26 visual and accessibility review of the 2×2 Welcome panel, permission page, dividers, symbols, and text wrapping; no administrator prompt was approved during UI automation
- Manual Help replay smoke test covering repeated invocation, Welcome → permission → Done, Command-W, single-window behavior, and unchanged ArcBox/daemon PIDs
- Manual normal-launch check confirming Containers remains the selected default destination