### PR TITLE
fix(containers): keep ArcBox domains visible

### DIFF
--- a/ArcBox/Models/ContainerModel.swift
+++ b/ArcBox/Models/ContainerModel.swift
@@ -142,21 +142,19 @@ struct ContainerViewModel: Identifiable, Hashable {
     /// Whether this container belongs to a compose project with known service name.
     var isCompose: Bool { composeProject != nil && composeService != nil }
 
-    /// The primary display domain for this container given the current DNS state.
+    /// The stable primary domain identity for this container.
     /// Compose containers use the hierarchical format: `<service>.<project>.arcbox.local`.
     /// Plain containers use the flat format: `<name>.arcbox.local`.
-    func hostDomain(useDNS: Bool) -> String {
-        guard useDNS else { return "localhost" }
+    var hostDomain: String {
         if let service = composeService, let project = composeProject {
             return "\(service).\(project).arcbox.local"
         }
         return "\(name).arcbox.local"
     }
 
-    /// All resolvable domains for this container.
+    /// All stable domain identities for this container.
     /// Compose containers have both the hierarchical and flat names.
-    func allDomains(useDNS: Bool) -> [String] {
-        guard useDNS else { return ["localhost"] }
+    var allDomains: [String] {
         if let service = composeService, let project = composeProject {
             return [
                 "\(service).\(project).arcbox.local",
@@ -166,14 +164,19 @@ struct ContainerViewModel: Identifiable, Hashable {
         return ["\(name).arcbox.local"]
     }
 
+    /// Host used for an actionable link under the current network health.
+    func connectionHost(useDNS: Bool) -> String {
+        useDNS ? hostDomain : "localhost"
+    }
+
     /// Build a URL for the container's primary port, respecting DNS mode.
     func domainURL(useDNS: Bool) -> URL? {
         if useDNS {
             if let port = ports.first {
                 let suffix = port.containerPort == 80 ? "" : ":\(port.containerPort)"
-                return URL(string: "http://\(hostDomain(useDNS: true))\(suffix)")
+                return URL(string: "http://\(hostDomain)\(suffix)")
             }
-            return URL(string: "http://\(hostDomain(useDNS: true))")
+            return URL(string: "http://\(hostDomain)")
         } else if let hostPort = hostPorts.first {
             return URL(string: "http://localhost:\(hostPort)")
         }
@@ -184,7 +187,7 @@ struct ContainerViewModel: Identifiable, Hashable {
     func portURL(_ port: PortMapping, useDNS: Bool) -> URL? {
         if useDNS {
             let suffix = port.containerPort == 80 ? "" : ":\(port.containerPort)"
-            return URL(string: "http://\(hostDomain(useDNS: true))\(suffix)")
+            return URL(string: "http://\(hostDomain)\(suffix)")
         } else {
             return URL(string: "http://localhost:\(port.hostPort)")
         }

--- a/ArcBox/Views/Containers/ContainerListCells.swift
+++ b/ArcBox/Views/Containers/ContainerListCells.swift
@@ -483,7 +483,7 @@ final class ContainerTableCellView: NSTableCellView, ResourceListActionDisplayin
         statusColor = Self.color(for: container.state)
 
         self.useDNS = useDNS
-        hostDomain = container.hostDomain(useDNS: useDNS)
+        hostDomain = container.connectionHost(useDNS: useDNS)
         ports =
             useDNS
             ? container.ports

--- a/ArcBox/Views/Containers/Tabs/ContainerInfoTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerInfoTab.swift
@@ -50,6 +50,9 @@ struct ContainerInfoTab: View {
                             )
                         }
                     }
+                    if let domain = container.domain {
+                        InfoRow(label: "Container Domain", value: domain)
+                    }
                     if let ip = container.ipAddress {
                         InfoRow(label: "IP", value: ip)
                     }

--- a/ArcBox/Views/Containers/Tabs/ContainerInfoTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerInfoTab.swift
@@ -13,7 +13,9 @@ struct ContainerInfoTab: View {
     let container: ContainerViewModel
     @Environment(DaemonManager.self) private var daemonManager
 
-    private var useDNS: Bool { daemonManager.dnsResolverInstalled && daemonManager.routeInstalled }
+    private var canUseDNS: Bool {
+        daemonManager.dnsResolverInstalled && daemonManager.routeInstalled
+    }
 
     var body: some View {
         ScrollView {
@@ -33,35 +35,26 @@ struct ContainerInfoTab: View {
                 .infoSectionStyle()
 
                 // Domain & IP section
-                if useDNS || !container.hostPorts.isEmpty
-                    || container.domain != nil || container.ipAddress != nil
-                {
-                    VStack(spacing: 0) {
-                        if useDNS || !container.hostPorts.isEmpty {
+                VStack(spacing: 0) {
+                    InfoRow(
+                        label: "Domain",
+                        value: container.hostDomain,
+                        link: canUseDNS ? container.domainURL(useDNS: true) : nil
+                    )
+                    if container.isCompose {
+                        let domains = container.allDomains
+                        if domains.count > 1 {
                             InfoRow(
-                                label: "Domain",
-                                value: container.hostDomain(useDNS: useDNS),
-                                link: container.domainURL(useDNS: useDNS)
+                                label: "Alias",
+                                value: domains[1]
                             )
-                            // Show flat alias for compose containers
-                            if useDNS, container.isCompose {
-                                let domains = container.allDomains(useDNS: true)
-                                if domains.count > 1 {
-                                    InfoRow(
-                                        label: "Alias",
-                                        value: domains[1]
-                                    )
-                                }
-                            }
-                        } else if let domain = container.domain {
-                            InfoRow(label: "Domain", value: domain)
-                        }
-                        if let ip = container.ipAddress {
-                            InfoRow(label: "IP", value: ip)
                         }
                     }
-                    .infoSectionStyle()
+                    if let ip = container.ipAddress {
+                        InfoRow(label: "IP", value: ip)
+                    }
                 }
+                .infoSectionStyle()
 
                 // Port Forwards section
                 if !container.ports.isEmpty {

--- a/ArcBoxTests/ContainersViewModelTests.swift
+++ b/ArcBoxTests/ContainersViewModelTests.swift
@@ -296,8 +296,8 @@ final class ContainersViewModelTests: XCTestCase {
 
     func testHostDomainPlainContainer() {
         let c = makeContainer(id: "1", name: "nginx")
-        XCTAssertEqual(c.hostDomain(useDNS: true), "nginx.arcbox.local")
-        XCTAssertEqual(c.hostDomain(useDNS: false), "localhost")
+        XCTAssertEqual(c.hostDomain, "nginx.arcbox.local")
+        XCTAssertEqual(c.connectionHost(useDNS: false), "localhost")
     }
 
     func testHostDomainComposeContainer() {
@@ -305,13 +305,13 @@ final class ContainersViewModelTests: XCTestCase {
             id: "1", name: "myapp-web-1",
             composeProject: "myapp", composeService: "web"
         )
-        XCTAssertEqual(c.hostDomain(useDNS: true), "web.myapp.arcbox.local")
-        XCTAssertEqual(c.hostDomain(useDNS: false), "localhost")
+        XCTAssertEqual(c.hostDomain, "web.myapp.arcbox.local")
+        XCTAssertEqual(c.connectionHost(useDNS: false), "localhost")
     }
 
     func testAllDomainsPlainContainer() {
         let c = makeContainer(id: "1", name: "redis")
-        let domains = c.allDomains(useDNS: true)
+        let domains = c.allDomains
         XCTAssertEqual(domains, ["redis.arcbox.local"])
     }
 
@@ -320,7 +320,7 @@ final class ContainersViewModelTests: XCTestCase {
             id: "1", name: "myapp-web-1",
             composeProject: "myapp", composeService: "web"
         )
-        let domains = c.allDomains(useDNS: true)
+        let domains = c.allDomains
         XCTAssertEqual(
             domains,
             [
@@ -329,12 +329,15 @@ final class ContainersViewModelTests: XCTestCase {
             ])
     }
 
-    func testAllDomainsDNSDisabled() {
+    func testAllDomainsRemainStableWhenDNSIsUnavailable() {
         let c = makeContainer(
             id: "1", name: "myapp-web-1",
             composeProject: "myapp", composeService: "web"
         )
-        XCTAssertEqual(c.allDomains(useDNS: false), ["localhost"])
+        XCTAssertEqual(
+            c.allDomains,
+            ["web.myapp.arcbox.local", "myapp-web-1.arcbox.local"]
+        )
     }
 
     func testIsComposeFlag() {


### PR DESCRIPTION
## Summary

- keep `<service>.<project>.arcbox.local` and `<container-name>.arcbox.local` as stable container identities
- always show the compose container's flat-name alias in the info UI
- use route/DNS health only to decide whether a domain is clickable; retain the existing localhost fallback for actionable list links

## Root cause

The Desktop model treated `dnsResolverInstalled && routeInstalled` as part of domain identity. A transient route-health failure therefore replaced domains with `localhost` or hid them, even though the container and Compose DNS names remained valid identity metadata.

This separates stable identity from current reachability: the names remain visible, while unhealthy route/DNS state only disables the link.

## Impact

Container details consistently expose both expected ArcBox domain forms. Users can still see and copy the correct names while networking is recovering, without the UI offering a broken domain link.

## Tracking

[ABX-510](https://linear.app/arcbox/issue/ABX-510/make-container-route-state-single-owned-and-keep-desktop-dns)

## Validation

- `make format`
- `make lint` — 0 violations
- `make test` — 223 XCTest tests and 84 Swift Testing tests passed