### PR TITLE
fix(app): use native quit window placement

### DIFF
--- a/ArcBox/App/QuitWindowController.swift
+++ b/ArcBox/App/QuitWindowController.swift
@@ -10,7 +10,8 @@ final class QuitWindowController: NSWindowController {
             contentRect: NSRect(origin: .zero, size: Self.cardSize),
             styleMask: .borderless,
             backing: .buffered,
-            defer: false
+            defer: false,
+            screen: screen
         )
         window.title = "Quitting ArcBox"
         window.contentViewController = NSHostingController(rootView: QuitCardView())
@@ -25,16 +26,7 @@ final class QuitWindowController: NSWindowController {
         window.isExcludedFromWindowsMenu = true
         window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         window.animationBehavior = .none
-        if let screen {
-            let visibleFrame = screen.visibleFrame
-            window.setFrameOrigin(
-                NSPoint(
-                    x: visibleFrame.midX - Self.cardSize.width / 2,
-                    y: visibleFrame.midY - Self.cardSize.height / 2
-                ))
-        } else {
-            window.center()
-        }
+        window.center()
 
         super.init(window: window)
     }


### PR DESCRIPTION
## Summary

- initialize the quit window on the display that owned the active app window
- use AppKit's native `NSWindow.center()` placement instead of manual screen geometry

## Why

The custom placement calculated the exact geometric center of the visible frame, bypassing AppKit's standard modal-window placement, which is horizontally centered and visually offset upward. Binding the window to the captured `NSScreen` preserves the existing multi-display behavior while letting AppKit own the platform convention.

Users now see the quitting card in the native macOS visual-center position on the display where they were working.

## Validation

- `devenv shell -- make build`
- `devenv shell -- make lint`
- `devenv shell -- make test` — 223 XCTest and 84 Swift Testing tests passed