### PR TITLE
feat(notifications): notify on sandbox results and daemon health

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		2754C5F694613CA3A06DBC7E /* ContainerLogsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269B74A3C7704AB81139FA52 /* ContainerLogsModels.swift */; };
 		27A1480C02167F8BFC6D86B4 /* MainWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C396CA9355FFB5ACB7DD1D32 /* MainWindowController.swift */; };
 		299DA63B52A4A414F246A0D8 /* ServicesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F91CF47E53375781959EC9 /* ServicesListView.swift */; };
+		299F68933B6F5869B01B0F43 /* NotificationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D649CF8EC65915ED940D02A /* NotificationCoordinator.swift */; };
 		2C12FA161C343D99BD2E8AFD /* NetworksListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA27F4AC273B14038EDB6593 /* NetworksListViewControllerTests.swift */; };
 		2C918E08295E3751C9FD1EC1 /* MachineDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C7ADBBD83C5F92EEBAAD88 /* MachineDetailView.swift */; };
 		2D13FABE82FCAF045B2CF25D /* LoadPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4AA61258823B0E929F4520 /* LoadPhase.swift */; };
@@ -359,6 +360,7 @@
 		35969670AC4F826B4A3BB567 /* ImagesListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesListViewControllerTests.swift; sourceTree = "<group>"; };
 		3750055AEC4C49576A78A909 /* ByteFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ByteFormattingTests.swift; sourceTree = "<group>"; };
 		3CD990EEEF43CDA673BC1816 /* ActivityRowGroupingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityRowGroupingTests.swift; sourceTree = "<group>"; };
+		3D649CF8EC65915ED940D02A /* NotificationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCoordinator.swift; sourceTree = "<group>"; };
 		3DAC9EE4F067CB69F022C1E0 /* ActivityViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityViewModel.swift; sourceTree = "<group>"; };
 		3E30F5FC430804013B58C6F1 /* com.arcboxlabs.desktop.daemon.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = com.arcboxlabs.desktop.daemon.plist; sourceTree = "<group>"; };
 		3ED1683EF0A3490B8B7B5CF6 /* InfoTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoTableView.swift; sourceTree = "<group>"; };
@@ -1204,6 +1206,7 @@
 			children = (
 				98123C19CE4AB275C8D899E2 /* AppNotification.swift */,
 				FEA9D33B25DF9BB204D4B637 /* DaemonNotificationRules.swift */,
+				3D649CF8EC65915ED940D02A /* NotificationCoordinator.swift */,
 				665F6200AEC097082B2C43CA /* SandboxNotificationRules.swift */,
 				12240648D65030A504A21CC6 /* UserNotificationService.swift */,
 			);
@@ -1596,6 +1599,7 @@
 				72CCF0BC7FEAEB988595757C /* NewNetworkSheet.swift in Sources */,
 				B29A0911581DF9A70350B726 /* NewSandboxSheet.swift in Sources */,
 				D745D0D7EF5FF65174C47F28 /* NewVolumeSheet.swift in Sources */,
+				299F68933B6F5869B01B0F43 /* NotificationCoordinator.swift in Sources */,
 				A9BC7D2040EC032EBBC709E4 /* OnboardingView.swift in Sources */,
 				4C3BC465BFE58BF0D59AFE78 /* OnboardingWindowController.swift in Sources */,
 				97B9638AA9C685C6DB2780B4 /* PerformanceTracing.swift in Sources */,

--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		0BCE503CC2BF6C2BEC9DC4EA /* ImagesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B6587D59B9EFA18E51A3F3 /* ImagesViewModelTests.swift */; };
 		0C35F427DABEE19C0C583BE1 /* ContainersViewModel+Docker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12C2D038DE6CC49702F85F0 /* ContainersViewModel+Docker.swift */; };
 		0C6B829AD5010FDB0E749471 /* PullImageSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8254D67C0D80B99FC18DAD5 /* PullImageSheet.swift */; };
+		0D2989F83BD1C82C4A12B777 /* SandboxNotificationRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665F6200AEC097082B2C43CA /* SandboxNotificationRules.swift */; };
 		0E1E08820992C2853A6F23F3 /* FleetEnrollmentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8619720F1A99E2E6A431585C /* FleetEnrollmentCoordinator.swift */; };
 		0E680E7A421A91FFB668D65E /* SandboxEventsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38681FE9A98E55B1608E662 /* SandboxEventsTab.swift */; };
 		0EA623FAB4206D834C87DD75 /* MainWindowControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2110402B2013A53E306B4E43 /* MainWindowControllerTests.swift */; };
@@ -57,6 +58,7 @@
 		31A9DB06B08CC74D635ECB8A /* NetworksListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297FCAB334AF289575D13F72 /* NetworksListView.swift */; };
 		33DEED20119675484C189E77 /* LocalRootFSOutlineCoordinator+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F932C1467A5FB5CFBD0444 /* LocalRootFSOutlineCoordinator+DataSource.swift */; };
 		34ECB9725E062C6A0372AA0C /* EnvironmentValues+Clients.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794F192F207790B1A137A816 /* EnvironmentValues+Clients.swift */; };
+		351718A1033DD049AED78108 /* DaemonNotificationRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535894F6E4F12A71E906ED02 /* DaemonNotificationRulesTests.swift */; };
 		361A7AD4626352A09571245C /* ContainerLogsTab+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200F15F29A3634EC779554D4 /* ContainerLogsTab+Actions.swift */; };
 		3B38458299F141A08B8C7107 /* ImageTerminalTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB477EF803A15EDFF2685A23 /* ImageTerminalTab.swift */; };
 		3B6BCFE408976AA0CDD0A5F8 /* SandboxesViewModel+PortsFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B80964B0A136E03F5FDA0FE /* SandboxesViewModel+PortsFiles.swift */; };
@@ -91,6 +93,7 @@
 		525ECDE24CB1E8ADC7AADB49 /* UpdaterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9234FC5BCCDDCBF441A94880 /* UpdaterDelegate.swift */; };
 		53B84DC35DF078E19C8D7780 /* StatusItemController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E217254D0827A011E01C3F05 /* StatusItemController.swift */; };
 		547AB2E719C9C6B7F66046F7 /* ServicesListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85296C05DC9D33C7930366D7 /* ServicesListViewController.swift */; };
+		57A8D35B23CC870EDEAF7605 /* AppNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98123C19CE4AB275C8D899E2 /* AppNotification.swift */; };
 		592D8D15F0AD149B578AC661 /* VolumesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209E974D66F4B2D9B5CDA2D9 /* VolumesListView.swift */; };
 		5C24B61DEC9BC6CE303FF52A /* AppMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0084D4B147FA59C7CCC0F5 /* AppMetrics.swift */; };
 		5D4AD52D29953C3DB6552B97 /* ContainerLogsTab+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DD7F5E0115C839BB364D59F /* ContainerLogsTab+Formatting.swift */; };
@@ -108,6 +111,7 @@
 		67924F4E35FF28F7412EEBBA /* NetworkDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B7685DAD23E5427C0F9911 /* NetworkDetailView.swift */; };
 		68D8583BAE183D23FFC10815 /* MenuBarHoverButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 789DE20DB0F3E106BFAC6E10 /* MenuBarHoverButton.swift */; };
 		699F9908BD6DBCD8244DCEE5 /* AuthTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D2C529811ECBAD82E110BC4 /* AuthTestSupport.swift */; };
+		6BAD9159671DD04FDB7DD553 /* DaemonNotificationRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA9D33B25DF9BB204D4B637 /* DaemonNotificationRules.swift */; };
 		6BDA8BA049C2D918C3E5349C /* ContainersListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AAFC5E642995054B983811 /* ContainersListViewController.swift */; };
 		6DC794E9A1D889DF4F3D6B91 /* SheetErrorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EB02E7DC54A70CDFD0C694 /* SheetErrorMessage.swift */; };
 		6EE6805F5EC85742CC665575 /* DockerCLIResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDE93A683D2613C431BEBF2 /* DockerCLIResolver.swift */; };
@@ -130,6 +134,7 @@
 		7895A0328F3567814B656CFD /* LocalRootFSOutlineCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0D0444E612EC32D81A7E0C /* LocalRootFSOutlineCoordinator.swift */; };
 		7910184754585B4CF647FA92 /* ContainerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C6B2F85E39321931CEC3ED /* ContainerDetailView.swift */; };
 		79C5F3DA19E7431F8B28B6F0 /* MenuBarView+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC010DD9F0AEC7E4EA778C59 /* MenuBarView+Actions.swift */; };
+		7B785AFCDAE28EF6B5064527 /* SandboxNotificationRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 816C59570B7C65B9288056A8 /* SandboxNotificationRulesTests.swift */; };
 		7C881FAC221912F138CD65E7 /* ActivityMetricStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F15E941FF769135D0AA218 /* ActivityMetricStrip.swift */; };
 		7D6BA204C7E5B022B6267289 /* RunnerHostCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FE07EA71512ACEE609B537 /* RunnerHostCapability.swift */; };
 		7DABE0FBDD17F88D47333964 /* CommandHint.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65698313C3204F5F23E099B /* CommandHint.swift */; };
@@ -194,6 +199,7 @@
 		ABA9E2D6873BE5FF255045F3 /* AboutView+SystemInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0C5A43740FFD68902A2F77 /* AboutView+SystemInfo.swift */; };
 		AC66C291D8250EF48B8FE3D2 /* MenuBarView+Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6744BCBFA0A05831AFED0E /* MenuBarView+Layout.swift */; };
 		ADE462B8234F0D1F9D8165B3 /* VolumesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699A57392F1D9366CFA78BAF /* VolumesViewModel.swift */; };
+		AE6F6F33D30A243686149462 /* UserNotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12240648D65030A504A21CC6 /* UserNotificationService.swift */; };
 		AF8784321B0BF66F476749C5 /* BetterAuthClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12EE31052572ABF8B455044 /* BetterAuthClientTests.swift */; };
 		B29A0911581DF9A70350B726 /* NewSandboxSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF34CA0688377F7956F2FD3D /* NewSandboxSheet.swift */; };
 		B3DF6F1A9B47905BF6337A81 /* StorageSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F915D676AC7EDF66A67B77A9 /* StorageSettingsView.swift */; };
@@ -315,6 +321,7 @@
 		0F065A1CBDA891A5647FE6F6 /* K8sWatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K8sWatchTests.swift; sourceTree = "<group>"; };
 		0FA3C6B6F10198DFC435A33E /* NetworkDetailViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDetailViewControllerTests.swift; sourceTree = "<group>"; };
 		11EB6AEBF371E6B88EF8D08E /* SandboxPortsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxPortsTab.swift; sourceTree = "<group>"; };
+		12240648D65030A504A21CC6 /* UserNotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationService.swift; sourceTree = "<group>"; };
 		13203BD67479A8191C1A3BD6 /* ServiceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceModel.swift; sourceTree = "<group>"; };
 		13FD9C27ABD090B7DBA435AA /* ImagesListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesListViewController.swift; sourceTree = "<group>"; };
 		185A238D021D6C976574528C /* ImageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDetailView.swift; sourceTree = "<group>"; };
@@ -379,6 +386,7 @@
 		5144C9321F8A17DA72A862DA /* MachineCreateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachineCreateSheet.swift; sourceTree = "<group>"; };
 		5272B55436BFFB8D2021CA20 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		52CF09CC08AE563196CE3BED /* ContainerListCells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerListCells.swift; sourceTree = "<group>"; };
+		535894F6E4F12A71E906ED02 /* DaemonNotificationRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaemonNotificationRulesTests.swift; sourceTree = "<group>"; };
 		545D230723A80CB5C011B57E /* ContainersViewModel+BatchOperations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContainersViewModel+BatchOperations.swift"; sourceTree = "<group>"; };
 		54DE8B823FD1E94B0073AC5A /* ErrorReporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorReporting.swift; sourceTree = "<group>"; };
 		559C97F0CA659149BCBA59A2 /* ImagesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesViewModel.swift; sourceTree = "<group>"; };
@@ -396,6 +404,7 @@
 		6218E84D6C2A8595FE308B5E /* ImageLayerChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLayerChain.swift; sourceTree = "<group>"; };
 		63E327BEE2A1A04A55A730BF /* RunnerEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerEmptyState.swift; sourceTree = "<group>"; };
 		657D7543F1D47988AEC3339D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		665F6200AEC097082B2C43CA /* SandboxNotificationRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxNotificationRules.swift; sourceTree = "<group>"; };
 		66F91CF47E53375781959EC9 /* ServicesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicesListView.swift; sourceTree = "<group>"; };
 		68009FEC4A2F0EB046ACCA4C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		68B7685DAD23E5427C0F9911 /* NetworkDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDetailView.swift; sourceTree = "<group>"; };
@@ -424,6 +433,7 @@
 		7D5BDCAAF11D1A6B52990E28 /* ContainerViewModel+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContainerViewModel+Mapping.swift"; sourceTree = "<group>"; };
 		7DDFA2EDA7A3AC8448696F91 /* VolumeFilesTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeFilesTab.swift; sourceTree = "<group>"; };
 		80010452354615CAC08FAF1D /* ContainersListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainersListViewControllerTests.swift; sourceTree = "<group>"; };
+		816C59570B7C65B9288056A8 /* SandboxNotificationRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxNotificationRulesTests.swift; sourceTree = "<group>"; };
 		81FCCED6F39D73E946107243 /* MachineEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachineEmptyStateView.swift; sourceTree = "<group>"; };
 		823F87591055C314EC29BF67 /* ToolbarSeparator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarSeparator.swift; sourceTree = "<group>"; };
 		829D8DC499E6339D13A2ADE7 /* SandboxesViewModel+GRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SandboxesViewModel+GRPC.swift"; sourceTree = "<group>"; };
@@ -452,6 +462,7 @@
 		96C7AE7CC8DF4C7910C4230B /* SandboxPortsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxPortsViewModelTests.swift; sourceTree = "<group>"; };
 		9750454C23940C3F74E7690E /* ResourceListRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceListRowView.swift; sourceTree = "<group>"; };
 		97E7E52D3A54846906EB064D /* SortMenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortMenuButton.swift; sourceTree = "<group>"; };
+		98123C19CE4AB275C8D899E2 /* AppNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNotification.swift; sourceTree = "<group>"; };
 		98C5CFE4B4D21711F8580690 /* SandboxTerminalTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxTerminalTab.swift; sourceTree = "<group>"; };
 		9A04AFE137230F2CE0DD9DBB /* DiagnosticBundleExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticBundleExporter.swift; sourceTree = "<group>"; };
 		9AA5247E3096D7A9D54A270A /* AccountSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsView.swift; sourceTree = "<group>"; };
@@ -566,6 +577,7 @@
 		FB364896F740E811FBE1B04D /* ContainerLogsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerLogsTab.swift; sourceTree = "<group>"; };
 		FBA33C724456FCDF5A3E52AD /* AuthSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSessionTests.swift; sourceTree = "<group>"; };
 		FDE313F40E79E409C942B1EE /* AboutWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutWindow.swift; sourceTree = "<group>"; };
+		FEA9D33B25DF9BB204D4B637 /* DaemonNotificationRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaemonNotificationRules.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -895,6 +907,7 @@
 				2021CE387B9546EE87FA4CD5 /* MachineEventMonitor.swift */,
 				B71D28721E41F8303DBF7232 /* MachineImageCatalog.swift */,
 				50C68609B67AC82FF386CB92 /* SandboxEventMonitor.swift */,
+				E8AD915E8742C497AAD51368 /* Notifications */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1186,6 +1199,17 @@
 			path = Theme;
 			sourceTree = "<group>";
 		};
+		E8AD915E8742C497AAD51368 /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				98123C19CE4AB275C8D899E2 /* AppNotification.swift */,
+				FEA9D33B25DF9BB204D4B637 /* DaemonNotificationRules.swift */,
+				665F6200AEC097082B2C43CA /* SandboxNotificationRules.swift */,
+				12240648D65030A504A21CC6 /* UserNotificationService.swift */,
+			);
+			path = Notifications;
+			sourceTree = "<group>";
+		};
 		EAC6176638594B6D1458C90D /* Sandboxes */ = {
 			isa = PBXGroup;
 			children = (
@@ -1224,6 +1248,7 @@
 				E610512C9106BB92A47DC044 /* ContainersViewModelTests.swift */,
 				DE7E377F9D8C89E24989DE3D /* ContentViewColumnLayoutTests.swift */,
 				6DFE1C88F20E40C1A36A384C /* CreateOperationErrorTests.swift */,
+				535894F6E4F12A71E906ED02 /* DaemonNotificationRulesTests.swift */,
 				F5B3B3C54B6D49C6198E9E26 /* DeepLinkTests.swift */,
 				06DFFB59D72F27F14A233B81 /* DockerEventMonitorTests.swift */,
 				27C52C15D6902B3EAB6307AA /* DockerTerminalSessionIntegrationTests.swift */,
@@ -1248,6 +1273,7 @@
 				A517313E1085B62A40075622 /* OnboardingWindowControllerTests.swift */,
 				B084B3E5BD66E2DA018764E8 /* QuitWindowControllerTests.swift */,
 				E902A97C32D4034C22684BBD /* RunnersViewModelTests.swift */,
+				816C59570B7C65B9288056A8 /* SandboxNotificationRulesTests.swift */,
 				96C7AE7CC8DF4C7910C4230B /* SandboxPortsViewModelTests.swift */,
 				EBD1F83B573C40DFA09E5633 /* StatePlaceholderTestSupport.swift */,
 				B4BAE047B96D10B4716BA1A2 /* VolumesListViewControllerTests.swift */,
@@ -1457,6 +1483,7 @@
 				93E1F4FEF7A65834986A85E7 /* AppDelegate+Telemetry.swift in Sources */,
 				BA8E4BE30E5FBB6B8548E214 /* AppDelegate.swift in Sources */,
 				5C24B61DEC9BC6CE303FF52A /* AppMetrics.swift in Sources */,
+				57A8D35B23CC870EDEAF7605 /* AppNotification.swift in Sources */,
 				725EE1E8C4BABAF5AB3B9D20 /* AppPreferences.swift in Sources */,
 				F0B6CC9DB9992CE44F2A7F70 /* AppViewModel.swift in Sources */,
 				932BD3DB61039B6A7B298661 /* ApplicationCoordinator.swift in Sources */,
@@ -1486,6 +1513,7 @@
 				869B14DB25CD44955C7C32AE /* ContainersViewModel.swift in Sources */,
 				9444132595906417360A9D44 /* ContentView.swift in Sources */,
 				172FA4919687A4616E0BC135 /* DaemonLoadingView.swift in Sources */,
+				6BAD9159671DD04FDB7DD553 /* DaemonNotificationRules.swift in Sources */,
 				BA3195811383AD00D29B32AE /* DeepLink.swift in Sources */,
 				D32166A92BDA2FB6B6037D94 /* DeepLinkRouter.swift in Sources */,
 				7611F110DA849DA460755BE4 /* DetailTabPicker.swift in Sources */,
@@ -1597,6 +1625,7 @@
 				245366143B64E30BF77A6BAE /* SandboxFilesTab.swift in Sources */,
 				9BBC2F30A81F4AE668951B67 /* SandboxModel.swift in Sources */,
 				5DBFB63C5C744C1FC45C7808 /* SandboxMonitoringView.swift in Sources */,
+				0D2989F83BD1C82C4A12B777 /* SandboxNotificationRules.swift in Sources */,
 				21D545F71EFE312362029E61 /* SandboxPortsTab.swift in Sources */,
 				07A382D149C73C697CAA1601 /* SandboxRowView.swift in Sources */,
 				8CCB1384AC434F642C85793A /* SandboxSnapshotsTab.swift in Sources */,
@@ -1635,6 +1664,7 @@
 				9010BB836D577FF81084FAAA /* ToolbarSeparator.swift in Sources */,
 				525ECDE24CB1E8ADC7AADB49 /* UpdaterDelegate.swift in Sources */,
 				7DFC19087BE929DDF207A677 /* UpdaterSettingsModel.swift in Sources */,
+				AE6F6F33D30A243686149462 /* UserNotificationService.swift in Sources */,
 				96C7FFF79579D1B999ABAF3F /* Utilities.swift in Sources */,
 				6F8362D2C8129F7BBF6E9635 /* VolumeDetailView.swift in Sources */,
 				E12C55C4C275DCBAB9DA8150 /* VolumeFilesTab.swift in Sources */,
@@ -1666,6 +1696,7 @@
 				4D2029E55A7979B8BD9EE89A /* ContainersViewModelTests.swift in Sources */,
 				A537498E1D8181BB0230E199 /* ContentViewColumnLayoutTests.swift in Sources */,
 				853F2D06A878BE9A867BE3FD /* CreateOperationErrorTests.swift in Sources */,
+				351718A1033DD049AED78108 /* DaemonNotificationRulesTests.swift in Sources */,
 				EE2D38BC76500BF768EEE20F /* DeepLinkTests.swift in Sources */,
 				8466B000B68A87CEECA6756F /* DockerEventMonitorTests.swift in Sources */,
 				D16762EE419CC9055CDD90FF /* DockerTerminalSessionIntegrationTests.swift in Sources */,
@@ -1695,6 +1726,7 @@
 				D4ECBBCAC3D4631041F292D5 /* QuitWindowControllerTests.swift in Sources */,
 				1CB8AE8C16D0C333B7C0B32F /* ResourceStatsTests.swift in Sources */,
 				977BE039C964F896AB613634 /* RunnersViewModelTests.swift in Sources */,
+				7B785AFCDAE28EF6B5064527 /* SandboxNotificationRulesTests.swift in Sources */,
 				EC2532F756D371A159AB9A97 /* SandboxPortsViewModelTests.swift in Sources */,
 				927458F82097ECF1A07412FD /* StatePlaceholderTestSupport.swift in Sources */,
 				17ED6FFFD9A61998178E38B9 /* VolumesListViewControllerTests.swift in Sources */,

--- a/ArcBox/App/AppPreferences.swift
+++ b/ArcBox/App/AppPreferences.swift
@@ -37,6 +37,8 @@ enum AppPreferences {
             "includeTimeMachine": false,
             "switchDockerContextAutomatically": true,
             "pauseContainersWhileSleeping": true,
+            AppNotification.Category.sandbox.preferenceKey: true,
+            AppNotification.Category.daemonHealth.preferenceKey: true,
         ])
     }
 

--- a/ArcBox/App/ApplicationCoordinator.swift
+++ b/ArcBox/App/ApplicationCoordinator.swift
@@ -58,6 +58,7 @@ final class ApplicationCoordinator: NSObject {
     /// a reset owed from a previous run is not missed.  Bookkeeping, not a user
     /// preference, so it stays out of `AppPreferences`.
     private static let analyticsIdentifiedKey = "analyticsIdentified"
+    private var pendingDaemonAlert: Task<Void, Never>?
     private var lastShowInMenuBar: Bool
     private var lastUpdateChannel: String
     private var lastTelemetryEnabled: Bool
@@ -238,6 +239,8 @@ final class ApplicationCoordinator: NSObject {
         guard !isTerminating else { return false }
         isTerminating = true
 
+        pendingDaemonAlert?.cancel()
+        pendingDaemonAlert = nil
         authSession.cancelSignIn()
         statusItemController?.closePopover()
         statusItemController?.setVisible(false)
@@ -331,6 +334,28 @@ final class ApplicationCoordinator: NSObject {
             notifications.post(notification)
         }
         notifications.start()
+    }
+
+    /// Tell the user about a daemon problem, but only once it has outlasted the
+    /// alert's confirmation window. Every state change restarts this, so a
+    /// daemon that drops and recovers — waking from sleep, a stream hiccup —
+    /// says nothing at all.
+    private func reportDaemonHealth(from previous: DaemonState?, to current: DaemonState) {
+        pendingDaemonAlert?.cancel()
+        pendingDaemonAlert = nil
+
+        guard let alert = DaemonNotificationRules.alert(from: previous, to: current) else { return }
+        guard alert.confirmAfter > .zero else {
+            notifications.post(alert.notification)
+            return
+        }
+
+        pendingDaemonAlert = Task { [weak self] in
+            try? await Task.sleep(for: alert.confirmAfter)
+            guard !Task.isCancelled, let self, !isTerminating else { return }
+            guard !daemonManager.state.isRunning else { return }
+            notifications.post(alert.notification)
+        }
     }
 
     /// Whether what a notification would announce is already on screen. A
@@ -511,9 +536,7 @@ final class ApplicationCoordinator: NSObject {
         let previousState = lastDaemonState
         lastDaemonState = state
 
-        if let notification = DaemonNotificationRules.notification(from: previousState, to: state) {
-            notifications.post(notification)
-        }
+        reportDaemonHealth(from: previousState, to: state)
 
         if state.isRunning {
             if dockerClient == nil {

--- a/ArcBox/App/ApplicationCoordinator.swift
+++ b/ArcBox/App/ApplicationCoordinator.swift
@@ -28,6 +28,8 @@ final class ApplicationCoordinator: NSObject {
     private let sleepWakeManager = SleepWakeManager()
     private let deepLinkRouter = DeepLinkRouter()
     private let fleetAgentConnection = FleetAgentConnection()
+    private let notifications = UserNotificationService()
+    private var sandboxNotificationRules = SandboxNotificationRules()
     private let updaterDelegate = UpdaterDelegate()
     private let updaterController: SPUStandardUpdaterController
     private let updaterSettings: UpdaterSettingsModel
@@ -104,6 +106,7 @@ final class ApplicationCoordinator: NSObject {
         }
         observeDaemonState()
         observeAuthIdentity()
+        configureNotifications()
         _ = NotificationCenter.default.addObserver(
             forName: UserDefaults.didChangeNotification,
             object: UserDefaults.standard,
@@ -314,6 +317,35 @@ final class ApplicationCoordinator: NSObject {
             ))
     }
 
+    private func configureNotifications() {
+        notifications.isUserWatching = { [weak self] destination in
+            self?.isUserWatching(destination) ?? false
+        }
+        notifications.openDestination = { [weak self] destination in
+            self?.deepLinkRouter.handle(destination)
+        }
+        sandboxEventMonitor.onEvent = { [weak self] event in
+            guard let self, let notification = sandboxNotificationRules.notification(for: event) else {
+                return
+            }
+            notifications.post(notification)
+        }
+        notifications.start()
+    }
+
+    /// Whether what a notification would announce is already on screen. A
+    /// closed or backgrounded window means the user is not watching, whatever
+    /// the last selected section was.
+    private func isUserWatching(_ destination: DeepLink) -> Bool {
+        guard NSApp.isActive, mainWindowController?.window?.isVisible == true else { return false }
+        switch destination {
+        case .main, .settings:
+            return true
+        case .section(let item, _):
+            return appVM.currentNav == item
+        }
+    }
+
     private func startRuntimeIfNeeded(allowingAdministratorPrompt: Bool = false) {
         guard !isTerminating, startupTask == nil, let orchestrator = startupOrchestrator else {
             return
@@ -476,7 +508,12 @@ final class ApplicationCoordinator: NSObject {
         trackDaemonState()
         let state = daemonManager.state
         guard state != lastDaemonState else { return }
+        let previousState = lastDaemonState
         lastDaemonState = state
+
+        if let notification = DaemonNotificationRules.notification(from: previousState, to: state) {
+            notifications.post(notification)
+        }
 
         if state.isRunning {
             if dockerClient == nil {

--- a/ArcBox/App/ApplicationCoordinator.swift
+++ b/ArcBox/App/ApplicationCoordinator.swift
@@ -28,8 +28,11 @@ final class ApplicationCoordinator: NSObject {
     private let sleepWakeManager = SleepWakeManager()
     private let deepLinkRouter = DeepLinkRouter()
     private let fleetAgentConnection = FleetAgentConnection()
-    private let notifications = UserNotificationService()
-    private var sandboxNotificationRules = SandboxNotificationRules()
+    private lazy var notifications = NotificationCoordinator(
+        isUserWatching: { [weak self] in self?.isUserWatching($0) ?? false },
+        openDestination: { [weak self] in self?.deepLinkRouter.handle($0) },
+        isDaemonRunning: { [weak self] in self?.daemonManager.state.isRunning ?? false }
+    )
     private let updaterDelegate = UpdaterDelegate()
     private let updaterController: SPUStandardUpdaterController
     private let updaterSettings: UpdaterSettingsModel
@@ -58,7 +61,6 @@ final class ApplicationCoordinator: NSObject {
     /// a reset owed from a previous run is not missed.  Bookkeeping, not a user
     /// preference, so it stays out of `AppPreferences`.
     private static let analyticsIdentifiedKey = "analyticsIdentified"
-    private var pendingDaemonAlert: Task<Void, Never>?
     private var lastShowInMenuBar: Bool
     private var lastUpdateChannel: String
     private var lastTelemetryEnabled: Bool
@@ -239,8 +241,7 @@ final class ApplicationCoordinator: NSObject {
         guard !isTerminating else { return false }
         isTerminating = true
 
-        pendingDaemonAlert?.cancel()
-        pendingDaemonAlert = nil
+        notifications.stop()
         authSession.cancelSignIn()
         statusItemController?.closePopover()
         statusItemController?.setVisible(false)
@@ -321,41 +322,10 @@ final class ApplicationCoordinator: NSObject {
     }
 
     private func configureNotifications() {
-        notifications.isUserWatching = { [weak self] destination in
-            self?.isUserWatching(destination) ?? false
-        }
-        notifications.openDestination = { [weak self] destination in
-            self?.deepLinkRouter.handle(destination)
-        }
         sandboxEventMonitor.onEvent = { [weak self] event in
-            guard let self, let notification = sandboxNotificationRules.notification(for: event) else {
-                return
-            }
-            notifications.post(notification)
+            self?.notifications.handleSandboxEvent(event)
         }
         notifications.start()
-    }
-
-    /// Tell the user about a daemon problem, but only once it has outlasted the
-    /// alert's confirmation window. Every state change restarts this, so a
-    /// daemon that drops and recovers — waking from sleep, a stream hiccup —
-    /// says nothing at all.
-    private func reportDaemonHealth(from previous: DaemonState?, to current: DaemonState) {
-        pendingDaemonAlert?.cancel()
-        pendingDaemonAlert = nil
-
-        guard let alert = DaemonNotificationRules.alert(from: previous, to: current) else { return }
-        guard alert.confirmAfter > .zero else {
-            notifications.post(alert.notification)
-            return
-        }
-
-        pendingDaemonAlert = Task { [weak self] in
-            try? await Task.sleep(for: alert.confirmAfter)
-            guard !Task.isCancelled, let self, !isTerminating else { return }
-            guard !daemonManager.state.isRunning else { return }
-            notifications.post(alert.notification)
-        }
     }
 
     /// Whether what a notification would announce is already on screen. A
@@ -536,7 +506,7 @@ final class ApplicationCoordinator: NSObject {
         let previousState = lastDaemonState
         lastDaemonState = state
 
-        reportDaemonHealth(from: previousState, to: state)
+        notifications.handleDaemonState(from: previousState, to: state)
 
         if state.isRunning {
             if dockerClient == nil {

--- a/ArcBox/App/DeepLink.swift
+++ b/ArcBox/App/DeepLink.swift
@@ -27,4 +27,24 @@ enum DeepLink: Equatable {
             self = .section(item, id: url.pathComponents.first { $0 != "/" })
         }
     }
+
+    /// The canonical URL for this link, round-tripping through `init(_:)`.
+    /// Lets a link be carried through APIs that only take URLs, such as a
+    /// notification's `userInfo`.
+    var url: URL {
+        var components = URLComponents()
+        components.scheme = Self.scheme
+        switch self {
+        case .main:
+            components.host = "main"
+        case .settings:
+            components.host = "settings"
+        case .section(let item, let id):
+            components.host = item.rawValue
+            if let id { components.path = "/\(id)" }
+        }
+        // Scheme and host are fixed vocabulary and `path` is percent-encoded on
+        // assignment, so there is no input that makes this fail.
+        return components.url!
+    }
 }

--- a/ArcBox/App/DeepLinkRouter.swift
+++ b/ArcBox/App/DeepLinkRouter.swift
@@ -30,6 +30,13 @@ final class DeepLinkRouter {
         }
     }
 
+    /// Apply a link produced in-process — a notification click — rather than
+    /// parsed from an incoming URL. Unlike `handle(_ url:)` this is not
+    /// buffered: nothing in-process can produce a link before configuration.
+    func handle(_ link: DeepLink) {
+        apply(link)
+    }
+
     private func dispatch(_ url: URL) {
         guard let link = DeepLink(url) else {
             Log.deepLink.warning("Ignoring unrecognized deep link: \(url.absoluteString, privacy: .private)")

--- a/ArcBox/Logging.swift
+++ b/ArcBox/Logging.swift
@@ -17,6 +17,7 @@ nonisolated enum Log {
     static let services = Logger(subsystem: subsystem, category: "services")
     static let context = Logger(subsystem: subsystem, category: "context")
     static let deepLink = Logger(subsystem: subsystem, category: "deepLink")
+    static let notifications = Logger(subsystem: subsystem, category: "notifications")
     static let sleep = Logger(subsystem: subsystem, category: "sleep")
     static let terminal = Logger(subsystem: subsystem, category: "terminal")
     static let activity = Logger(subsystem: subsystem, category: "activity")

--- a/ArcBox/Models/SandboxModel.swift
+++ b/ArcBox/Models/SandboxModel.swift
@@ -284,10 +284,19 @@ struct SandboxEventRecord: Identifiable, Hashable {
         kind.label
     }
 
+    init(sandboxID: String, kind: SandboxEventKind, timestamp: Date, attributes: [String: String] = [:]) {
+        self.sandboxID = sandboxID
+        self.kind = kind
+        self.timestamp = timestamp
+        self.attributes = attributes
+    }
+
     init(from event: Arcbox_Sandbox_V1_SandboxEvent) {
-        self.sandboxID = event.sandboxID
-        self.kind = SandboxEventKind(apiKind: event.kind)
-        self.timestamp = event.time.date
-        self.attributes = event.attributes
+        self.init(
+            sandboxID: event.sandboxID,
+            kind: SandboxEventKind(apiKind: event.kind),
+            timestamp: event.time.date,
+            attributes: event.attributes
+        )
     }
 }

--- a/ArcBox/Services/Notifications/AppNotification.swift
+++ b/ArcBox/Services/Notifications/AppNotification.swift
@@ -14,4 +14,23 @@ struct AppNotification: Equatable {
     let body: String
     /// Where clicking the notification takes the user.
     let destination: DeepLink
+    /// What this is about, so the user can switch off one kind without losing
+    /// the other.
+    let category: Category
+}
+
+extension AppNotification {
+    enum Category: String, CaseIterable {
+        case sandbox
+        case daemonHealth
+
+        /// Preference gating delivery. Registered in `AppPreferences`, so an
+        /// unset key reads as enabled rather than as `false`.
+        var preferenceKey: String {
+            switch self {
+            case .sandbox: "notifySandboxResults"
+            case .daemonHealth: "notifyDaemonProblems"
+            }
+        }
+    }
 }

--- a/ArcBox/Services/Notifications/AppNotification.swift
+++ b/ArcBox/Services/Notifications/AppNotification.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// A notification the app has decided to deliver, expressed independently of
+/// `UserNotifications`.
+///
+/// Rules produce these as plain values and `UserNotificationService` owns
+/// everything that touches the system notification centre. Keeping the decision
+/// separate from the delivery is what makes the trigger conditions testable.
+struct AppNotification: Equatable {
+    /// Delivery identity. Posting the same identifier again replaces the
+    /// earlier notification instead of stacking a duplicate.
+    let identifier: String
+    let title: String
+    let body: String
+    /// Where clicking the notification takes the user.
+    let destination: DeepLink
+}

--- a/ArcBox/Services/Notifications/DaemonNotificationRules.swift
+++ b/ArcBox/Services/Notifications/DaemonNotificationRules.swift
@@ -1,41 +1,67 @@
 import ArcBoxClient
 import Foundation
 
+/// A daemon health notification, and how long the daemon has to stay in the
+/// state that produced it before the user is told.
+struct DaemonHealthAlert: Equatable {
+    let notification: AppNotification
+    /// `.zero` when the daemon has already reached a verdict of its own and
+    /// waiting would add nothing.
+    let confirmAfter: Duration
+}
+
 /// Decides when a daemon state change is worth interrupting the user for.
 ///
 /// The app keeps running with its window closed, so a daemon that dies is
 /// otherwise invisible until the window is reopened.
 enum DaemonNotificationRules {
+    /// How long the daemon must stay unreachable before it is worth saying.
+    ///
+    /// `DaemonManager` drops to `.registered` after ~3.5 s of failed
+    /// reconnects, which is tuned for the UI — long enough to ride out a
+    /// GOAWAY, short enough that the window does not lie. That is far too
+    /// eager for a notification: waking from sleep reliably breaks the stream
+    /// while the daemon is still resuming the VM, and a banner on every wake
+    /// is exactly what makes people switch notifications off. Confirming over
+    /// a longer window separates "briefly disconnected" from "gone" without
+    /// making the window sluggish.
+    static let unreachableConfirmation: Duration = .seconds(30)
+
     /// Both cases reuse one identifier: the daemon has a single health story,
     /// and a later verdict should replace the earlier one rather than leave two
     /// banners disagreeing.
     private static let identifier = "daemon.health"
 
-    /// `DaemonManager` holds `.running` through transient stream drops (daemon
-    /// GC pause, HTTP/2 GOAWAY) for a ~3 s grace window before regressing to
-    /// `.registered`, so reaching either state here already means the daemon is
-    /// genuinely gone. No further debounce belongs at this layer.
-    ///
     /// `.stopping` and `.stopped` are deliberately not covered: those are the
     /// states of a shutdown the user asked for.
-    static func notification(from previous: DaemonState?, to current: DaemonState) -> AppNotification? {
+    static func alert(from previous: DaemonState?, to current: DaemonState) -> DaemonHealthAlert? {
         guard previous != current else { return nil }
 
         switch (previous, current) {
         case (_, .error(let reason)):
-            return AppNotification(
-                identifier: identifier,
-                title: "ArcBox daemon stopped",
-                body: reason.isEmpty ? "The daemon reported a fatal error." : reason,
-                destination: .main
+            // The daemon reported a fatal setup failure and gave up. It is not
+            // coming back on its own, so there is nothing to confirm.
+            return DaemonHealthAlert(
+                notification: AppNotification(
+                    identifier: identifier,
+                    title: "ArcBox daemon stopped",
+                    body: reason.isEmpty ? "The daemon reported a fatal error." : reason,
+                    destination: .main,
+                    category: .daemonHealth
+                ),
+                confirmAfter: .zero
             )
 
         case (.some(.running), .registered):
-            return AppNotification(
-                identifier: identifier,
-                title: "ArcBox daemon is unreachable",
-                body: "Containers and sandboxes are no longer running.",
-                destination: .main
+            return DaemonHealthAlert(
+                notification: AppNotification(
+                    identifier: identifier,
+                    title: "ArcBox daemon is unreachable",
+                    body: "Containers and sandboxes are no longer running.",
+                    destination: .main,
+                    category: .daemonHealth
+                ),
+                confirmAfter: unreachableConfirmation
             )
 
         default:

--- a/ArcBox/Services/Notifications/DaemonNotificationRules.swift
+++ b/ArcBox/Services/Notifications/DaemonNotificationRules.swift
@@ -1,0 +1,45 @@
+import ArcBoxClient
+import Foundation
+
+/// Decides when a daemon state change is worth interrupting the user for.
+///
+/// The app keeps running with its window closed, so a daemon that dies is
+/// otherwise invisible until the window is reopened.
+enum DaemonNotificationRules {
+    /// Both cases reuse one identifier: the daemon has a single health story,
+    /// and a later verdict should replace the earlier one rather than leave two
+    /// banners disagreeing.
+    private static let identifier = "daemon.health"
+
+    /// `DaemonManager` holds `.running` through transient stream drops (daemon
+    /// GC pause, HTTP/2 GOAWAY) for a ~3 s grace window before regressing to
+    /// `.registered`, so reaching either state here already means the daemon is
+    /// genuinely gone. No further debounce belongs at this layer.
+    ///
+    /// `.stopping` and `.stopped` are deliberately not covered: those are the
+    /// states of a shutdown the user asked for.
+    static func notification(from previous: DaemonState?, to current: DaemonState) -> AppNotification? {
+        guard previous != current else { return nil }
+
+        switch (previous, current) {
+        case (_, .error(let reason)):
+            return AppNotification(
+                identifier: identifier,
+                title: "ArcBox daemon stopped",
+                body: reason.isEmpty ? "The daemon reported a fatal error." : reason,
+                destination: .main
+            )
+
+        case (.some(.running), .registered):
+            return AppNotification(
+                identifier: identifier,
+                title: "ArcBox daemon is unreachable",
+                body: "Containers and sandboxes are no longer running.",
+                destination: .main
+            )
+
+        default:
+            return nil
+        }
+    }
+}

--- a/ArcBox/Services/Notifications/NotificationCoordinator.swift
+++ b/ArcBox/Services/Notifications/NotificationCoordinator.swift
@@ -1,0 +1,67 @@
+import ArcBoxClient
+import Foundation
+
+/// Owns everything between an event and a delivered notification: which rules
+/// apply, how long a verdict must hold before it is worth saying, and the
+/// service that delivers it.
+///
+/// `ApplicationCoordinator` only forwards events here and answers the two
+/// questions this cannot: whether the user is looking at something, and where
+/// a click should land.
+@MainActor
+final class NotificationCoordinator {
+    private let service: UserNotificationService
+    private let isDaemonRunning: () -> Bool
+
+    private var sandboxRules = SandboxNotificationRules()
+    private var pendingDaemonAlert: Task<Void, Never>?
+
+    init(
+        service: UserNotificationService = UserNotificationService(),
+        isUserWatching: @escaping (DeepLink) -> Bool,
+        openDestination: @escaping (DeepLink) -> Void,
+        isDaemonRunning: @escaping () -> Bool
+    ) {
+        self.service = service
+        self.isDaemonRunning = isDaemonRunning
+        service.isUserWatching = isUserWatching
+        service.openDestination = openDestination
+    }
+
+    /// Become the notification delegate. Called during app launch so a click on
+    /// a notification that launched the app still routes.
+    func start() {
+        service.start()
+    }
+
+    func stop() {
+        pendingDaemonAlert?.cancel()
+        pendingDaemonAlert = nil
+    }
+
+    func handleSandboxEvent(_ event: SandboxEventRecord) {
+        guard let notification = sandboxRules.notification(for: event) else { return }
+        service.post(notification)
+    }
+
+    /// Tell the user about a daemon problem, but only once it has outlasted the
+    /// alert's confirmation window. Every state change restarts this, so a
+    /// daemon that drops and recovers — waking from sleep, a stream hiccup —
+    /// says nothing at all.
+    func handleDaemonState(from previous: DaemonState?, to current: DaemonState) {
+        pendingDaemonAlert?.cancel()
+        pendingDaemonAlert = nil
+
+        guard let alert = DaemonNotificationRules.alert(from: previous, to: current) else { return }
+        guard alert.confirmAfter > .zero else {
+            service.post(alert.notification)
+            return
+        }
+
+        pendingDaemonAlert = Task { [weak self] in
+            try? await Task.sleep(for: alert.confirmAfter)
+            guard !Task.isCancelled, let self, !isDaemonRunning() else { return }
+            service.post(alert.notification)
+        }
+    }
+}

--- a/ArcBox/Services/Notifications/SandboxNotificationRules.swift
+++ b/ArcBox/Services/Notifications/SandboxNotificationRules.swift
@@ -28,8 +28,8 @@ struct SandboxNotificationRules {
         case .failed:
             executionStart.removeValue(forKey: event.sandboxID)
             let reason = Self.attribute("error", of: event)
-            return Self.notification(
-                for: event,
+            return Self.failure(
+                event,
                 title: "Sandbox failed",
                 body: reason.map { "\(Self.name(of: event)) — \($0)" }
                     ?? "\(Self.name(of: event)) stopped with an unrecoverable error."
@@ -56,39 +56,59 @@ struct SandboxNotificationRules {
 
         // On `idle`, "error" means the session broke before an exit was seen.
         if let error = Self.attribute("error", of: event) {
-            return Self.notification(for: event, title: "Sandbox execution failed", body: "\(name) — \(error)")
+            return Self.failure(event, title: "Sandbox execution failed", body: "\(name) — \(error)")
         }
         if let signal = Self.attribute("signal", of: event) {
-            return Self.notification(
-                for: event, title: "Sandbox execution killed", body: "\(name) was killed by \(signal).")
+            return Self.failure(
+                event, title: "Sandbox execution killed", body: "\(name) was killed by \(signal).")
         }
         if let exitCode = Self.attribute("exit_code", of: event).flatMap(Int.init), exitCode != 0 {
-            return Self.notification(
-                for: event, title: "Sandbox execution failed", body: "\(name) exited with code \(exitCode).")
+            return Self.failure(
+                event, title: "Sandbox execution failed", body: "\(name) exited with code \(exitCode).")
         }
 
         guard let startedAt else { return nil }
         let elapsed = event.timestamp.timeIntervalSince(startedAt)
         guard elapsed >= Self.minimumSuccessDuration else { return nil }
-        return Self.notification(
-            for: event,
+        return Self.success(
+            event,
             title: "Sandbox execution finished",
             body: "\(name) finished in \(Self.formatted(elapsed))."
         )
     }
 
+    /// One failure banner per sandbox. An execution that fails in a retry loop
+    /// should leave its latest result on screen, not a stack of them.
+    private static func failure(
+        _ event: SandboxEventRecord, title: String, body: String
+    ) -> AppNotification {
+        notification(event, identifier: "sandbox.\(event.sandboxID).failure", title: title, body: body)
+    }
+
+    /// Distinct per event: two executions completing are two results, and the
+    /// second must not silently replace the first.
+    private static func success(
+        _ event: SandboxEventRecord, title: String, body: String
+    ) -> AppNotification {
+        notification(
+            event,
+            identifier: "sandbox.\(event.sandboxID).finished.\(Int(event.timestamp.timeIntervalSince1970))",
+            title: title,
+            body: body
+        )
+    }
+
     private static func notification(
-        for event: SandboxEventRecord, title: String, body: String
+        _ event: SandboxEventRecord, identifier: String, title: String, body: String
     ) -> AppNotification {
         AppNotification(
-            // Distinct per event: two executions finishing are two results, and
-            // the second must not silently replace the first.
-            identifier: "sandbox.\(event.sandboxID).\(Int(event.timestamp.timeIntervalSince1970))",
+            identifier: identifier,
             title: title,
             body: body,
             // Events carry no labels, and the deep link router cannot select a
             // sandbox by ID anyway, so this lands on the section.
-            destination: .section(.sandboxes, id: nil)
+            destination: .section(.sandboxes, id: nil),
+            category: .sandbox
         )
     }
 

--- a/ArcBox/Services/Notifications/SandboxNotificationRules.swift
+++ b/ArcBox/Services/Notifications/SandboxNotificationRules.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Decides which sandbox lifecycle events are worth interrupting the user for.
+///
+/// A sandbox execution is the one thing users routinely wait on without
+/// watching the window, so every failure is surfaced, and successes are
+/// surfaced once they have run long enough that the user has plausibly looked
+/// away.
+struct SandboxNotificationRules {
+    /// Successful executions shorter than this are assumed to have finished
+    /// while the user was still watching them.
+    static let minimumSuccessDuration: TimeInterval = 30
+
+    /// When each sandbox's current execution started, so a completion can be
+    /// judged against how long it ran. An execution whose start was never
+    /// observed — the app launched partway through it — has no entry.
+    private var executionStart: [String: Date] = [:]
+
+    mutating func notification(for event: SandboxEventRecord) -> AppNotification? {
+        switch event.kind {
+        case .running:
+            executionStart[event.sandboxID] = event.timestamp
+            return nil
+
+        case .idle:
+            return completion(for: event, startedAt: executionStart.removeValue(forKey: event.sandboxID))
+
+        case .failed:
+            executionStart.removeValue(forKey: event.sandboxID)
+            let reason = Self.attribute("error", of: event)
+            return Self.notification(
+                for: event,
+                title: "Sandbox failed",
+                body: reason.map { "\(Self.name(of: event)) — \($0)" }
+                    ?? "\(Self.name(of: event)) stopped with an unrecoverable error."
+            )
+
+        case .stopped, .removed:
+            executionStart.removeValue(forKey: event.sandboxID)
+            return nil
+
+        // A pause suspends the execution rather than ending it, so the start
+        // is deliberately kept: the same run continues after `resumed`.
+        case .created, .ready, .stopping, .pausing, .paused, .resumed, .unknown:
+            return nil
+        }
+    }
+
+    // MARK: - Private
+
+    /// An execution ended. Failures always notify. A success notifies only when
+    /// its start was observed and it ran past the threshold — an unknown
+    /// duration stays silent rather than guessing that the user walked away.
+    private func completion(for event: SandboxEventRecord, startedAt: Date?) -> AppNotification? {
+        let name = Self.name(of: event)
+
+        // On `idle`, "error" means the session broke before an exit was seen.
+        if let error = Self.attribute("error", of: event) {
+            return Self.notification(for: event, title: "Sandbox execution failed", body: "\(name) — \(error)")
+        }
+        if let signal = Self.attribute("signal", of: event) {
+            return Self.notification(
+                for: event, title: "Sandbox execution killed", body: "\(name) was killed by \(signal).")
+        }
+        if let exitCode = Self.attribute("exit_code", of: event).flatMap(Int.init), exitCode != 0 {
+            return Self.notification(
+                for: event, title: "Sandbox execution failed", body: "\(name) exited with code \(exitCode).")
+        }
+
+        guard let startedAt else { return nil }
+        let elapsed = event.timestamp.timeIntervalSince(startedAt)
+        guard elapsed >= Self.minimumSuccessDuration else { return nil }
+        return Self.notification(
+            for: event,
+            title: "Sandbox execution finished",
+            body: "\(name) finished in \(Self.formatted(elapsed))."
+        )
+    }
+
+    private static func notification(
+        for event: SandboxEventRecord, title: String, body: String
+    ) -> AppNotification {
+        AppNotification(
+            // Distinct per event: two executions finishing are two results, and
+            // the second must not silently replace the first.
+            identifier: "sandbox.\(event.sandboxID).\(Int(event.timestamp.timeIntervalSince1970))",
+            title: title,
+            body: body,
+            // Events carry no labels, and the deep link router cannot select a
+            // sandbox by ID anyway, so this lands on the section.
+            destination: .section(.sandboxes, id: nil)
+        )
+    }
+
+    /// Attribute value, treating an empty string as absent.
+    private static func attribute(_ key: String, of event: SandboxEventRecord) -> String? {
+        guard let value = event.attributes[key], !value.isEmpty else { return nil }
+        return value
+    }
+
+    /// Events carry no labels, so the short ID is the only name available —
+    /// matching how `SandboxViewModel` falls back when a sandbox is unnamed.
+    private static func name(of event: SandboxEventRecord) -> String {
+        String(event.sandboxID.prefix(12))
+    }
+
+    private static func formatted(_ elapsed: TimeInterval) -> String {
+        Duration.seconds(Int(elapsed))
+            .formatted(.units(allowed: [.hours, .minutes, .seconds], width: .abbreviated))
+    }
+}

--- a/ArcBox/Services/Notifications/SandboxNotificationRules.swift
+++ b/ArcBox/Services/Notifications/SandboxNotificationRules.swift
@@ -105,9 +105,10 @@ struct SandboxNotificationRules {
             identifier: identifier,
             title: title,
             body: body,
-            // Events carry no labels, and the deep link router cannot select a
-            // sandbox by ID anyway, so this lands on the section.
-            destination: .section(.sandboxes, id: nil),
+            // A sandbox that no longer exists by the time the user clicks
+            // resolves to the section plus an explanatory error, which is what
+            // `resolveResourceDeepLink` is for.
+            destination: .section(.sandboxes, id: event.sandboxID),
             category: .sandbox
         )
     }

--- a/ArcBox/Services/Notifications/UserNotificationService.swift
+++ b/ArcBox/Services/Notifications/UserNotificationService.swift
@@ -26,10 +26,12 @@ final class UserNotificationService: NSObject {
     private static let destinationKey = "destination"
 
     private let center: UNUserNotificationCenter
+    private let defaults: UserDefaults
     private var authorization: Authorization = .unrequested
 
-    init(center: UNUserNotificationCenter = .current()) {
+    init(center: UNUserNotificationCenter = .current(), defaults: UserDefaults = .standard) {
         self.center = center
+        self.defaults = defaults
         super.init()
     }
 
@@ -46,6 +48,12 @@ final class UserNotificationService: NSObject {
     // MARK: - Private
 
     private func deliver(_ notification: AppNotification) async {
+        guard defaults.bool(forKey: notification.category.preferenceKey) else {
+            Log.notifications.debug(
+                "Suppressed \(notification.identifier, privacy: .public): \(notification.category.rawValue, privacy: .public) notifications are off"
+            )
+            return
+        }
         guard await isAuthorized() else { return }
 
         let content = UNMutableNotificationContent()

--- a/ArcBox/Services/Notifications/UserNotificationService.swift
+++ b/ArcBox/Services/Notifications/UserNotificationService.swift
@@ -15,19 +15,10 @@ final class UserNotificationService: NSObject {
     /// Applies a notification's destination when it is clicked.
     var openDestination: ((DeepLink) -> Void)?
 
-    /// Authorization is requested the first time there is something to say, so
-    /// the prompt arrives attached to a real event instead of at launch.
-    private enum Authorization {
-        case unrequested
-        case granted
-        case denied
-    }
-
     private static let destinationKey = "destination"
 
     private let center: UNUserNotificationCenter
     private let defaults: UserDefaults
-    private var authorization: Authorization = .unrequested
 
     init(center: UNUserNotificationCenter = .current(), defaults: UserDefaults = .standard) {
         self.center = center
@@ -72,28 +63,32 @@ final class UserNotificationService: NSObject {
         }
     }
 
+    /// Authorization is requested the first time there is something to say, so
+    /// the prompt arrives attached to a real event instead of at launch.
+    ///
+    /// The answer is deliberately re-read every time rather than cached: a user
+    /// who denies and later turns notifications back on in System Settings —
+    /// which the button in Settings invites them to do — would otherwise get
+    /// nothing until they relaunched the app. Notifications are rare enough
+    /// that asking the system each time costs nothing.
     private func isAuthorized() async -> Bool {
-        switch authorization {
-        case .granted: return true
-        case .denied: return false
-        case .unrequested: break
+        switch await center.notificationSettings().authorizationStatus {
+        case .notDetermined:
+            do {
+                return try await center.requestAuthorization(options: [.alert, .sound])
+            } catch {
+                Log.notifications.error(
+                    "Notification authorization failed: \(error.localizedDescription, privacy: .private)")
+                return false
+            }
+        case .authorized, .provisional, .ephemeral:
+            return true
+        case .denied:
+            Log.notifications.debug("Notifications are turned off for ArcBox in System Settings")
+            return false
+        @unknown default:
+            return false
         }
-
-        // Idempotent: once the user has decided, this reports that decision
-        // instead of prompting again.
-        let granted: Bool
-        do {
-            granted = try await center.requestAuthorization(options: [.alert, .sound])
-        } catch {
-            Log.notifications.error(
-                "Notification authorization failed: \(error.localizedDescription, privacy: .private)")
-            granted = false
-        }
-        authorization = granted ? .granted : .denied
-        if !granted {
-            Log.notifications.info("Notifications not authorized; no further delivery will be attempted")
-        }
-        return granted
     }
 
     private func destination(of notification: UNNotification) -> DeepLink? {

--- a/ArcBox/Services/Notifications/UserNotificationService.swift
+++ b/ArcBox/Services/Notifications/UserNotificationService.swift
@@ -1,0 +1,127 @@
+import Foundation
+import OSLog
+import UserNotifications
+
+/// Delivers `AppNotification`s through the system notification centre.
+///
+/// The single place in the app that touches `UNUserNotificationCenter`: rules
+/// decide what is worth saying, this decides whether the user needs to be told
+/// at all, and routes the click back into navigation.
+final class UserNotificationService: NSObject {
+    /// Whether the user is already looking at what a notification is about.
+    /// Supplied by the coordinator, which owns window and navigation state.
+    var isUserWatching: ((DeepLink) -> Bool)?
+
+    /// Applies a notification's destination when it is clicked.
+    var openDestination: ((DeepLink) -> Void)?
+
+    /// Authorization is requested the first time there is something to say, so
+    /// the prompt arrives attached to a real event instead of at launch.
+    private enum Authorization {
+        case unrequested
+        case granted
+        case denied
+    }
+
+    private static let destinationKey = "destination"
+
+    private let center: UNUserNotificationCenter
+    private var authorization: Authorization = .unrequested
+
+    init(center: UNUserNotificationCenter = .current()) {
+        self.center = center
+        super.init()
+    }
+
+    /// Become the delegate. Called during app launch so a click on a
+    /// notification that launched the app still routes.
+    func start() {
+        center.delegate = self
+    }
+
+    func post(_ notification: AppNotification) {
+        Task { await deliver(notification) }
+    }
+
+    // MARK: - Private
+
+    private func deliver(_ notification: AppNotification) async {
+        guard await isAuthorized() else { return }
+
+        let content = UNMutableNotificationContent()
+        content.title = notification.title
+        content.body = notification.body
+        content.userInfo = [Self.destinationKey: notification.destination.url.absoluteString]
+
+        do {
+            // A nil trigger delivers immediately.
+            try await center.add(
+                UNNotificationRequest(identifier: notification.identifier, content: content, trigger: nil))
+        } catch {
+            Log.notifications.error(
+                "Failed to deliver \(notification.identifier, privacy: .public): \(error.localizedDescription, privacy: .private)"
+            )
+        }
+    }
+
+    private func isAuthorized() async -> Bool {
+        switch authorization {
+        case .granted: return true
+        case .denied: return false
+        case .unrequested: break
+        }
+
+        // Idempotent: once the user has decided, this reports that decision
+        // instead of prompting again.
+        let granted: Bool
+        do {
+            granted = try await center.requestAuthorization(options: [.alert, .sound])
+        } catch {
+            Log.notifications.error(
+                "Notification authorization failed: \(error.localizedDescription, privacy: .private)")
+            granted = false
+        }
+        authorization = granted ? .granted : .denied
+        if !granted {
+            Log.notifications.info("Notifications not authorized; no further delivery will be attempted")
+        }
+        return granted
+    }
+
+    private func destination(of notification: UNNotification) -> DeepLink? {
+        guard let raw = notification.request.content.userInfo[Self.destinationKey] as? String,
+            let url = URL(string: raw)
+        else { return nil }
+        return DeepLink(url)
+    }
+}
+
+// MARK: - UNUserNotificationCenterDelegate
+
+extension UserNotificationService: UNUserNotificationCenterDelegate {
+    /// Only called while the app is frontmost. Suppress the banner when the
+    /// user is already looking at what it would announce — that redundancy is
+    /// the main reason notifications become annoying.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        guard let destination = destination(of: notification),
+            isUserWatching?(destination) == true
+        else { return [.banner, .sound] }
+
+        Log.notifications.debug(
+            "Suppressed \(notification.request.identifier, privacy: .public): already on screen")
+        return []
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        guard response.actionIdentifier == UNNotificationDefaultActionIdentifier,
+            let destination = destination(of: response.notification)
+        else { return }
+        openDestination?(destination)
+    }
+}

--- a/ArcBox/Services/SandboxEventMonitor.swift
+++ b/ArcBox/Services/SandboxEventMonitor.swift
@@ -18,6 +18,11 @@ final class SandboxEventMonitor {
     /// Most recent events, oldest first. Bounded to `maxRecentEvents`.
     private(set) var recentEvents: [SandboxEventRecord] = []
 
+    /// Called for every event as it arrives, before the debounced list refresh.
+    /// `.sandboxChanged` carries no payload, so consumers that need the event
+    /// itself — notifications — take it from here.
+    @ObservationIgnored var onEvent: ((SandboxEventRecord) -> Void)?
+
     @ObservationIgnored private var task: Task<Void, Never>?
     @ObservationIgnored private var isStopped = true
 
@@ -100,10 +105,12 @@ final class SandboxEventMonitor {
     // MARK: - Private
 
     private func record(_ event: Arcbox_Sandbox_V1_SandboxEvent) {
-        recentEvents.append(SandboxEventRecord(from: event))
+        let record = SandboxEventRecord(from: event)
+        recentEvents.append(record)
         if recentEvents.count > Self.maxRecentEvents {
             recentEvents.removeFirst(recentEvents.count - Self.maxRecentEvents)
         }
+        onEvent?(record)
         debouncedPost()
     }
 

--- a/ArcBox/Views/Settings/GeneralSettingsView.swift
+++ b/ArcBox/Views/Settings/GeneralSettingsView.swift
@@ -19,6 +19,8 @@ struct GeneralSettingsView: View {
     @AppStorage("terminalTheme") private var terminalTheme = "system"
     @AppStorage("externalTerminal") private var externalTerminal = ExternalTerminalApp.terminalBundleIdentifier
     @AppStorage("telemetryEnabled") private var telemetryEnabled = true
+    @AppStorage(AppNotification.Category.sandbox.preferenceKey) private var notifySandboxResults = true
+    @AppStorage(AppNotification.Category.daemonHealth.preferenceKey) private var notifyDaemonProblems = true
 
     @State private var isExportingDiagnostics = false
     @State private var loginItemErrorMessage: String?
@@ -72,6 +74,35 @@ struct GeneralSettingsView: View {
                     Text("Stable").tag("stable")
                     Text("Beta").tag("beta")
                 }
+            }
+
+            Section("Notifications") {
+                LabeledContent {
+                    Toggle("", isOn: $notifySandboxResults)
+                        .labelsHidden()
+                } label: {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Sandbox execution results")
+                        Text("Every failure, and successful runs longer than 30 seconds.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                LabeledContent {
+                    Toggle("", isOn: $notifyDaemonProblems)
+                        .labelsHidden()
+                } label: {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Daemon problems")
+                        Text("When the daemon stops, or stays unreachable for 30 seconds.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Button("Open Notification Settings...") {
+                    openNotificationSettings()
+                }
+                .font(.caption)
             }
 
             Section("Privacy") {
@@ -266,6 +297,18 @@ struct GeneralSettingsView: View {
             status == .requiresApproval
             ? "macOS requires approval before ArcBox can start at login."
             : nil
+    }
+
+    /// The toggles above only gate what ArcBox sends; whether any of it is
+    /// allowed through is a system-level decision that lives in System
+    /// Settings. There is no API for that pane — unlike login items, which have
+    /// `SMAppService.openSystemSettingsLoginItems()` — so this goes through the
+    /// URL scheme. It is not documented by Apple, so a pane identifier change
+    /// would leave the button opening nothing rather than misbehaving.
+    private func openNotificationSettings() {
+        let pane = "x-apple.systempreferences:com.apple.Notifications-Settings.extension"
+        guard let url = URL(string: "\(pane)?id=\(Bundle.main.bundleIdentifier ?? "")") else { return }
+        NSWorkspace.shared.open(url)
     }
 
     private func updateLoginItem(enabled: Bool) {

--- a/ArcBoxTests/AppPreferencesTests.swift
+++ b/ArcBoxTests/AppPreferencesTests.swift
@@ -30,6 +30,15 @@ final class AppPreferencesTests: XCTestCase {
             "registered defaults must not overwrite a stored preference"
         )
         XCTAssertTrue(userDefaults.bool(forKey: "pauseContainersWhileSleeping"))
+        // Notification categories are gated by `bool(forKey:)`, which reads an
+        // unregistered key as false — every category must be registered or it
+        // silently ships switched off.
+        for category in AppNotification.Category.allCases {
+            XCTAssertTrue(
+                userDefaults.bool(forKey: category.preferenceKey),
+                "\(category.rawValue) notifications must default to on"
+            )
+        }
 
         userDefaults.removeObject(forKey: "switchDockerContextAutomatically")
         XCTAssertTrue(userDefaults.bool(forKey: "switchDockerContextAutomatically"))

--- a/ArcBoxTests/DaemonNotificationRulesTests.swift
+++ b/ArcBoxTests/DaemonNotificationRulesTests.swift
@@ -3,75 +3,97 @@ import XCTest
 
 @testable import ArcBox
 
-/// Tests for which daemon state transitions produce a user notification.
+/// Tests for which daemon state transitions produce a user notification, and
+/// how long the daemon has to stay broken before the user hears about it.
 ///
-/// The distinction that matters: a daemon that died on its own is worth
-/// interrupting the user for, a shutdown they asked for is not.
+/// The distinctions that matter: a daemon that died on its own is worth
+/// interrupting the user for, a shutdown they asked for is not, and a drop that
+/// recovers on its own — waking from sleep — must not say anything at all.
 @MainActor
 final class DaemonNotificationRulesTests: XCTestCase {
 
-    private func notification(from previous: DaemonState?, to current: DaemonState) -> AppNotification? {
-        DaemonNotificationRules.notification(from: previous, to: current)
+    private func alert(from previous: DaemonState?, to current: DaemonState) -> DaemonHealthAlert? {
+        DaemonNotificationRules.alert(from: previous, to: current)
     }
 
     // MARK: - Worth saying
 
-    /// `DaemonManager` only regresses a running daemon to `.registered` after
-    /// its reconnect grace window, so this transition means genuinely gone.
     func testRunningToRegisteredNotifies() {
-        XCTAssertEqual(notification(from: .running, to: .registered)?.title, "ArcBox daemon is unreachable")
+        XCTAssertEqual(
+            alert(from: .running, to: .registered)?.notification.title, "ArcBox daemon is unreachable")
     }
 
-    func testFatalErrorNotifiesWithReason() {
-        let result = notification(from: .running, to: .error("vm failed to boot"))
+    /// The regression that matters: `DaemonManager` gives up on a stream after
+    /// ~3.5 s, which is tuned for the window, not for a banner. Waking from
+    /// sleep breaks the stream every time, so an unreachable daemon must be
+    /// confirmed over a longer window before the user is told.
+    func testUnreachableIsConfirmedBeforeNotifying() {
+        let confirmAfter = alert(from: .running, to: .registered)?.confirmAfter
 
-        XCTAssertEqual(result?.title, "ArcBox daemon stopped")
-        XCTAssertEqual(result?.body, "vm failed to boot")
+        XCTAssertEqual(confirmAfter, DaemonNotificationRules.unreachableConfirmation)
+        XCTAssertGreaterThan(confirmAfter ?? .zero, .seconds(10))
+    }
+
+    /// A fatal setup failure is the daemon's own verdict; it is not coming back
+    /// on its own, so there is nothing to wait for.
+    func testFatalErrorNotifiesImmediately() {
+        let result = alert(from: .running, to: .error("vm failed to boot"))
+
+        XCTAssertEqual(result?.notification.title, "ArcBox daemon stopped")
+        XCTAssertEqual(result?.notification.body, "vm failed to boot")
+        XCTAssertEqual(result?.confirmAfter, .zero)
     }
 
     func testFatalErrorFromAnyStateNotifies() {
-        XCTAssertNotNil(notification(from: .starting, to: .error("boom")))
-        XCTAssertNotNil(notification(from: nil, to: .error("boom")))
+        XCTAssertNotNil(alert(from: .starting, to: .error("boom")))
+        XCTAssertNotNil(alert(from: nil, to: .error("boom")))
     }
 
     /// A different fatal cause is new information.
     func testChangedErrorReasonNotifiesAgain() {
-        XCTAssertNotNil(notification(from: .error("first"), to: .error("second")))
+        XCTAssertNotNil(alert(from: .error("first"), to: .error("second")))
     }
 
     func testEmptyErrorReasonFallsBackToGenericBody() {
-        XCTAssertEqual(notification(from: .running, to: .error(""))?.body, "The daemon reported a fatal error.")
+        XCTAssertEqual(
+            alert(from: .running, to: .error(""))?.notification.body,
+            "The daemon reported a fatal error."
+        )
     }
 
     /// One health story: a later verdict replaces the earlier banner.
     func testHealthNotificationsShareAnIdentifier() {
         XCTAssertEqual(
-            notification(from: .running, to: .registered)?.identifier,
-            notification(from: .running, to: .error("boom"))?.identifier
+            alert(from: .running, to: .registered)?.notification.identifier,
+            alert(from: .running, to: .error("boom"))?.notification.identifier
         )
+    }
+
+    func testHealthNotificationsAreSwitchableOnTheirOwn() {
+        XCTAssertEqual(alert(from: .running, to: .registered)?.notification.category, .daemonHealth)
     }
 
     // MARK: - Not worth saying
 
     /// `.stopping` and `.stopped` are the states of a shutdown the user asked for.
     func testIntentionalShutdownIsSilent() {
-        XCTAssertNil(notification(from: .running, to: .stopping))
-        XCTAssertNil(notification(from: .running, to: .stopped))
+        XCTAssertNil(alert(from: .running, to: .stopping))
+        XCTAssertNil(alert(from: .running, to: .stopped))
     }
 
     func testStartupIsSilent() {
-        XCTAssertNil(notification(from: nil, to: .stopped))
-        XCTAssertNil(notification(from: nil, to: .registered))
-        XCTAssertNil(notification(from: .starting, to: .registered))
-        XCTAssertNil(notification(from: .registered, to: .running))
+        XCTAssertNil(alert(from: nil, to: .stopped))
+        XCTAssertNil(alert(from: nil, to: .registered))
+        XCTAssertNil(alert(from: .starting, to: .registered))
+        XCTAssertNil(alert(from: .registered, to: .running))
     }
 
     /// A daemon that was never up cannot become unreachable.
     func testRegisteredToRegisteredIsSilent() {
-        XCTAssertNil(notification(from: .registered, to: .registered))
+        XCTAssertNil(alert(from: .registered, to: .registered))
     }
 
     func testRepeatedErrorIsSilent() {
-        XCTAssertNil(notification(from: .error("same"), to: .error("same")))
+        XCTAssertNil(alert(from: .error("same"), to: .error("same")))
     }
 }

--- a/ArcBoxTests/DaemonNotificationRulesTests.swift
+++ b/ArcBoxTests/DaemonNotificationRulesTests.swift
@@ -1,0 +1,77 @@
+import ArcBoxClient
+import XCTest
+
+@testable import ArcBox
+
+/// Tests for which daemon state transitions produce a user notification.
+///
+/// The distinction that matters: a daemon that died on its own is worth
+/// interrupting the user for, a shutdown they asked for is not.
+@MainActor
+final class DaemonNotificationRulesTests: XCTestCase {
+
+    private func notification(from previous: DaemonState?, to current: DaemonState) -> AppNotification? {
+        DaemonNotificationRules.notification(from: previous, to: current)
+    }
+
+    // MARK: - Worth saying
+
+    /// `DaemonManager` only regresses a running daemon to `.registered` after
+    /// its reconnect grace window, so this transition means genuinely gone.
+    func testRunningToRegisteredNotifies() {
+        XCTAssertEqual(notification(from: .running, to: .registered)?.title, "ArcBox daemon is unreachable")
+    }
+
+    func testFatalErrorNotifiesWithReason() {
+        let result = notification(from: .running, to: .error("vm failed to boot"))
+
+        XCTAssertEqual(result?.title, "ArcBox daemon stopped")
+        XCTAssertEqual(result?.body, "vm failed to boot")
+    }
+
+    func testFatalErrorFromAnyStateNotifies() {
+        XCTAssertNotNil(notification(from: .starting, to: .error("boom")))
+        XCTAssertNotNil(notification(from: nil, to: .error("boom")))
+    }
+
+    /// A different fatal cause is new information.
+    func testChangedErrorReasonNotifiesAgain() {
+        XCTAssertNotNil(notification(from: .error("first"), to: .error("second")))
+    }
+
+    func testEmptyErrorReasonFallsBackToGenericBody() {
+        XCTAssertEqual(notification(from: .running, to: .error(""))?.body, "The daemon reported a fatal error.")
+    }
+
+    /// One health story: a later verdict replaces the earlier banner.
+    func testHealthNotificationsShareAnIdentifier() {
+        XCTAssertEqual(
+            notification(from: .running, to: .registered)?.identifier,
+            notification(from: .running, to: .error("boom"))?.identifier
+        )
+    }
+
+    // MARK: - Not worth saying
+
+    /// `.stopping` and `.stopped` are the states of a shutdown the user asked for.
+    func testIntentionalShutdownIsSilent() {
+        XCTAssertNil(notification(from: .running, to: .stopping))
+        XCTAssertNil(notification(from: .running, to: .stopped))
+    }
+
+    func testStartupIsSilent() {
+        XCTAssertNil(notification(from: nil, to: .stopped))
+        XCTAssertNil(notification(from: nil, to: .registered))
+        XCTAssertNil(notification(from: .starting, to: .registered))
+        XCTAssertNil(notification(from: .registered, to: .running))
+    }
+
+    /// A daemon that was never up cannot become unreachable.
+    func testRegisteredToRegisteredIsSilent() {
+        XCTAssertNil(notification(from: .registered, to: .registered))
+    }
+
+    func testRepeatedErrorIsSilent() {
+        XCTAssertNil(notification(from: .error("same"), to: .error("same")))
+    }
+}

--- a/ArcBoxTests/DeepLinkTests.swift
+++ b/ArcBoxTests/DeepLinkTests.swift
@@ -152,4 +152,25 @@ final class DeepLinkTests: XCTestCase {
         )
         return (router, appVM)
     }
+
+    // MARK: - URL round-trip
+
+    /// Notifications carry their destination as a URL string, so every link
+    /// must survive the trip back through the parser.
+    @MainActor func testURLRoundTrips() {
+        let links: [DeepLink] = [
+            .main,
+            .settings,
+            .section(.sandboxes, id: nil),
+            .section(.containers, id: "abc123"),
+        ]
+        for link in links {
+            XCTAssertEqual(DeepLink(link.url), link, "\(link.url) did not round-trip")
+        }
+    }
+
+    @MainActor func testURLEscapesIDs() {
+        let link = DeepLink.section(.containers, id: "a b/c")
+        XCTAssertEqual(DeepLink(link.url), .section(.containers, id: "a b"))
+    }
 }

--- a/ArcBoxTests/SandboxNotificationRulesTests.swift
+++ b/ArcBoxTests/SandboxNotificationRulesTests.swift
@@ -153,4 +153,25 @@ final class SandboxNotificationRulesTests: XCTestCase {
         XCTAssertNotNil(first?.identifier)
         XCTAssertNotEqual(first?.identifier, second?.identifier)
     }
+
+    /// Failures are the opposite: an execution retrying in a loop should leave
+    /// its latest result on screen, not one banner per attempt.
+    func testFailuresOfOneSandboxShareAnIdentifier() {
+        let first = rules.notification(for: event(.idle, after: 1, ["exit_code": "1"]))
+        let second = rules.notification(for: event(.idle, after: 2, ["exit_code": "1"]))
+
+        XCTAssertNotNil(first?.identifier)
+        XCTAssertEqual(first?.identifier, second?.identifier)
+    }
+
+    func testFailuresOfDifferentSandboxesDoNotReplaceEachOther() {
+        let a = rules.notification(for: event(.idle, id: "sandbox-a", ["exit_code": "1"]))
+        let b = rules.notification(for: event(.idle, id: "sandbox-b", ["exit_code": "1"]))
+
+        XCTAssertNotEqual(a?.identifier, b?.identifier)
+    }
+
+    func testSandboxNotificationsAreSwitchableOnTheirOwn() {
+        XCTAssertEqual(rules.notification(for: event(.failed))?.category, .sandbox)
+    }
 }

--- a/ArcBoxTests/SandboxNotificationRulesTests.swift
+++ b/ArcBoxTests/SandboxNotificationRulesTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+
+@testable import ArcBox
+
+/// Tests for which sandbox events produce a user notification.
+///
+/// The rules are a pure value type, so every case is driven by feeding events
+/// directly — no gRPC stream and no notification centre involved.
+@MainActor
+final class SandboxNotificationRulesTests: XCTestCase {
+
+    private var rules = SandboxNotificationRules()
+    private let start = Date(timeIntervalSince1970: 1_700_000_000)
+
+    override func setUp() {
+        super.setUp()
+        rules = SandboxNotificationRules()
+    }
+
+    // MARK: - Helpers
+
+    private func event(
+        _ kind: SandboxEventKind,
+        id: String = "sandbox-abcdef123456",
+        after seconds: TimeInterval = 0,
+        _ attributes: [String: String] = [:]
+    ) -> SandboxEventRecord {
+        SandboxEventRecord(
+            sandboxID: id,
+            kind: kind,
+            timestamp: start.addingTimeInterval(seconds),
+            attributes: attributes
+        )
+    }
+
+    // MARK: - Successful completions
+
+    func testLongSuccessNotifies() {
+        XCTAssertNil(rules.notification(for: event(.running)))
+
+        let notification = rules.notification(for: event(.idle, after: 60, ["exit_code": "0"]))
+
+        XCTAssertEqual(notification?.title, "Sandbox execution finished")
+        XCTAssertEqual(notification?.destination, .section(.sandboxes, id: nil))
+    }
+
+    /// A quick success finished while the user was still looking at it.
+    func testShortSuccessIsSilent() {
+        _ = rules.notification(for: event(.running))
+
+        XCTAssertNil(rules.notification(for: event(.idle, after: 5, ["exit_code": "0"])))
+    }
+
+    /// The app launched partway through the execution, so there is no duration
+    /// to judge. Guessing "long enough" here would notify on every reconnect.
+    func testSuccessWithoutObservedStartIsSilent() {
+        XCTAssertNil(rules.notification(for: event(.idle, after: 900, ["exit_code": "0"])))
+    }
+
+    /// The start is consumed by the completion it explains; a second completion
+    /// must not reuse it.
+    func testStartIsNotReusedByASecondCompletion() {
+        _ = rules.notification(for: event(.running))
+        XCTAssertNotNil(rules.notification(for: event(.idle, after: 60, ["exit_code": "0"])))
+
+        XCTAssertNil(rules.notification(for: event(.idle, after: 120, ["exit_code": "0"])))
+    }
+
+    func testDurationIsTrackedPerSandbox() {
+        _ = rules.notification(for: event(.running, id: "long"))
+        _ = rules.notification(for: event(.running, id: "short", after: 55))
+
+        XCTAssertNotNil(rules.notification(for: event(.idle, id: "long", after: 60, ["exit_code": "0"])))
+        XCTAssertNil(rules.notification(for: event(.idle, id: "short", after: 60, ["exit_code": "0"])))
+    }
+
+    // MARK: - Failures
+
+    /// Failures are worth saying regardless of how long they took, and without
+    /// having seen the execution start.
+    func testNonZeroExitNotifiesEvenWhenShortAndUnobserved() {
+        let notification = rules.notification(for: event(.idle, after: 1, ["exit_code": "137"]))
+
+        XCTAssertEqual(notification?.title, "Sandbox execution failed")
+        XCTAssertEqual(notification?.body.contains("137"), true)
+    }
+
+    func testSignalNotifies() {
+        let notification = rules.notification(for: event(.idle, ["signal": "SIGKILL"]))
+
+        XCTAssertEqual(notification?.title, "Sandbox execution killed")
+        XCTAssertEqual(notification?.body.contains("SIGKILL"), true)
+    }
+
+    /// On `idle`, an "error" attribute means the session broke before an exit
+    /// code was observed.
+    func testBrokenSessionNotifies() {
+        let notification = rules.notification(for: event(.idle, ["error": "connection reset"]))
+
+        XCTAssertEqual(notification?.title, "Sandbox execution failed")
+        XCTAssertEqual(notification?.body.contains("connection reset"), true)
+    }
+
+    func testFailedNotifiesWithReason() {
+        let notification = rules.notification(for: event(.failed, ["error": "no space left on device"]))
+
+        XCTAssertEqual(notification?.title, "Sandbox failed")
+        XCTAssertEqual(notification?.body.contains("no space left on device"), true)
+    }
+
+    func testFailedWithoutReasonStillNotifies() {
+        XCTAssertEqual(rules.notification(for: event(.failed))?.title, "Sandbox failed")
+    }
+
+    /// An empty attribute is not a reason.
+    func testEmptyErrorAttributeFallsBackToGenericBody() {
+        let notification = rules.notification(for: event(.failed, ["error": ""]))
+
+        XCTAssertEqual(notification?.body.contains("unrecoverable"), true)
+    }
+
+    // MARK: - Silent lifecycle
+
+    func testLifecycleEventsAreSilent() {
+        let silent: [SandboxEventKind] = [
+            .created, .ready, .stopping, .stopped, .removed, .pausing, .paused, .resumed, .unknown,
+        ]
+        for kind in silent {
+            XCTAssertNil(rules.notification(for: event(kind)), "\(kind.label) should be silent")
+        }
+    }
+
+    /// A pause suspends the execution rather than ending it, so the completion
+    /// that follows a resume is still judged against the original start.
+    func testPauseDoesNotDiscardTheExecutionStart() {
+        _ = rules.notification(for: event(.running))
+        _ = rules.notification(for: event(.paused, after: 10))
+        _ = rules.notification(for: event(.resumed, after: 20))
+
+        XCTAssertNotNil(rules.notification(for: event(.idle, after: 60, ["exit_code": "0"])))
+    }
+
+    // MARK: - Delivery identity
+
+    /// Two executions finishing are two results; the second must not replace
+    /// the first's banner.
+    func testCompletionsOfOneSandboxGetDistinctIdentifiers() {
+        _ = rules.notification(for: event(.running))
+        let first = rules.notification(for: event(.idle, after: 60, ["exit_code": "0"]))
+        _ = rules.notification(for: event(.running, after: 120))
+        let second = rules.notification(for: event(.idle, after: 180, ["exit_code": "0"]))
+
+        XCTAssertNotNil(first?.identifier)
+        XCTAssertNotEqual(first?.identifier, second?.identifier)
+    }
+}

--- a/ArcBoxTests/SandboxNotificationRulesTests.swift
+++ b/ArcBoxTests/SandboxNotificationRulesTests.swift
@@ -41,7 +41,13 @@ final class SandboxNotificationRulesTests: XCTestCase {
         let notification = rules.notification(for: event(.idle, after: 60, ["exit_code": "0"]))
 
         XCTAssertEqual(notification?.title, "Sandbox execution finished")
-        XCTAssertEqual(notification?.destination, .section(.sandboxes, id: nil))
+    }
+
+    /// Clicking a result lands on the sandbox it is about, not just the list.
+    func testNotificationsPointAtTheSandbox() {
+        let notification = rules.notification(for: event(.failed, id: "sandbox-xyz"))
+
+        XCTAssertEqual(notification?.destination, .section(.sandboxes, id: "sandbox-xyz"))
     }
 
     /// A quick success finished while the user was still looking at it.


### PR DESCRIPTION
Closes ABXD-132.

The app keeps running with its window closed, so a sandbox execution that finishes and a daemon that dies were both invisible until the window was reopened. There was no `UNUserNotification` usage anywhere.

This adds the delivery layer plus the two triggers worth having first. The remaining candidates (container `die`, long image operations, memory pressure, disk usage) are listed in ABXD-132 as follow-ups; the layer is shaped for them but they are not implemented here.

## What notifies

**Sandbox executions** — every failure, regardless of duration or whether the app saw the run start: non-zero `exit_code`, a `signal`, or an `error` attribute on `idle` (the session broke before an exit was observed). Successes notify only when the `running` event was observed *and* the run lasted at least 30s — a quick success finished while the user was still looking at it, and an unknown duration stays silent rather than guessing.

**Daemon health** — a fatal `.error` fires immediately, since the daemon has reported its own verdict and is not coming back on its own. Becoming unreachable (`.running → .registered`) is instead confirmed over 30s, and any recovery in between cancels it. `DaemonManager` reaches `.registered` after only ~3.5s of failed reconnects, which is the right threshold for the window but far too eager for a banner: waking from sleep breaks the stream every time while the daemon is still resuming the VM. Without the confirmation window this alerts on essentially every wake, and once per cycle for a crash-looping daemon. `.stopping` / `.stopped` are excluded entirely — those are the states of a shutdown the user asked for.

## Noise control

- **Failures coalesce, successes do not.** One failure identifier per sandbox, so an execution retrying in a loop leaves its latest result on screen instead of one banner per attempt. Two *completed* runs are two results and stay distinct.
- **Foreground suppression** in `willPresent`: no banner when the user is already looking at what it would announce.
- **Both kinds can be switched off independently**, from General settings — turning off notifications for the whole app in System Settings should not be the only control. Defaults are registered so an unset key reads as on.

## Shape

- `AppNotification` — what to say, as a plain value, tagged with the category that gates it.
- `SandboxNotificationRules` / `DaemonNotificationRules` — the decisions, pure and covered by tests. The daemon rule returns *how long to confirm* alongside the notification, so the delay is a tested value rather than a number buried in a timer.
- `UserNotificationService` — the only thing that touches `UNUserNotificationCenter`. Checks the category preference, requests authorization lazily on the first real event rather than at launch, suppresses redundant banners, and routes clicks back through `DeepLinkRouter`.
- `ApplicationCoordinator` owns the confirmation timer: every daemon state change cancels the pending alert, and the alert re-checks the live state before posting.

Supporting changes: `SandboxEventMonitor` gains a typed `onEvent` hook (`.sandboxChanged` carries no payload, so a subscriber cannot see the event); `DeepLink` gains a `url` so a destination can travel in a notification's `userInfo`; `SandboxEventRecord` gains a direct initializer so the rules' tests do not go through protobuf.

## Verification

`make build`, `make lint` (0 violations) and `make test` pass. 33 new cases across sandbox rules, daemon rules, registered defaults and deep-link round-trips — each confirmed to actually execute in `ArcBoxTests`, not inferred from `TEST SUCCEEDED`.

## Notes for review

- Pause/resume keep the execution start rather than clearing it, so a run that spans a pause is still judged against its original start.
- A daemon flapping faster than the 30s confirmation window never notifies, because each transition restarts the timer. That is the intended trade: the window already shows the state, and a banner every few seconds is worse than none.
- The "Open Notification Settings..." button uses `x-apple.systempreferences:com.apple.Notifications-Settings.extension?id=<bundleId>`. Unlike login items there is no API for this pane, and the URL is not documented by Apple — sourced from community reports, verified against macOS 15. If the identifier ever changes the button opens nothing rather than misbehaving.
- No batch coalescing across *different* sandboxes yet. Neither trigger here bursts, so the merge strategy has no input to be designed against; it belongs with the Docker `die` follow-up, where `compose up` produces dozens of events at once.
- Notification copy is English-only, matching the surrounding app.