### PR TITLE
feat(onboarding): add Docker environment migration

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		012B6BCE79F6FAE406EE97A0 /* ContainerLogsTab+Views.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2CC2B117E020C62C1E9952E /* ContainerLogsTab+Views.swift */; };
 		0188EE6B84CB38AA29EBEC57 /* ContainersViewModel+GRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70BE1C3890C5F6A96C6BCBD /* ContainersViewModel+GRPC.swift */; };
 		03AB091DAB7FD7F059C90480 /* ImagesListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FD9C27ABD090B7DBA435AA /* ImagesListViewController.swift */; };
+		05EFDA7AAB590520BC711D4C /* OnboardingMigrationPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F0BF05531582B5E276A5E2 /* OnboardingMigrationPage.swift */; };
 		0720D45362971FA9338BAA53 /* SwiftTermView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA74DBE71D29DEB680F08E7 /* SwiftTermView.swift */; };
 		07A382D149C73C697CAA1601 /* SandboxRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE564AAFEC0EF6D094409728 /* SandboxRowView.swift */; };
 		08DDBA6E0000548FEF44EB7B /* StatsFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B33A34931421365A5BCAE6 /* StatsFormat.swift */; };
@@ -81,6 +82,7 @@
 		4C3BC465BFE58BF0D59AFE78 /* OnboardingWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 915561BEEE49F5E27F4B0D40 /* OnboardingWindowController.swift */; };
 		4D2029E55A7979B8BD9EE89A /* ContainersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610512C9106BB92A47DC044 /* ContainersViewModelTests.swift */; };
 		4D2FB362066EF19A8C5983F1 /* DockerClient in Frameworks */ = {isa = PBXBuildFile; productRef = 984278376FF4860E6FADC66F /* DockerClient */; };
+		4DF1A85E96002569D24CCF66 /* OnboardingMigrationModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912DD5CF669A1B8EB0F5734C /* OnboardingMigrationModelTests.swift */; };
 		50CCDEFCA186BCD1E99D291F /* ChangelogParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBEBBF08F0E4AC45D9C0BB83 /* ChangelogParser.swift */; };
 		519C116D9CC62268CE4859D4 /* ExternalTerminalApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D70EF1BF223C47C7B8E71A5 /* ExternalTerminalApp.swift */; };
 		525ECDE24CB1E8ADC7AADB49 /* UpdaterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9234FC5BCCDDCBF441A94880 /* UpdaterDelegate.swift */; };
@@ -104,6 +106,7 @@
 		68D8583BAE183D23FFC10815 /* MenuBarHoverButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 789DE20DB0F3E106BFAC6E10 /* MenuBarHoverButton.swift */; };
 		699F9908BD6DBCD8244DCEE5 /* AuthTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D2C529811ECBAD82E110BC4 /* AuthTestSupport.swift */; };
 		6BDA8BA049C2D918C3E5349C /* ContainersListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AAFC5E642995054B983811 /* ContainersListViewController.swift */; };
+		6C008EEBEEC7101D289DD9D0 /* DockerContextManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40D34F775F57891973F6945 /* DockerContextManagerTests.swift */; };
 		6DC794E9A1D889DF4F3D6B91 /* SheetErrorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EB02E7DC54A70CDFD0C694 /* SheetErrorMessage.swift */; };
 		6EE6805F5EC85742CC665575 /* DockerCLIResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDE93A683D2613C431BEBF2 /* DockerCLIResolver.swift */; };
 		6EE78011A83F450B9E754CAB /* DockerTerminalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC42E91F0BCACABF173B87F /* DockerTerminalSession.swift */; };
@@ -159,6 +162,7 @@
 		94A832E6C744F534C80CB410 /* ImagesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C9AACAD52AFF216B6A69E0 /* ImagesListView.swift */; };
 		94ED0CE623AF8D60C793D919 /* com.arcboxlabs.desktop.daemon.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3E30F5FC430804013B58C6F1 /* com.arcboxlabs.desktop.daemon.plist */; };
 		95820205B54ABC3FAF14EC8F /* MachinesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EE316315F864BA1BF0FFED /* MachinesViewModel.swift */; };
+		95B02103F5CEC65396806F7E /* OnboardingMigrationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93492ACC2F34E108901582CF /* OnboardingMigrationModel.swift */; };
 		961ABBF2262B0BA2139BECBA /* KubernetesStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC273E219CB1B213B2DC57A /* KubernetesStateTests.swift */; };
 		967B79B7F3A20ACDDC610AD4 /* ContainerFilesTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = A80B0A0F4FC2E7ECA0B844DD /* ContainerFilesTab.swift */; };
 		96C7FFF79579D1B999ABAF3F /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A093F9D88FA4D914DE6F45 /* Utilities.swift */; };
@@ -412,9 +416,11 @@
 		8ECCF18CC36CC3579EE2B5B9 /* MachinesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachinesView.swift; sourceTree = "<group>"; };
 		903FA72CEF39142ADA5CA378 /* NewVolumeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewVolumeSheet.swift; sourceTree = "<group>"; };
 		9101DCB26B0BB5B8DE4CAE70 /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
+		912DD5CF669A1B8EB0F5734C /* OnboardingMigrationModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingMigrationModelTests.swift; sourceTree = "<group>"; };
 		915561BEEE49F5E27F4B0D40 /* OnboardingWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWindowController.swift; sourceTree = "<group>"; };
 		920C9CA81449FA23CEC17EF6 /* SandboxFilesTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxFilesTab.swift; sourceTree = "<group>"; };
 		9234FC5BCCDDCBF441A94880 /* UpdaterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterDelegate.swift; sourceTree = "<group>"; };
+		93492ACC2F34E108901582CF /* OnboardingMigrationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingMigrationModel.swift; sourceTree = "<group>"; };
 		93968609F8E058EAC838DD18 /* UpdaterSettingsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterSettingsModel.swift; sourceTree = "<group>"; };
 		9467D1D1EA60DDF80414B20B /* ContainerListModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerListModels.swift; sourceTree = "<group>"; };
 		95F313C9C7AA84A964728D44 /* AppDelegate+Telemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Telemetry.swift"; sourceTree = "<group>"; };
@@ -429,6 +435,7 @@
 		A2B6587D59B9EFA18E51A3F3 /* ImagesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesViewModelTests.swift; sourceTree = "<group>"; };
 		A2B92BFA23F4133B8488DDD8 /* Local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Local.xcconfig; sourceTree = "<group>"; };
 		A37BB3605830EBE3A1625452 /* PodModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodModel.swift; sourceTree = "<group>"; };
+		A40D34F775F57891973F6945 /* DockerContextManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockerContextManagerTests.swift; sourceTree = "<group>"; };
 		A45A5AAA9B74A59E7543D8D0 /* LocalRootFSOutlineCoordinator+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalRootFSOutlineCoordinator+Actions.swift"; sourceTree = "<group>"; };
 		A517313E1085B62A40075622 /* OnboardingWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWindowControllerTests.swift; sourceTree = "<group>"; };
 		A70BE1C3890C5F6A96C6BCBD /* ContainersViewModel+GRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContainersViewModel+GRPC.swift"; sourceTree = "<group>"; };
@@ -497,6 +504,7 @@
 		E37F8C85EB27987F81FFB5F4 /* KubernetesState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KubernetesState.swift; sourceTree = "<group>"; };
 		E38681FE9A98E55B1608E662 /* SandboxEventsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxEventsTab.swift; sourceTree = "<group>"; };
 		E3A8FF41635473729BF0A36E /* StatusBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBadge.swift; sourceTree = "<group>"; };
+		E5F0BF05531582B5E276A5E2 /* OnboardingMigrationPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingMigrationPage.swift; sourceTree = "<group>"; };
 		E610512C9106BB92A47DC044 /* ContainersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainersViewModelTests.swift; sourceTree = "<group>"; };
 		E8632512053E9C750CAA97F9 /* MachineTerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachineTerminalSession.swift; sourceTree = "<group>"; };
 		EA6DBFBB43078F295AFE54C0 /* PerformanceTracing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTracing.swift; sourceTree = "<group>"; };
@@ -869,6 +877,8 @@
 		7D67538045DC5ABA446A6F68 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
+				93492ACC2F34E108901582CF /* OnboardingMigrationModel.swift */,
+				E5F0BF05531582B5E276A5E2 /* OnboardingMigrationPage.swift */,
 				747AB46D7603C23FB9112444 /* OnboardingView.swift */,
 			);
 			path = Onboarding;
@@ -1128,6 +1138,7 @@
 				DE7E377F9D8C89E24989DE3D /* ContentViewColumnLayoutTests.swift */,
 				6DFE1C88F20E40C1A36A384C /* CreateOperationErrorTests.swift */,
 				F5B3B3C54B6D49C6198E9E26 /* DeepLinkTests.swift */,
+				A40D34F775F57891973F6945 /* DockerContextManagerTests.swift */,
 				06DFFB59D72F27F14A233B81 /* DockerEventMonitorTests.swift */,
 				27130DDA57D2645C7E81D75D /* GuestDataMountTests.swift */,
 				738233A82C7BAA825F73EE2F /* GuestExportFixture.swift */,
@@ -1145,6 +1156,7 @@
 				2110402B2013A53E306B4E43 /* MainWindowControllerTests.swift */,
 				0FA3C6B6F10198DFC435A33E /* NetworkDetailViewControllerTests.swift */,
 				FA27F4AC273B14038EDB6593 /* NetworksListViewControllerTests.swift */,
+				912DD5CF669A1B8EB0F5734C /* OnboardingMigrationModelTests.swift */,
 				A517313E1085B62A40075622 /* OnboardingWindowControllerTests.swift */,
 				B084B3E5BD66E2DA018764E8 /* QuitWindowControllerTests.swift */,
 				EBD1F83B573C40DFA09E5633 /* StatePlaceholderTestSupport.swift */,
@@ -1456,6 +1468,8 @@
 				72CCF0BC7FEAEB988595757C /* NewNetworkSheet.swift in Sources */,
 				B29A0911581DF9A70350B726 /* NewSandboxSheet.swift in Sources */,
 				D745D0D7EF5FF65174C47F28 /* NewVolumeSheet.swift in Sources */,
+				95B02103F5CEC65396806F7E /* OnboardingMigrationModel.swift in Sources */,
+				05EFDA7AAB590520BC711D4C /* OnboardingMigrationPage.swift in Sources */,
 				A9BC7D2040EC032EBBC709E4 /* OnboardingView.swift in Sources */,
 				4C3BC465BFE58BF0D59AFE78 /* OnboardingWindowController.swift in Sources */,
 				97B9638AA9C685C6DB2780B4 /* PerformanceTracing.swift in Sources */,
@@ -1543,6 +1557,7 @@
 				A537498E1D8181BB0230E199 /* ContentViewColumnLayoutTests.swift in Sources */,
 				853F2D06A878BE9A867BE3FD /* CreateOperationErrorTests.swift in Sources */,
 				EE2D38BC76500BF768EEE20F /* DeepLinkTests.swift in Sources */,
+				6C008EEBEEC7101D289DD9D0 /* DockerContextManagerTests.swift in Sources */,
 				8466B000B68A87CEECA6756F /* DockerEventMonitorTests.swift in Sources */,
 				D2AB4B6BF0723EE12A0DBC83 /* GuestDataMountTests.swift in Sources */,
 				D4FFF718B8B6D79B469D2C3C /* GuestExportFixture.swift in Sources */,
@@ -1566,6 +1581,7 @@
 				F6386D2A578AD21E751CFC57 /* OIDCAuthorizationURLBuilderTests.swift in Sources */,
 				D6C6DEA33D73FF969786C018 /* OIDCClientConfigurationTests.swift in Sources */,
 				B6AB384B22968963098E96F3 /* OIDCClientTests.swift in Sources */,
+				4DF1A85E96002569D24CCF66 /* OnboardingMigrationModelTests.swift in Sources */,
 				DB5CE5663EE824474F0739FF /* OnboardingWindowControllerTests.swift in Sources */,
 				98E7A55FC92F874A28D762FD /* PKCETests.swift in Sources */,
 				D4ECBBCAC3D4631041F292D5 /* QuitWindowControllerTests.swift in Sources */,

--- a/ArcBox/App/AppDelegate.swift
+++ b/ArcBox/App/AppDelegate.swift
@@ -63,6 +63,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         {
             return coordinator?.canUseMainInterface == true
         }
+        if menuItem.action == #selector(showMigrationAssistant(_:)) {
+            return coordinator?.canShowMigrationAssistant == true
+        }
         return true
     }
 
@@ -80,6 +83,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 
     @objc private func showGettingStarted(_ sender: Any?) {
         coordinator?.showGettingStarted()
+    }
+
+    @objc private func showMigrationAssistant(_ sender: Any?) {
+        coordinator?.showMigrationAssistant()
     }
 
     private func installMainMenu() {
@@ -230,6 +237,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
             item(
                 "Getting Started with ArcBox",
                 action: #selector(showGettingStarted(_:))
+            ))
+        menu.addItem(
+            item(
+                "Migrate from Docker Desktop or OrbStack…",
+                action: #selector(showMigrationAssistant(_:))
             ))
         return menu
     }

--- a/ArcBox/App/ApplicationCoordinator.swift
+++ b/ArcBox/App/ApplicationCoordinator.swift
@@ -35,6 +35,7 @@ final class ApplicationCoordinator: NSObject {
     private var mainWindowController: MainWindowController?
     private var onboardingWindowController: OnboardingWindowController?
     private var gettingStartedWindowController: OnboardingWindowController?
+    private var migrationWindowController: OnboardingWindowController?
     private var settingsWindowController: SettingsWindowController?
     private var statusItemController: StatusItemController?
     private var quitWindowController: QuitWindowController?
@@ -49,6 +50,8 @@ final class ApplicationCoordinator: NSObject {
     private var isOnboarding: Bool
     private var deepLinksConfigured = false
     private var started = false
+    private var isMigrationExecuting = false
+    private var migrationCompletionWaiter: CheckedContinuation<Void, Never>?
     private(set) var isTerminating = false
 
     override init() {
@@ -71,6 +74,10 @@ final class ApplicationCoordinator: NSObject {
 
     var canUseMainInterface: Bool {
         !isTerminating && !isOnboarding
+    }
+
+    var canShowMigrationAssistant: Bool {
+        canUseMainInterface && startupOrchestrator?.isReady == true
     }
 
     func start() {
@@ -169,6 +176,10 @@ final class ApplicationCoordinator: NSObject {
                     orchestrator: orchestrator,
                     initialStep: .welcome,
                     isReplay: true,
+                    clientProvider: { [weak self] in self?.arcboxClient },
+                    onMigrationActivityChanged: { [weak self] in
+                        self?.migrationActivityChanged($0)
+                    },
                     onStart: {},
                     onComplete: { [weak self] in
                         self?.gettingStartedWindowController?.window?.performClose(nil)
@@ -185,6 +196,45 @@ final class ApplicationCoordinator: NSObject {
 
         activate()
         gettingStartedWindowController?.show()
+    }
+
+    func showMigrationAssistant() {
+        guard
+            canUseMainInterface,
+            let orchestrator = startupOrchestrator,
+            orchestrator.isReady
+        else {
+            return
+        }
+
+        if migrationWindowController == nil {
+            let host = NSHostingController(
+                rootView: OnboardingView(
+                    orchestrator: orchestrator,
+                    initialStep: .migration,
+                    isReplay: true,
+                    clientProvider: { [weak self] in self?.arcboxClient },
+                    onMigrationActivityChanged: { [weak self] in
+                        self?.migrationActivityChanged($0)
+                    },
+                    onStart: {},
+                    onComplete: { [weak self] in
+                        self?.closeMigrationAssistant()
+                    },
+                    onQuit: {}
+                ))
+            migrationWindowController = OnboardingWindowController(
+                title: "Migrate to ArcBox",
+                contentViewController: host,
+                allowsClosing: false,
+                onClose: { [weak self] in
+                    self?.closeMigrationAssistant()
+                }
+            )
+        }
+
+        activate()
+        migrationWindowController?.show()
     }
 
     func checkForUpdates() {
@@ -224,6 +274,7 @@ final class ApplicationCoordinator: NSObject {
     }
 
     func shutdown() async {
+        await waitForMigrationCompletion()
         startupTask?.cancel()
         await startupOrchestrator?.cancelForTermination()
         await startupTask?.value
@@ -307,6 +358,10 @@ final class ApplicationCoordinator: NSObject {
                 rootView: OnboardingView(
                     orchestrator: orchestrator,
                     initialStep: initialStep ?? .welcome,
+                    clientProvider: { [weak self] in self?.arcboxClient },
+                    onMigrationActivityChanged: { [weak self] in
+                        self?.migrationActivityChanged($0)
+                    },
                     onStart: { [weak self] in
                         self?.startRuntimeIfNeeded(allowingAdministratorPrompt: true)
                     },
@@ -341,6 +396,47 @@ final class ApplicationCoordinator: NSObject {
         statusItemController?.setVisible(lastShowInMenuBar)
         showMainWindow()
         configureDeepLinks()
+    }
+
+    private func closeMigrationAssistant() {
+        guard !isMigrationExecuting else {
+            guard
+                let window = migrationWindowController?.window,
+                window.attachedSheet == nil
+            else {
+                return
+            }
+
+            let alert = NSAlert()
+            alert.messageText = "Migration in Progress"
+            alert.informativeText =
+                "Keep ArcBox open until the migration finishes to avoid leaving resources "
+                + "partially migrated."
+            alert.addButton(withTitle: "Continue Migration")
+            alert.beginSheetModal(for: window)
+            return
+        }
+
+        migrationWindowController?.window?.orderOut(nil)
+        migrationWindowController = nil
+    }
+
+    private func migrationActivityChanged(_ isExecuting: Bool) {
+        isMigrationExecuting = isExecuting
+        guard !isExecuting else { return }
+        migrationCompletionWaiter?.resume()
+        migrationCompletionWaiter = nil
+    }
+
+    private func waitForMigrationCompletion() async {
+        guard isMigrationExecuting else { return }
+        await withCheckedContinuation { continuation in
+            if isMigrationExecuting {
+                migrationCompletionWaiter = continuation
+            } else {
+                continuation.resume()
+            }
+        }
     }
 
     private func observeStartupPhase() {

--- a/ArcBox/Integrations/Docker/DockerCLIResolver.swift
+++ b/ArcBox/Integrations/Docker/DockerCLIResolver.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum DockerCLIResolver {
+nonisolated enum DockerCLIResolver {
     private static let dockerSearchPaths = [
         "/usr/local/bin/docker",
         "/opt/homebrew/bin/docker",

--- a/ArcBox/Integrations/Docker/DockerContextManager.swift
+++ b/ArcBox/Integrations/Docker/DockerContextManager.swift
@@ -1,6 +1,44 @@
 import Foundation
 import OSLog
 
+nonisolated struct DockerMigrationSource: Equatable, Sendable {
+    enum Kind: String, Sendable {
+        case dockerDesktop = "docker-desktop"
+        case orbStack = "orbstack"
+
+        var displayName: String {
+            switch self {
+            case .dockerDesktop: "Docker Desktop"
+            case .orbStack: "OrbStack"
+            }
+        }
+    }
+
+    let kind: Kind
+    let contextName: String
+    let socketPath: String
+}
+
+nonisolated struct DockerContextDescription: Decodable, Equatable, Sendable {
+    let current: Bool
+    let dockerEndpoint: String
+    let name: String
+
+    enum CodingKeys: String, CodingKey {
+        case current = "Current"
+        case dockerEndpoint = "DockerEndpoint"
+        case name = "Name"
+    }
+}
+
+nonisolated private struct DockerContextInspectionError: LocalizedError {
+    let errorDescription: String?
+
+    init(_ message: String) {
+        errorDescription = message
+    }
+}
+
 /// Manages Docker CLI context switching to point at the ArcBox daemon socket.
 ///
 /// When enabled, sets the Docker context on app startup and restores the
@@ -24,6 +62,176 @@ nonisolated enum DockerContextManager {
     private static var arcboxContextName: String {
         let profile = Bundle.main.object(forInfoDictionaryKey: "ArcBoxProfile") as? String
         return profile?.caseInsensitiveCompare("development") == .orderedSame ? "arcbox-dev" : "arcbox"
+    }
+
+    /// Finds a Docker Desktop or OrbStack candidate without relying on the
+    /// current context, which ArcBox may already have switched to itself.
+    static func detectMigrationSource() async throws -> DockerMigrationSource? {
+        let task = Task.detached(priority: .utility) { () throws -> DockerMigrationSource? in
+            let contexts = try readDockerContexts()
+            let previousContext = UserDefaults.standard.string(forKey: previousContextKey)
+            return try selectMigrationSource(
+                from: contexts,
+                previousContext: previousContext,
+                homeDirectory: FileManager.default.homeDirectoryForCurrentUser.path,
+                socketExists: FileManager.default.fileExists(atPath:)
+            )
+        }
+        return try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
+    static func decodeDockerContexts(_ data: Data) throws -> [DockerContextDescription] {
+        try data.split(separator: UInt8(ascii: "\n")).map { line in
+            try JSONDecoder().decode(DockerContextDescription.self, from: Data(line))
+        }
+    }
+
+    static func selectMigrationSource(
+        from contexts: [DockerContextDescription],
+        previousContext: String?,
+        homeDirectory: String,
+        socketExists: (String) -> Bool
+    ) throws -> DockerMigrationSource? {
+        let candidates = contexts.compactMap { context -> DockerMigrationSource? in
+            guard
+                let source = migrationSource(from: context, homeDirectory: homeDirectory),
+                socketExists(source.socketPath)
+            else {
+                return nil
+            }
+            return source
+        }
+
+        if let current = contexts.first(where: \.current),
+            let source = candidates.first(where: { $0.contextName == current.name })
+        {
+            return source
+        }
+        if let previousContext,
+            let source = candidates.first(where: { $0.contextName == previousContext })
+        {
+            return source
+        }
+
+        let unique = Dictionary(
+            candidates.map { ("\($0.kind.rawValue):\($0.socketPath)", $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        guard unique.count <= 1 else {
+            throw DockerContextInspectionError(
+                "Both Docker Desktop and OrbStack are available. "
+                    + "Make the environment you want to migrate the current Docker context."
+            )
+        }
+        return unique.values.first
+    }
+
+    private static func migrationSource(
+        from context: DockerContextDescription,
+        homeDirectory: String
+    ) -> DockerMigrationSource? {
+        guard context.dockerEndpoint.hasPrefix("unix://") else { return nil }
+
+        var socketPath = String(context.dockerEndpoint.dropFirst("unix://".count))
+        if socketPath.hasPrefix("~/") {
+            socketPath = "\(homeDirectory)/\(socketPath.dropFirst(2))"
+        }
+        socketPath = URL(fileURLWithPath: socketPath).standardizedFileURL.path
+
+        let knownPaths = migrationSocketPaths(homeDirectory: homeDirectory)
+
+        let kind: DockerMigrationSource.Kind
+        switch socketPath {
+        case knownPaths.dockerDesktop:
+            kind = .dockerDesktop
+        case knownPaths.orbStack:
+            kind = .orbStack
+        default:
+            return nil
+        }
+
+        return DockerMigrationSource(
+            kind: kind,
+            contextName: context.name,
+            socketPath: socketPath
+        )
+    }
+
+    private static func readDockerContexts() throws -> [DockerContextDescription] {
+        guard let dockerCLI = DockerCLIResolver.findDockerCLI() else {
+            let paths = migrationSocketPaths(
+                homeDirectory: FileManager.default.homeDirectoryForCurrentUser.path
+            )
+            if [paths.dockerDesktop, paths.orbStack].contains(
+                where: FileManager.default.fileExists(atPath:)
+            ) {
+                throw DockerContextInspectionError(
+                    "A supported Docker environment is running, but the Docker CLI was not found."
+                )
+            }
+            return []
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: dockerCLI)
+        process.arguments = ["context", "ls", "--format", "{{json .}}"]
+        let output = Pipe()
+        let error = Pipe()
+        process.standardOutput = output
+        process.standardError = error
+
+        do {
+            try process.run()
+        } catch {
+            logger.warning(
+                "Unable to inspect Docker contexts: \(error.localizedDescription, privacy: .private)"
+            )
+            throw error
+        }
+
+        let deadline = Date().addingTimeInterval(3)
+        while process.isRunning, !Task.isCancelled, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        let timedOut = process.isRunning && !Task.isCancelled
+        if process.isRunning {
+            process.terminate()
+            process.waitUntilExit()
+        }
+        try Task.checkCancellation()
+        if timedOut {
+            throw DockerContextInspectionError("Docker context inspection timed out.")
+        }
+        guard process.terminationStatus == 0 else {
+            let message =
+                String(
+                    data: error.fileHandleForReading.readDataToEndOfFile(),
+                    encoding: .utf8
+                ) ?? ""
+            logger.warning("Docker context inspection failed: \(message, privacy: .private)")
+            let detail = message.trimmingCharacters(in: .whitespacesAndNewlines)
+            throw DockerContextInspectionError(
+                detail.isEmpty ? "Docker context inspection failed." : detail
+            )
+        }
+
+        return try decodeDockerContexts(output.fileHandleForReading.readDataToEndOfFile())
+    }
+
+    private static func migrationSocketPaths(
+        homeDirectory: String
+    ) -> (
+        dockerDesktop: String, orbStack: String
+    ) {
+        let home = URL(fileURLWithPath: homeDirectory)
+        return (
+            home.appendingPathComponent(".docker/run/docker.sock").standardizedFileURL.path,
+            home.appendingPathComponent(".orbstack/run/docker.sock").standardizedFileURL.path
+        )
     }
 
     /// Switch the Docker CLI context to use ArcBox's socket.

--- a/ArcBox/Views/Onboarding/OnboardingMigrationModel.swift
+++ b/ArcBox/Views/Onboarding/OnboardingMigrationModel.swift
@@ -1,0 +1,360 @@
+import ArcBoxClient
+import Foundation
+import GRPCCore
+import Observation
+
+struct OnboardingMigrationPreview: Equatable {
+    let source: DockerMigrationSource
+    let daemonName: String
+    let serverVersion: String
+    let imageCount: UInt32
+    let volumeCount: UInt32
+    let networkCount: UInt32
+    let containerCount: UInt32
+    let warnings: [String]
+    let unsupportedResources: [String]
+    let replacementsRequired: Bool
+    let stopsSourceContainers: Bool
+
+    init(
+        source: DockerMigrationSource,
+        response: Arcbox_V1_PrepareMigrationResponse
+    ) {
+        self.source = source
+        daemonName = response.plan.source.daemonName
+        serverVersion = response.plan.source.serverVersion
+        imageCount = response.imageCount
+        volumeCount = response.volumeCount
+        networkCount = response.networkCount
+        containerCount = response.containerCount
+        warnings = response.warnings
+        unsupportedResources = response.unsupportedResources
+        replacementsRequired = response.replacementsRequired
+        stopsSourceContainers = !response.plan.blockers.isEmpty
+    }
+
+    var totalResourceCount: UInt64 {
+        UInt64(imageCount)
+            + UInt64(volumeCount)
+            + UInt64(networkCount)
+            + UInt64(containerCount)
+    }
+
+    var canRun: Bool {
+        unsupportedResources.isEmpty
+    }
+
+    var confirmationMessages: [String] {
+        var messages: [String] = []
+        if replacementsRequired {
+            messages.append("Matching ArcBox resources will be replaced.")
+        }
+        if stopsSourceContainers {
+            messages.append("Source containers using migrated volumes will be stopped.")
+        }
+        return messages
+    }
+
+    func matches(_ response: Arcbox_V1_PrepareMigrationResponse) -> Bool {
+        response.sourceKind == source.kind.rawValue
+            && URL(fileURLWithPath: response.sourceSocketPath).standardizedFileURL.path
+                == URL(fileURLWithPath: source.socketPath).standardizedFileURL.path
+            && response.imageCount == imageCount
+            && response.volumeCount == volumeCount
+            && response.networkCount == networkCount
+            && response.containerCount == containerCount
+            && response.replacementsRequired == replacementsRequired
+            && Set(response.warnings) == Set(warnings)
+    }
+}
+
+struct OnboardingMigrationProgress: Equatable {
+    let phase: String
+    let resource: String
+    let message: String
+    let completed: UInt32
+    let total: UInt32
+
+    var fractionCompleted: Double? {
+        guard total > 0 else { return nil }
+        return min(Double(completed) / Double(total), 1)
+    }
+}
+
+@Observable
+@MainActor
+final class OnboardingMigrationModel {
+    enum State: Equatable {
+        case idle
+        case checking
+        case unavailable
+        case empty(DockerMigrationSource)
+        case review(OnboardingMigrationPreview)
+        case preparing(OnboardingMigrationPreview)
+        case migrating(OnboardingMigrationPreview, OnboardingMigrationProgress)
+        case completed(OnboardingMigrationPreview, warnings: [String])
+        case failed(OnboardingMigrationPreview?, message: String)
+
+        var isExecuting: Bool {
+            switch self {
+            case .preparing, .migrating:
+                true
+            default:
+                false
+            }
+        }
+    }
+
+    private(set) var state: State = .idle {
+        didSet {
+            guard oldValue.isExecuting != state.isExecuting else { return }
+            onMigrationActivityChanged(state.isExecuting)
+        }
+    }
+
+    @ObservationIgnored
+    private let clientProvider: @MainActor () -> ArcBoxClient?
+
+    @ObservationIgnored
+    private let onMigrationActivityChanged: @MainActor (Bool) -> Void
+
+    private static var prepareCallOptions: CallOptions {
+        var options = CallOptions.defaults
+        options.timeout = .seconds(120)
+        return options
+    }
+
+    init(
+        clientProvider: @escaping @MainActor () -> ArcBoxClient?,
+        onMigrationActivityChanged: @escaping @MainActor (Bool) -> Void
+    ) {
+        self.clientProvider = clientProvider
+        self.onMigrationActivityChanged = onMigrationActivityChanged
+    }
+
+    func loadPreview() async {
+        if case .checking = state { return }
+        state = .checking
+
+        let source: DockerMigrationSource
+        do {
+            guard let detectedSource = try await DockerContextManager.detectMigrationSource()
+            else {
+                state = .unavailable
+                return
+            }
+            source = detectedSource
+        } catch is CancellationError {
+            return
+        } catch {
+            state = .failed(nil, message: error.localizedDescription)
+            return
+        }
+        guard !Task.isCancelled else { return }
+        guard let client = clientProvider() else {
+            state = .failed(nil, message: "ArcBox runtime is not ready.")
+            return
+        }
+
+        var request = Arcbox_V1_PrepareMigrationRequest()
+        request.sourceKind = source.kind.rawValue
+        request.sourceSocketPath = source.socketPath
+        request.allowReplacements = true
+        request.dryRun = true
+
+        do {
+            let response = try await client.migration.prepareMigration(
+                request,
+                options: Self.prepareCallOptions
+            )
+            guard !Task.isCancelled else { return }
+            guard response.hasPlan else {
+                state = .failed(
+                    nil,
+                    message: "ArcBox returned an incomplete migration preview."
+                )
+                return
+            }
+
+            let preview = OnboardingMigrationPreview(source: source, response: response)
+            if preview.totalResourceCount == 0 && preview.unsupportedResources.isEmpty {
+                state = .empty(source)
+            } else {
+                state = .review(preview)
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            state = .failed(nil, message: ArcBoxClient.userMessage(for: error))
+        }
+    }
+
+    func startMigration() {
+        guard case .review(let preview) = state else { return }
+        state = .preparing(preview)
+        Task { await runMigration(preview) }
+    }
+
+    func retry() {
+        Task { await loadPreview() }
+    }
+
+    private func runMigration(_ preview: OnboardingMigrationPreview) async {
+        guard preview.canRun else { return }
+        guard let client = clientProvider() else {
+            state = .failed(preview, message: "ArcBox runtime is not ready.")
+            return
+        }
+
+        let prepared: Arcbox_V1_PrepareMigrationResponse
+        do {
+            var prepareRequest = Arcbox_V1_PrepareMigrationRequest()
+            prepareRequest.sourceKind = preview.source.kind.rawValue
+            prepareRequest.sourceSocketPath = preview.source.socketPath
+            prepareRequest.allowReplacements = true
+
+            prepared = try await client.migration.prepareMigration(
+                prepareRequest,
+                options: Self.prepareCallOptions
+            )
+            guard !Task.isCancelled else { return }
+            guard prepared.unsupportedResources.isEmpty else {
+                state = .failed(
+                    nil,
+                    message: prepared.unsupportedResources.joined(separator: "\n")
+                )
+                return
+            }
+            guard preview.matches(prepared) else {
+                state = .failed(
+                    nil,
+                    message:
+                        "The source environment changed after the preview. "
+                        + "Review the updated migration plan before continuing."
+                )
+                return
+            }
+            guard !prepared.planID.isEmpty else {
+                state = .failed(
+                    preview,
+                    message: "ArcBox did not return an executable migration plan."
+                )
+                return
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            state = .failed(preview, message: ArcBoxClient.userMessage(for: error))
+            return
+        }
+
+        var runRequest = Arcbox_V1_RunMigrationRequest()
+        runRequest.planID = prepared.planID
+        runRequest.allowReplacements = true
+
+        state = .migrating(
+            preview,
+            OnboardingMigrationProgress(
+                phase: "prepare",
+                resource: "",
+                message: "Starting migration…",
+                completed: 0,
+                total: 0
+            )
+        )
+
+        await observeMigration(client: client, request: runRequest, preview: preview)
+    }
+
+    private func observeMigration(
+        client: ArcBoxClient,
+        request: Arcbox_V1_RunMigrationRequest,
+        preview: OnboardingMigrationPreview
+    ) async {
+        var retryDelaySeconds: UInt64 = 1
+        while !Task.isCancelled {
+            do {
+                let reachedTerminalEvent = try await client.migration.runMigration(
+                    request
+                ) { response in
+                    for try await event in response.messages {
+                        try Task.checkCancellation()
+                        await self.receive(event, preview: preview)
+                        if event.done { return true }
+                    }
+                    return false
+                }
+                if reachedTerminalEvent { return }
+                retryDelaySeconds = 1
+            } catch let error as RPCError {
+                if error.code == .notFound {
+                    state = .failed(
+                        preview,
+                        message:
+                            "The ArcBox daemon restarted before migration completed. "
+                            + "Review the source environment before trying again."
+                    )
+                    return
+                }
+                guard Self.shouldReconnect(after: error.code) else {
+                    state = .failed(preview, message: ArcBoxClient.userMessage(for: error))
+                    return
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                state = .failed(preview, message: ArcBoxClient.userMessage(for: error))
+                return
+            }
+
+            state = .migrating(
+                preview,
+                OnboardingMigrationProgress(
+                    phase: "reconnecting",
+                    resource: "",
+                    message: "Reconnecting to the migration…",
+                    completed: 0,
+                    total: 0
+                )
+            )
+            do {
+                try await Task.sleep(for: .seconds(retryDelaySeconds))
+            } catch {
+                return
+            }
+            retryDelaySeconds = min(retryDelaySeconds * 2, 8)
+        }
+    }
+
+    nonisolated static func shouldReconnect(after code: RPCError.Code) -> Bool {
+        code == .unavailable
+    }
+
+    private func receive(
+        _ event: Arcbox_V1_RunMigrationEvent,
+        preview: OnboardingMigrationPreview
+    ) {
+        if event.done {
+            if event.success {
+                state = .completed(preview, warnings: event.warnings)
+            } else {
+                state = .failed(
+                    preview,
+                    message: event.message.isEmpty ? "Migration failed." : event.message
+                )
+            }
+            return
+        }
+
+        state = .migrating(
+            preview,
+            OnboardingMigrationProgress(
+                phase: event.phase,
+                resource: event.resource,
+                message: event.message,
+                completed: event.completed,
+                total: event.total
+            )
+        )
+    }
+}

--- a/ArcBox/Views/Onboarding/OnboardingMigrationPage.swift
+++ b/ArcBox/Views/Onboarding/OnboardingMigrationPage.swift
@@ -1,0 +1,372 @@
+import AppKit
+import SwiftUI
+
+struct OnboardingMigrationPage: View {
+    let state: OnboardingMigrationModel.State
+
+    @AccessibilityFocusState private var headingFocused: Bool
+
+    var body: some View {
+        Group {
+            switch state {
+            case .idle, .checking:
+                checkingPage
+            case .unavailable:
+                unavailablePage
+            case .empty(let source):
+                emptyPage(source)
+            case .review(let preview):
+                reviewPage(preview)
+            case .preparing:
+                progressPage(
+                    title: "Preparing migration",
+                    message: "ArcBox is creating an executable migration plan.",
+                    progress: nil
+                )
+            case .migrating(_, let progress):
+                progressPage(
+                    title: "Migrating your Docker environment",
+                    message: progress.message,
+                    progress: progress
+                )
+            case .completed(_, let warnings):
+                completedPage(warnings: warnings)
+            case .failed(_, let message):
+                failedPage(message: message)
+            }
+        }
+        .frame(maxWidth: 536)
+        .onAppear {
+            headingFocused = true
+        }
+        .onChange(of: pageIdentity) {
+            headingFocused = true
+        }
+    }
+
+    private var checkingPage: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .controlSize(.large)
+
+            pageTitle("Checking your Docker environment")
+
+            Text("Looking for workloads that can be brought into ArcBox.")
+                .font(.system(size: 14))
+                .foregroundStyle(AppColors.textSecondary)
+        }
+    }
+
+    private var unavailablePage: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "shippingbox")
+                .font(.system(size: 48))
+                .foregroundStyle(AppColors.textSecondary)
+                .accessibilityHidden(true)
+
+            pageTitle("No Docker environment to migrate")
+
+            Text("You can start using ArcBox now.")
+                .font(.system(size: 14))
+                .foregroundStyle(AppColors.textSecondary)
+        }
+    }
+
+    private func emptyPage(_ source: DockerMigrationSource) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "shippingbox")
+                .font(.system(size: 48))
+                .foregroundStyle(AppColors.textSecondary)
+                .accessibilityHidden(true)
+
+            pageTitle("Nothing to migrate")
+
+            Text("No supported resources were found in \(source.kind.displayName).")
+                .font(.system(size: 14))
+                .foregroundStyle(AppColors.textSecondary)
+        }
+    }
+
+    private func reviewPage(_ preview: OnboardingMigrationPreview) -> some View {
+        VStack(spacing: 14) {
+            Image(systemName: "shippingbox.and.arrow.backward")
+                .font(.system(size: 42))
+                .foregroundStyle(Color.accentColor)
+                .accessibilityHidden(true)
+
+            VStack(spacing: 5) {
+                pageTitle("Import your Docker environment")
+
+                Text(
+                    "ArcBox found \(preview.totalResourceCount) "
+                        + "resource\(preview.totalResourceCount == 1 ? "" : "s") "
+                        + "in \(preview.source.kind.displayName)."
+                )
+                .font(.system(size: 14))
+                .foregroundStyle(AppColors.textSecondary)
+
+                if !preview.daemonName.isEmpty || !preview.serverVersion.isEmpty {
+                    Text(
+                        [preview.daemonName, preview.serverVersion]
+                            .filter { !$0.isEmpty }
+                            .joined(separator: " · ")
+                    )
+                    .font(.system(size: 11))
+                    .foregroundStyle(AppColors.textMuted)
+                }
+            }
+
+            HStack(spacing: 8) {
+                MigrationCountView("Images", count: preview.imageCount, symbol: "shippingbox")
+                MigrationCountView("Volumes", count: preview.volumeCount, symbol: "externaldrive")
+                MigrationCountView("Networks", count: preview.networkCount, symbol: "network")
+                MigrationCountView(
+                    "Containers",
+                    count: preview.containerCount,
+                    symbol: "cube"
+                )
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("ArcBox copies supported resources without deleting them from the source.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(AppColors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if !preview.confirmationMessages.isEmpty {
+                    MigrationNotice(
+                        title: "Your confirmation is required",
+                        symbol: "exclamationmark.shield.fill",
+                        color: AppColors.warning,
+                        messages: preview.confirmationMessages
+                    )
+                }
+
+                if !preview.unsupportedResources.isEmpty {
+                    MigrationNotice(
+                        title: "Resolve before migrating",
+                        symbol: "xmark.octagon.fill",
+                        color: AppColors.error,
+                        messages: preview.unsupportedResources
+                    )
+                } else if !preview.warnings.isEmpty {
+                    MigrationNotice(
+                        title: "Review before migrating",
+                        symbol: "exclamationmark.triangle.fill",
+                        color: AppColors.warning,
+                        messages: preview.warnings
+                    )
+                }
+            }
+            .padding(14)
+            .background(cardBackground)
+            .overlay(cardBorder)
+        }
+    }
+
+    private func progressPage(
+        title: String,
+        message: String,
+        progress: OnboardingMigrationProgress?
+    ) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "arrow.triangle.2.circlepath")
+                .font(.system(size: 44))
+                .foregroundStyle(Color.accentColor)
+                .symbolEffect(.rotate)
+                .accessibilityHidden(true)
+
+            pageTitle(title)
+
+            VStack(spacing: 8) {
+                if let fraction = progress?.fractionCompleted {
+                    ProgressView(value: fraction)
+                } else {
+                    ProgressView()
+                }
+
+                Text(message.isEmpty ? "Working…" : message)
+                    .font(.system(size: 13))
+                    .foregroundStyle(AppColors.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .onChange(of: message) { _, newMessage in
+                        announceProgress(newMessage)
+                    }
+
+                if let progress {
+                    let detail = [progress.phase, progress.resource]
+                        .filter { !$0.isEmpty }
+                        .joined(separator: " · ")
+                    if !detail.isEmpty {
+                        Text(detail)
+                            .font(.system(size: 11))
+                            .foregroundStyle(AppColors.textMuted)
+                    }
+                }
+            }
+            .frame(width: 420)
+        }
+    }
+
+    private func completedPage(warnings: [String]) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: warnings.isEmpty ? "checkmark.circle.fill" : "checkmark.circle")
+                .font(.system(size: 52))
+                .foregroundStyle(warnings.isEmpty ? AppColors.running : AppColors.warning)
+                .accessibilityHidden(true)
+
+            pageTitle(
+                warnings.isEmpty ? "Migration complete" : "Migration completed with warnings"
+            )
+
+            if warnings.isEmpty {
+                Text("Your Docker resources are ready in ArcBox.")
+                    .font(.system(size: 14))
+                    .foregroundStyle(AppColors.textSecondary)
+            } else {
+                MigrationNotice(
+                    title: "Needs attention",
+                    symbol: "exclamationmark.triangle.fill",
+                    color: AppColors.warning,
+                    messages: warnings
+                )
+                .padding(14)
+                .background(cardBackground)
+                .overlay(cardBorder)
+            }
+        }
+    }
+
+    private func failedPage(message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(AppColors.warning)
+                .accessibilityHidden(true)
+
+            pageTitle("Migration could not be completed")
+
+            Text(message)
+                .font(.system(size: 13))
+                .foregroundStyle(AppColors.textSecondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .fill(AppColors.surfaceCard)
+    }
+
+    private var cardBorder: some View {
+        RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .stroke(AppColors.borderSubtle, lineWidth: 1)
+    }
+
+    private var pageIdentity: PageIdentity {
+        switch state {
+        case .idle, .checking: .checking
+        case .unavailable: .unavailable
+        case .empty: .empty
+        case .review: .review
+        case .preparing: .preparing
+        case .migrating: .migrating
+        case .completed: .completed
+        case .failed: .failed
+        }
+    }
+
+    private func pageTitle(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 24, weight: .semibold))
+            .accessibilityAddTraits(.isHeader)
+            .accessibilityFocused($headingFocused)
+    }
+
+    private func announceProgress(_ message: String) {
+        guard !message.isEmpty, let application = NSApp else { return }
+        NSAccessibility.post(
+            element: application,
+            notification: .announcementRequested,
+            userInfo: [
+                .announcement: message,
+                .priority: NSAccessibilityPriorityLevel.low.rawValue,
+            ]
+        )
+    }
+
+    private enum PageIdentity: Hashable {
+        case checking
+        case unavailable
+        case empty
+        case review
+        case preparing
+        case migrating
+        case completed
+        case failed
+    }
+}
+
+private struct MigrationCountView: View {
+    let title: String
+    let count: UInt32
+    let symbol: String
+
+    init(_ title: String, count: UInt32, symbol: String) {
+        self.title = title
+        self.count = count
+        self.symbol = symbol
+    }
+
+    var body: some View {
+        VStack(spacing: 5) {
+            Image(systemName: symbol)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(Color.accentColor)
+                .accessibilityHidden(true)
+            Text(count.formatted())
+                .font(.system(size: 16, weight: .semibold))
+            Text(title)
+                .font(.system(size: 10))
+                .foregroundStyle(AppColors.textSecondary)
+        }
+        .frame(maxWidth: .infinity, minHeight: 66)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(AppColors.surfaceCard)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(AppColors.borderSubtle, lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct MigrationNotice: View {
+    let title: String
+    let symbol: String
+    let color: Color
+    let messages: [String]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label(title, systemImage: symbol)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(color)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(Array(messages.enumerated()), id: \.offset) { _, message in
+                        Text("• \(message)")
+                            .font(.system(size: 11))
+                            .foregroundStyle(AppColors.textSecondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+            .frame(maxHeight: 76)
+        }
+    }
+}

--- a/ArcBox/Views/Onboarding/OnboardingView.swift
+++ b/ArcBox/Views/Onboarding/OnboardingView.swift
@@ -6,6 +6,7 @@ enum OnboardingStep: Hashable {
     case welcome
     case permission
     case setup
+    case migration
 }
 
 struct OnboardingView: View {
@@ -19,11 +20,14 @@ struct OnboardingView: View {
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @State private var step: OnboardingStep
     @State private var movingForward = true
+    @State private var migration: OnboardingMigrationModel
 
     init(
         orchestrator: StartupOrchestrator,
         initialStep: OnboardingStep,
         isReplay: Bool = false,
+        clientProvider: @escaping @MainActor () -> ArcBoxClient?,
+        onMigrationActivityChanged: @escaping @MainActor (Bool) -> Void,
         onStart: @escaping () -> Void,
         onComplete: @escaping () -> Void,
         onQuit: @escaping () -> Void
@@ -34,6 +38,12 @@ struct OnboardingView: View {
         self.onComplete = onComplete
         self.onQuit = onQuit
         _step = State(initialValue: initialStep)
+        _migration = State(
+            initialValue: OnboardingMigrationModel(
+                clientProvider: clientProvider,
+                onMigrationActivityChanged: onMigrationActivityChanged
+            )
+        )
     }
 
     var body: some View {
@@ -65,6 +75,18 @@ struct OnboardingView: View {
                 Rectangle().fill(.regularMaterial)
             }
         }
+        .task(id: shouldLoadMigrationPreview) {
+            guard shouldLoadMigrationPreview else { return }
+            await migration.loadPreview()
+
+            guard step == .setup else { return }
+            switch migration.state {
+            case .review, .failed:
+                move(to: .migration, forward: true)
+            default:
+                break
+            }
+        }
     }
 
     @ViewBuilder
@@ -76,6 +98,8 @@ struct OnboardingView: View {
             permissionPage
         case .setup:
             setupPage
+        case .migration:
+            OnboardingMigrationPage(state: migration.state)
         }
     }
 
@@ -211,20 +235,36 @@ struct OnboardingView: View {
     @ViewBuilder
     private var setupPage: some View {
         if orchestrator.isReady {
-            VStack(spacing: 16) {
-                Image(systemName: "checkmark.circle.fill")
-                    .font(.system(size: 52))
-                    .foregroundStyle(AppColors.running)
-                    .accessibilityHidden(true)
+            switch migration.state {
+            case .idle, .checking:
+                VStack(spacing: 16) {
+                    ProgressView()
+                        .controlSize(.large)
 
-                Text("ArcBox is ready")
-                    .font(.system(size: 24, weight: .semibold))
+                    Text("Checking your Docker environment")
+                        .font(.system(size: 24, weight: .semibold))
 
-                Text("ArcBox and its local runtime are ready to use.")
-                    .font(.system(size: 14))
-                    .foregroundStyle(AppColors.textSecondary)
+                    Text("Looking for workloads that can be brought into ArcBox.")
+                        .font(.system(size: 14))
+                        .foregroundStyle(AppColors.textSecondary)
+                }
+                .transition(.opacity)
+            default:
+                VStack(spacing: 16) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 52))
+                        .foregroundStyle(AppColors.running)
+                        .accessibilityHidden(true)
+
+                    Text("ArcBox is ready")
+                        .font(.system(size: 24, weight: .semibold))
+
+                    Text("ArcBox and its local runtime are ready to use.")
+                        .font(.system(size: 14))
+                        .foregroundStyle(AppColors.textSecondary)
+                }
+                .transition(.opacity)
             }
-            .transition(.opacity)
         } else {
             VStack(spacing: 14) {
                 Image(nsImage: NSApp.applicationIconImage)
@@ -281,14 +321,89 @@ struct OnboardingView: View {
                 }
             case .setup:
                 if orchestrator.isReady {
-                    Spacer()
-                    primaryButton("Open ArcBox", action: onComplete)
+                    switch migration.state {
+                    case .idle, .checking:
+                        Button("Skip for Now", action: onComplete)
+                            .buttonStyle(.bordered)
+                            .controlSize(.large)
+                        Spacer()
+                        Button("Checking Docker…") {}
+                            .buttonStyle(.borderedProminent)
+                            .controlSize(.large)
+                            .frame(minWidth: 132)
+                            .disabled(true)
+                    case .review, .failed:
+                        Spacer()
+                        Button("Continue") {}
+                            .buttonStyle(.borderedProminent)
+                            .controlSize(.large)
+                            .frame(minWidth: 132)
+                            .disabled(true)
+                    default:
+                        Spacer()
+                        primaryButton("Open ArcBox", action: onComplete)
+                    }
                 } else {
                     Button("Quit ArcBox", action: onQuit)
                         .buttonStyle(.bordered)
                         .controlSize(.large)
                     Spacer()
                 }
+            case .migration:
+                migrationFooter
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var migrationFooter: some View {
+        switch migration.state {
+        case .idle, .checking:
+            Button("Skip for Now", action: onComplete)
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+            Spacer()
+            Button("Checking…") {}
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .frame(minWidth: 132)
+                .disabled(true)
+        case .unavailable, .empty:
+            Spacer()
+            primaryButton("Open ArcBox", action: onComplete)
+        case .review(let preview):
+            Button("Not Now", action: onComplete)
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .keyboardShortcut(.cancelAction)
+            Spacer()
+            if preview.canRun {
+                primaryButton("Migrate Now") {
+                    migration.startMigration()
+                }
+            } else {
+                primaryButton("Check Again") {
+                    Task { await migration.loadPreview() }
+                }
+            }
+        case .preparing, .migrating:
+            Spacer()
+            Button("Migrating…") {}
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .frame(minWidth: 132)
+                .disabled(true)
+        case .completed:
+            Spacer()
+            primaryButton("Open ArcBox", action: onComplete)
+        case .failed:
+            Button("Not Now", action: onComplete)
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .keyboardShortcut(.cancelAction)
+            Spacer()
+            primaryButton("Retry") {
+                migration.retry()
             }
         }
     }
@@ -309,6 +424,10 @@ struct OnboardingView: View {
             insertion: .offset(x: movingForward ? 12 : -12).combined(with: .opacity),
             removal: .offset(x: movingForward ? -12 : 12).combined(with: .opacity)
         )
+    }
+
+    private var shouldLoadMigrationPreview: Bool {
+        orchestrator.isReady && (!isReplay || step == .migration)
     }
 
     private func capabilityCell(_ title: String, symbol: String, detail: String) -> some View {

--- a/ArcBoxTests/DockerContextManagerTests.swift
+++ b/ArcBoxTests/DockerContextManagerTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import XCTest
+
+@testable import ArcBox
+
+final class DockerContextManagerTests: XCTestCase {
+    func testSelectsPreviousExternalContextAfterArcBoxBecomesCurrent() throws {
+        let data = Data(
+            """
+            {"Current":true,"DockerEndpoint":"unix:///Users/test/.arcbox/run/docker.sock","Name":"arcbox"}
+            {"Current":false,"DockerEndpoint":"unix:///var/run/docker.sock","Name":"default"}
+            {"Current":false,"DockerEndpoint":"unix:///Users/test/.orbstack/run/docker.sock","Name":"orbstack"}
+            """.utf8
+        )
+
+        let source = try DockerContextManager.selectMigrationSource(
+            from: try DockerContextManager.decodeDockerContexts(data),
+            previousContext: "orbstack",
+            homeDirectory: "/Users/test",
+            socketExists: { $0 == "/Users/test/.orbstack/run/docker.sock" }
+        )
+
+        XCTAssertEqual(
+            source,
+            DockerMigrationSource(
+                kind: .orbStack,
+                contextName: "orbstack",
+                socketPath: "/Users/test/.orbstack/run/docker.sock"
+            )
+        )
+    }
+
+    func testRejectsMalformedContextOutput() {
+        XCTAssertThrowsError(
+            try DockerContextManager.decodeDockerContexts(
+                Data("{not-json}\n".utf8)
+            )
+        )
+    }
+
+    func testIgnoresDefaultRemoteAndStaleContexts() {
+        let contexts = [
+            DockerContextDescription(
+                current: true,
+                dockerEndpoint: "unix:///var/run/docker.sock",
+                name: "default"
+            ),
+            DockerContextDescription(
+                current: false,
+                dockerEndpoint: "ssh://docker.example.com",
+                name: "remote"
+            ),
+            DockerContextDescription(
+                current: false,
+                dockerEndpoint: "unix:///Users/test/.docker/run/docker.sock",
+                name: "desktop-linux"
+            ),
+        ]
+
+        XCTAssertNil(
+            try DockerContextManager.selectMigrationSource(
+                from: contexts,
+                previousContext: nil,
+                homeDirectory: "/Users/test",
+                socketExists: { _ in false }
+            )
+        )
+    }
+
+    func testRejectsAmbiguousExternalContexts() {
+        let contexts = [
+            DockerContextDescription(
+                current: false,
+                dockerEndpoint: "unix:///Users/test/.docker/run/docker.sock",
+                name: "desktop-linux"
+            ),
+            DockerContextDescription(
+                current: false,
+                dockerEndpoint: "unix:///Users/test/.orbstack/run/docker.sock",
+                name: "orbstack"
+            ),
+        ]
+
+        XCTAssertThrowsError(
+            try DockerContextManager.selectMigrationSource(
+                from: contexts,
+                previousContext: nil,
+                homeDirectory: "/Users/test",
+                socketExists: { _ in true }
+            )
+        )
+    }
+}

--- a/ArcBoxTests/OnboardingMigrationModelTests.swift
+++ b/ArcBoxTests/OnboardingMigrationModelTests.swift
@@ -1,0 +1,13 @@
+import GRPCCore
+import XCTest
+
+@testable import ArcBox
+
+final class OnboardingMigrationModelTests: XCTestCase {
+    func testReconnectsOnlyForUnavailableRPCs() {
+        XCTAssertTrue(OnboardingMigrationModel.shouldReconnect(after: .unavailable))
+        XCTAssertFalse(OnboardingMigrationModel.shouldReconnect(after: .internalError))
+        XCTAssertFalse(OnboardingMigrationModel.shouldReconnect(after: .invalidArgument))
+        XCTAssertFalse(OnboardingMigrationModel.shouldReconnect(after: .failedPrecondition))
+    }
+}

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/ArcBoxClient.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/ArcBoxClient.swift
@@ -180,6 +180,11 @@ public final class ArcBoxClient: Sendable {
         .init(wrapping: grpcClient)
     }
 
+    /// Docker Desktop and OrbStack migration operations.
+    public var migration: Arcbox_V1_MigrationService.Client<HTTP2ClientTransport.TransportServices> {
+        .init(wrapping: grpcClient)
+    }
+
     /// Virtual machine management operations.
     public var machines: Arcbox_V1_MachineService.Client<HTTP2ClientTransport.TransportServices> {
         .init(wrapping: grpcClient)


### PR DESCRIPTION
## Summary

- add an optional Docker Desktop / OrbStack migration step to onboarding
- expose the same flow from Help for existing users
- preview supported resources before confirmation and block close / quit while migration is executing
- distinguish no migration source from Docker detection failures

## Safety

- dry-run first, then re-prepare immediately before execution
- require explicit confirmation for replacements and source container stops
- retry only transient transport failures with the same plan ID
- report daemon restart and permanent RPC failures instead of reconnecting forever

## Dependency

Draft: do not merge until arcboxlabs/arcbox#575 is merged, a daemon release containing it is published, and `arcbox.version` is bumped here. The current v0.6.3 daemon does not support safe stream reattachment.

## Validation

- `make generate-xcodeproj`
- `make lint`
- `make test`

