### PR TITLE
fix(app): address production-audit regressions (ABXD-136/137/138/140/149/151)

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -212,6 +212,7 @@
 		CCD9ABC3F69FE5DA233E85EC /* MachineModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0647CCB67160C2509345B5E /* MachineModelTests.swift */; };
 		D0518D07973520530916560B /* ServiceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F238F21169A97B94193454CF /* ServiceDetailView.swift */; };
 		D0A2395C0C2BC0A77B175840 /* MachineEventMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2021CE387B9546EE87FA4CD5 /* MachineEventMonitor.swift */; };
+		D16762EE419CC9055CDD90FF /* DockerTerminalSessionIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C52C15D6902B3EAB6307AA /* DockerTerminalSessionIntegrationTests.swift */; };
 		D2AB4B6BF0723EE12A0DBC83 /* GuestDataMountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27130DDA57D2645C7E81D75D /* GuestDataMountTests.swift */; };
 		D2F870759080FB9D1DF58A3A /* NewContainerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B011CA693D5A9EFCCF61AA2D /* NewContainerSheet.swift */; };
 		D32166A92BDA2FB6B6037D94 /* DeepLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C649765AA76CFCBFC3302DA /* DeepLinkRouter.swift */; };
@@ -314,6 +315,7 @@
 		24D2CE72E40718D37B0293D1 /* StatePlaceholderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatePlaceholderView.swift; sourceTree = "<group>"; };
 		269B74A3C7704AB81139FA52 /* ContainerLogsModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerLogsModels.swift; sourceTree = "<group>"; };
 		27130DDA57D2645C7E81D75D /* GuestDataMountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestDataMountTests.swift; sourceTree = "<group>"; };
+		27C52C15D6902B3EAB6307AA /* DockerTerminalSessionIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockerTerminalSessionIntegrationTests.swift; sourceTree = "<group>"; };
 		297FCAB334AF289575D13F72 /* NetworksListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworksListView.swift; sourceTree = "<group>"; };
 		2D053B8542825698996A16FE /* ArcBoxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ArcBoxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D2C529811ECBAD82E110BC4 /* AuthTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthTestSupport.swift; sourceTree = "<group>"; };
@@ -1129,6 +1131,7 @@
 				6DFE1C88F20E40C1A36A384C /* CreateOperationErrorTests.swift */,
 				F5B3B3C54B6D49C6198E9E26 /* DeepLinkTests.swift */,
 				06DFFB59D72F27F14A233B81 /* DockerEventMonitorTests.swift */,
+				27C52C15D6902B3EAB6307AA /* DockerTerminalSessionIntegrationTests.swift */,
 				27130DDA57D2645C7E81D75D /* GuestDataMountTests.swift */,
 				738233A82C7BAA825F73EE2F /* GuestExportFixture.swift */,
 				C964312D5336EE55A8E4680B /* ImageLayerChainTests.swift */,
@@ -1544,6 +1547,7 @@
 				853F2D06A878BE9A867BE3FD /* CreateOperationErrorTests.swift in Sources */,
 				EE2D38BC76500BF768EEE20F /* DeepLinkTests.swift in Sources */,
 				8466B000B68A87CEECA6756F /* DockerEventMonitorTests.swift in Sources */,
+				D16762EE419CC9055CDD90FF /* DockerTerminalSessionIntegrationTests.swift in Sources */,
 				D2AB4B6BF0723EE12A0DBC83 /* GuestDataMountTests.swift in Sources */,
 				D4FFF718B8B6D79B469D2C3C /* GuestExportFixture.swift in Sources */,
 				466BD76F6F334FBAEA392BD5 /* HelperInstallErrorTests.swift in Sources */,

--- a/ArcBox/Integrations/Docker/DockerTerminalSession.swift
+++ b/ArcBox/Integrations/Docker/DockerTerminalSession.swift
@@ -16,6 +16,34 @@ class DockerTerminalSession {
         static let bufferSize = 8192
     }
 
+    nonisolated private struct DockerCommandResult {
+        let status: Int32
+        let error: String
+    }
+
+    nonisolated private struct ImageContainer: Sendable {
+        let name: String
+        let dockerPath: String
+        let environment: [String: String]
+
+        func run(_ arguments: [String]) throws -> DockerCommandResult {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: dockerPath)
+            process.arguments = arguments
+            process.environment = environment
+            process.standardOutput = FileHandle.nullDevice
+            let errorOutput = Pipe()
+            process.standardError = errorOutput
+            try process.run()
+            process.waitUntilExit()
+            let data = errorOutput.fileHandleForReading.readDataToEndOfFile()
+            return DockerCommandResult(
+                status: process.terminationStatus,
+                error: String(data: data, encoding: .utf8) ?? "unreadable Docker error"
+            )
+        }
+    }
+
     enum State: Equatable {
         case idle
         case connecting
@@ -35,9 +63,12 @@ class DockerTerminalSession {
     @ObservationIgnored private let ptyFDLock = OSAllocatedUnfairLock<Int32>(initialState: -1)
     @ObservationIgnored private var readTask: Task<Void, Never>?
     @ObservationIgnored private weak var terminalView: TerminalView?
+    @ObservationIgnored private var imageContainer: ImageContainer?
     /// Monotonically increasing counter to distinguish sessions.
     /// Stale readTask / terminationHandler callbacks check this before modifying state.
     @ObservationIgnored private var sessionGeneration: Int = 0
+
+    var activeImageContainerName: String? { imageContainer?.name }
 
     /// Store a terminal view reference for later use (called from makeNSView).
     func setTerminalView(_ tv: TerminalView) {
@@ -54,24 +85,34 @@ class DockerTerminalSession {
 
     /// Run a temporary interactive container from an image via `docker run -it --rm`.
     func runImage(imageName: String, shell: String, terminalView: TerminalView) {
-        launchDockerSession(
-            arguments: ["run", "-it", "--rm", "--stop-timeout", "1", imageName, shell],
-            terminalView: terminalView
-        )
+        launchImageSession(imageName: imageName, shell: shell, terminalView: terminalView)
     }
 
     /// Connect to an image using the previously stored TerminalView.
     func connectImage(imageName: String, shell: String) {
         guard let tv = terminalView else { return }
         tv.feed(text: "\u{1b}[2J\u{1b}[H")
+        launchImageSession(imageName: imageName, shell: shell, terminalView: tv)
+    }
+
+    private func launchImageSession(imageName: String, shell: String, terminalView: TerminalView) {
+        let containerName = "arcbox-image-terminal-\(UUID().uuidString.lowercased())"
         launchDockerSession(
-            arguments: ["run", "-it", "--rm", "--stop-timeout", "1", imageName, shell],
-            terminalView: tv
+            arguments: [
+                "run", "-it", "--rm", "--stop-timeout", "1", "--name", containerName,
+                imageName, shell,
+            ],
+            terminalView: terminalView,
+            imageContainerName: containerName
         )
     }
 
     /// Shared implementation: launch a docker CLI process with PTY.
-    private func launchDockerSession(arguments: [String], terminalView: TerminalView) {
+    private func launchDockerSession(
+        arguments: [String],
+        terminalView: TerminalView,
+        imageContainerName: String? = nil
+    ) {
         // Tear down old process without touching state (avoids intermediate .disconnected flicker)
         teardownProcess()
         self.terminalView = terminalView
@@ -150,6 +191,7 @@ class DockerTerminalSession {
             await MainActor.run { [weak self] in
                 guard let self, self.sessionGeneration == currentGen else { return }
                 if self.state == .connected {
+                    self.teardownProcess()
                     self.state = .disconnected
                 }
             }
@@ -160,6 +202,7 @@ class DockerTerminalSession {
             Task { @MainActor [weak self] in
                 guard let self, self.sessionGeneration == currentGen else { return }
                 if self.state == .connected {
+                    self.teardownProcess()
                     self.state = .disconnected
                 }
             }
@@ -170,6 +213,13 @@ class DockerTerminalSession {
             // Close replica FD in parent process — the child owns it now
             close(replica)
             process = proc
+            if let imageContainerName {
+                imageContainer = ImageContainer(
+                    name: imageContainerName,
+                    dockerPath: dockerPath,
+                    environment: env
+                )
+            }
             state = .connected
         } catch {
             close(replica)
@@ -202,7 +252,6 @@ class DockerTerminalSession {
     /// Disconnect and clean up the session.
     func disconnect() {
         teardownProcess()
-        terminalView = nil
         if state == .connected || state == .connecting {
             state = .disconnected
         }
@@ -216,7 +265,9 @@ class DockerTerminalSession {
 
         // Capture references before nilling them out
         let dyingProcess = process
+        let dyingImageContainer = imageContainer
         process = nil
+        imageContainer = nil
 
         // ABXD-17: Atomically swap the FD to -1 under the lock so that
         // concurrent `send()` / `resize()` calls see -1 immediately and
@@ -231,13 +282,62 @@ class DockerTerminalSession {
         // Foundation's Process deallocation uses Mach ports that can
         // trigger "Unable to obtain a task name port right" errors
         // and potentially block the main thread.
-        if dyingProcess != nil || oldPtyFD >= 0 {
+        if dyingProcess != nil || dyingImageContainer != nil || oldPtyFD >= 0 {
             DispatchQueue.global(qos: .utility).async {
-                if let proc = dyingProcess {
-                    kill(proc.processIdentifier, SIGKILL)
+                if let container = dyingImageContainer {
+                    do {
+                        let result = try container.run(["stop", "--timeout", "1", container.name])
+                        if result.status != 0, !result.error.contains("No such container") {
+                            Log.terminal.error(
+                                "Failed to stop image terminal container \(container.name, privacy: .private): \(result.error, privacy: .private)"
+                            )
+                        }
+                    } catch {
+                        Log.terminal.error(
+                            "Failed to stop image terminal container \(container.name, privacy: .private): \(error.localizedDescription, privacy: .public)"
+                        )
+                    }
                 }
+
                 if oldPtyFD >= 0 {
                     close(oldPtyFD)
+                }
+                if let proc = dyingProcess {
+                    if proc.isRunning {
+                        kill(proc.processIdentifier, SIGKILL)
+                    }
+                    proc.waitUntilExit()
+                }
+
+                if let container = dyingImageContainer {
+                    // `docker stop` does not AutoRemove a container that was created but never started.
+                    // ponytail: retry for one second so an in-flight create request can publish after launcher exit.
+                    for attempt in 0..<20 {
+                        let result: DockerCommandResult
+                        do {
+                            result = try container.run([
+                                "container", "rm", "--force", "--volumes", container.name,
+                            ])
+                        } catch {
+                            let message = error.localizedDescription
+                            Log.terminal.error(
+                                "Failed to remove image terminal container \(container.name, privacy: .private): \(message, privacy: .public)"
+                            )
+                            break
+                        }
+                        guard result.status != 0 else { break }
+                        let canRetry =
+                            result.error.contains("No such container")
+                            || result.error.contains("already in progress")
+                        guard canRetry else {
+                            Log.terminal.error(
+                                "Failed to remove image terminal container \(container.name, privacy: .private): \(result.error, privacy: .private)"
+                            )
+                            break
+                        }
+                        guard attempt < 19 else { break }
+                        Thread.sleep(forTimeInterval: 0.05)
+                    }
                 }
                 // dyingProcess is released here when the closure exits,
                 // allowing Foundation to deallocate on this background thread.

--- a/ArcBox/Integrations/Docker/DockerTerminalSession.swift
+++ b/ArcBox/Integrations/Docker/DockerTerminalSession.swift
@@ -113,12 +113,11 @@ class DockerTerminalSession {
         terminalView: TerminalView,
         imageContainerName: String? = nil
     ) {
+        sessionGeneration += 1
         // Tear down old process without touching state (avoids intermediate .disconnected flicker)
         teardownProcess()
         self.terminalView = terminalView
 
-        // Bump generation so stale callbacks from the old session are ignored
-        sessionGeneration += 1
         let currentGen = sessionGeneration
 
         state = .connecting
@@ -184,7 +183,8 @@ class DockerTerminalSession {
                 if bytesRead <= 0 { break }
                 let data = Array(UnsafeBufferPointer(start: buffer, count: bytesRead))
                 await MainActor.run { [weak self] in
-                    self?.terminalView?.feed(byteArray: ArraySlice(data))
+                    guard let self, self.sessionGeneration == currentGen else { return }
+                    self.terminalView?.feed(byteArray: data[...])
                 }
             }
 
@@ -251,6 +251,7 @@ class DockerTerminalSession {
 
     /// Disconnect and clean up the session.
     func disconnect() {
+        sessionGeneration += 1
         teardownProcess()
         if state == .connected || state == .connecting {
             state = .disconnected

--- a/ArcBox/Integrations/System/LayerStack.swift
+++ b/ArcBox/Integrations/System/LayerStack.swift
@@ -1,4 +1,36 @@
+import ArcBoxClient
 import Foundation
+
+nonisolated enum FilesTabPathResolution: Equatable {
+    case resolved([String])
+    case failed(String)
+    case cancelled
+
+    static let retryTitle = "Retry"
+
+    var errorMessage: String? {
+        guard case .failed(let message) = self else { return nil }
+        return message
+    }
+
+    static func resolve(
+        subject: String,
+        operation: () async throws -> [String],
+        onFailure: (Error) -> Void
+    ) async -> FilesTabPathResolution {
+        do {
+            let paths = try await operation()
+            return Task.isCancelled ? .cancelled : .resolved(paths)
+        } catch is CancellationError {
+            return .cancelled
+        } catch {
+            guard !Task.isCancelled else { return .cancelled }
+            onFailure(error)
+            return .failed(
+                "Couldn’t load \(subject) files. \(ArcBoxClient.userMessage(for: error))")
+        }
+    }
+}
 
 /// What a Files tab is browsing, and how much of it is missing.
 ///

--- a/ArcBox/Integrations/System/LayerStack.swift
+++ b/ArcBox/Integrations/System/LayerStack.swift
@@ -1,5 +1,8 @@
-import ArcBoxClient
+// Foundation precedes local modules per repository import style.
+// swift-format-ignore: OrderedImports
 import Foundation
+
+import ArcBoxClient
 
 nonisolated enum FilesTabPathResolution: Equatable {
     case resolved([String])

--- a/ArcBox/Integrations/System/LocalRootFSService.swift
+++ b/ArcBox/Integrations/System/LocalRootFSService.swift
@@ -4,7 +4,6 @@ nonisolated struct LocalFileEntry: Identifiable, Hashable {
     let url: URL
     let name: String
     let isDirectory: Bool
-    let isPackage: Bool
     let isSymbolicLink: Bool
     let sizeBytes: Int64?
     let modifiedDate: Date?
@@ -13,7 +12,16 @@ nonisolated struct LocalFileEntry: Identifiable, Hashable {
     var loadError: String?
 
     var id: String { url.standardizedFileURL.path }
-    var isExpandable: Bool { isDirectory && !isPackage }
+    var isExpandable: Bool { isDirectory }
+
+    var systemImageName: String {
+        switch kind {
+        case "Directory": "folder"
+        case "Symlink": "link"
+        case "Executable": "terminal"
+        default: "doc"
+        }
+    }
 
     var sizeDisplay: String {
         guard let sizeBytes else { return "" }
@@ -53,12 +61,10 @@ nonisolated struct LocalRootFSService {
 
     private static let resourceKeys: Set<URLResourceKey> = [
         .isDirectoryKey,
-        .isPackageKey,
         .isSymbolicLinkKey,
         .isHiddenKey,
         .fileSizeKey,
         .contentModificationDateKey,
-        .localizedTypeDescriptionKey,
         .fileResourceTypeKey,
         .nameKey,
     ]
@@ -142,20 +148,18 @@ nonisolated struct LocalRootFSService {
                     }
 
                     let isDirectory = values.isDirectory ?? false
-                    let isPackage = values.isPackage ?? false
-                    let kind: String
-                    if isDirectory && !isPackage {
-                        kind = "Folder"
-                    } else {
-                        kind = values.localizedTypeDescription ?? "Document"
-                    }
+                    let isSymbolicLink = values.isSymbolicLink ?? false
+                    let kind = neutralKind(
+                        at: entryURL,
+                        isDirectory: isDirectory,
+                        isSymbolicLink: isSymbolicLink
+                    )
 
                     let entry = LocalFileEntry(
                         url: entryURL,
                         name: values.name ?? entryURL.lastPathComponent,
                         isDirectory: isDirectory,
-                        isPackage: isPackage,
-                        isSymbolicLink: values.isSymbolicLink ?? false,
+                        isSymbolicLink: isSymbolicLink,
                         sizeBytes: isDirectory ? nil : Int64(values.fileSize ?? 0),
                         modifiedDate: values.contentModificationDate,
                         kind: kind,
@@ -180,6 +184,21 @@ nonisolated struct LocalRootFSService {
         }
 
         return entries
+    }
+
+    private static func neutralKind(
+        at url: URL,
+        isDirectory: Bool,
+        isSymbolicLink: Bool
+    ) -> String {
+        if isSymbolicLink { return "Symlink" }
+        if isDirectory { return "Directory" }
+
+        var status = stat()
+        guard lstat(url.path, &status) == 0, status.st_mode & 0o111 != 0 else {
+            return "File"
+        }
+        return "Executable"
     }
 
     static func finderDefaultShowHiddenFiles() -> Bool {

--- a/ArcBox/Models/ImageModel.swift
+++ b/ArcBox/Models/ImageModel.swift
@@ -8,7 +8,7 @@ struct ImageViewModel: Identifiable, Hashable {
     let repository: String
     let tag: String
     let sizeBytes: UInt64
-    let createdAt: Date
+    let createdAt: Date?
     let inUse: Bool
     let os: String
     let architecture: String
@@ -33,7 +33,20 @@ struct ImageViewModel: Identifiable, Hashable {
     }
 
     var createdAgo: String {
-        relativeTime(from: createdAt)
+        guard let createdAt, createdAt.timeIntervalSince1970 > 0 else { return "Unknown" }
+        return relativeTime(from: createdAt)
+    }
+
+    var platformDisplay: String? {
+        let components = [os, architecture].compactMap { value in
+            let value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return value.isEmpty ? nil : value
+        }
+        return components.isEmpty ? nil : components.joined(separator: "/")
+    }
+
+    var canDelete: Bool {
+        !inUse
     }
 
     static let rootfsMountPathLabelKeys = [

--- a/ArcBox/Models/NetworkModel.swift
+++ b/ArcBox/Models/NetworkModel.swift
@@ -34,4 +34,8 @@ struct NetworkViewModel: Identifiable, Hashable {
     var isSystem: Bool {
         ["bridge", "host", "none"].contains(name)
     }
+
+    var canDelete: Bool {
+        !isSystem && containerCount == 0
+    }
 }

--- a/ArcBox/ViewModels/Images/ImageViewModel+Docker.swift
+++ b/ArcBox/ViewModels/Images/ImageViewModel+Docker.swift
@@ -6,7 +6,11 @@ import Foundation
 extension ImageViewModel {
     /// Create ImageViewModels from a Docker Engine API ImageSummary.
     /// One ImageSummary can have multiple RepoTags, producing multiple view models.
-    static func fromDocker(_ summary: Components.Schemas.ImageSummary) -> [ImageViewModel] {
+    static func fromDocker(
+        _ summary: Components.Schemas.ImageSummary,
+        os: String = "",
+        architecture: String = ""
+    ) -> [ImageViewModel] {
         let tags = summary.RepoTags.isEmpty ? ["<none>:<none>"] : summary.RepoTags
 
         return tags.map { repoTag in
@@ -20,10 +24,11 @@ extension ImageViewModel {
                 repository: repository,
                 tag: tag,
                 sizeBytes: UInt64(summary.Size),
-                createdAt: Date(timeIntervalSince1970: TimeInterval(summary.Created)),
+                createdAt: summary.Created > 0
+                    ? Date(timeIntervalSince1970: TimeInterval(summary.Created)) : nil,
                 inUse: summary.Containers > 0,
-                os: "",
-                architecture: ""
+                os: os,
+                architecture: architecture
             )
         }
     }

--- a/ArcBox/ViewModels/Images/ImagesViewModel+Docker.swift
+++ b/ArcBox/ViewModels/Images/ImagesViewModel+Docker.swift
@@ -64,10 +64,23 @@ extension ImagesViewModel {
         let isRefresh = loadState.beginLoading()
         do {
             let imageList = try await Perf.measure("image.list") {
-                let response = try await docker.api.ImageList(.init())
-                return try response.ok.body.json
+                let response = try await docker.api.SystemDataUsage(
+                    query: .init(_type: [.image])
+                )
+                return try response.ok.body.json.Images ?? []
             }
-            var viewModels = imageList.flatMap { ImageViewModel.fromDocker($0) }
+            var metadataByID: [String: ImageInspectSnapshot] = [:]
+            for image in imageList {
+                metadataByID[image.Id] = try await docker.inspectImageSnapshot(id: image.Id)
+            }
+            var viewModels = imageList.flatMap { image in
+                let metadata = metadataByID[image.Id]
+                return ImageViewModel.fromDocker(
+                    image,
+                    os: metadata?.os ?? "",
+                    architecture: metadata?.architecture ?? ""
+                )
+            }
             applyCachedIcons(to: &viewModels)
             images = viewModels
             Log.image.info("Loaded \(self.images.count, privacy: .public) images")
@@ -162,13 +175,21 @@ extension ImagesViewModel {
 
     func removeImage(_ id: String, dockerId: String, docker: DockerClient?) async {
         lastError = nil
-        guard let docker else { return }
-        if selectedID == id { selectedID = nil }
+        guard let image = images.first(where: { $0.id == id }) else { return }
+        guard image.canDelete else {
+            lastError = "Image is in use and cannot be deleted."
+            return
+        }
+        guard let docker else {
+            lastError = "Docker client unavailable."
+            return
+        }
 
         do {
             let response = try await docker.api.ImageDelete(path: .init(name: dockerId), query: .init(force: true))
-            _ = try response.ok
-            Log.image.info("Removed image \(dockerId, privacy: .private)")
+            if applyImageDeletion(response, id: id) {
+                Log.image.info("Removed image \(dockerId, privacy: .private)")
+            }
         } catch {
             Log.image.error(
                 "Error removing image \(dockerId, privacy: .private): \(error.localizedDescription, privacy: .private)")
@@ -176,5 +197,32 @@ extension ImagesViewModel {
             lastError = error.localizedDescription
         }
         await loadImages(docker: docker)
+    }
+
+    @discardableResult
+    func applyImageDeletion(_ response: Operations.ImageDelete.Output, id: String) -> Bool {
+        if let message = response.deleteFailureMessage {
+            lastError = message
+            return false
+        }
+        if selectedID == id { selectedID = nil }
+        return true
+    }
+}
+
+extension Operations.ImageDelete.Output {
+    nonisolated var deleteFailureMessage: String? {
+        switch self {
+        case .ok:
+            nil
+        case .notFound(let response):
+            (try? response.body.json.message) ?? "Image not found."
+        case .conflict(let response):
+            (try? response.body.json.message) ?? "Docker cannot remove an image that is in use."
+        case .internalServerError(let response):
+            (try? response.body.json.message) ?? "Docker failed to remove the image."
+        case .undocumented(let statusCode, _):
+            "Unexpected response status \(statusCode)."
+        }
     }
 }

--- a/ArcBox/ViewModels/Images/ImagesViewModel+Docker.swift
+++ b/ArcBox/ViewModels/Images/ImagesViewModel+Docker.swift
@@ -69,9 +69,10 @@ extension ImagesViewModel {
                 )
                 return try response.ok.body.json.Images ?? []
             }
-            var metadataByID: [String: ImageInspectSnapshot] = [:]
-            for image in imageList {
-                metadataByID[image.Id] = try await docker.inspectImageSnapshot(id: image.Id)
+            let metadataByID = try await Self.inspectImageMetadata(
+                imageIDs: imageList.map(\.Id)
+            ) { id in
+                try await docker.inspectImageSnapshot(id: id)
             }
             var viewModels = imageList.flatMap { image in
                 let metadata = metadataByID[image.Id]
@@ -98,6 +99,26 @@ extension ImagesViewModel {
                 retainingLoadedContent: isRefresh
             )
         }
+    }
+
+    static func inspectImageMetadata(
+        imageIDs: [String],
+        inspect: (String) async throws -> ImageInspectSnapshot
+    ) async throws -> [String: ImageInspectSnapshot] {
+        var metadataByID: [String: ImageInspectSnapshot] = [:]
+        for id in imageIDs {
+            do {
+                let metadata = try await inspect(id)
+                try Task.checkCancellation()
+                metadataByID[id] = metadata
+            } catch {
+                if Task.isCancelled || error is CancellationError { throw error }
+                Log.image.debug(
+                    "Image metadata inspection failed for \(id, privacy: .private): \(error.localizedDescription, privacy: .private)"
+                )
+            }
+        }
+        return metadataByID
     }
 
     /// Parse an image reference into (fromImage, tag), handling registry ports and digests.

--- a/ArcBox/ViewModels/Images/ImagesViewModel.swift
+++ b/ArcBox/ViewModels/Images/ImagesViewModel.swift
@@ -46,7 +46,7 @@ class ImagesViewModel {
             case .name:
                 comparison = a.repository.localizedCaseInsensitiveCompare(b.repository)
             case .dateCreated:
-                comparison = a.createdAt.compare(b.createdAt)
+                comparison = (a.createdAt ?? .distantPast).compare(b.createdAt ?? .distantPast)
             case .size:
                 comparison =
                     a.sizeBytes == b.sizeBytes

--- a/ArcBox/ViewModels/NetworksViewModel.swift
+++ b/ArcBox/ViewModels/NetworksViewModel.swift
@@ -91,7 +91,8 @@ class NetworksViewModel {
             for network in networkList {
                 guard let id = network.Id else { continue }
                 let response = try await docker.api.NetworkInspect(path: .init(id: id))
-                if let network = NetworkViewModel(fromDocker: try response.ok.body.json) {
+                guard let inspectedNetwork = try response.networkForList else { continue }
+                if let network = NetworkViewModel(fromDocker: inspectedNetwork) {
                     networks.append(network)
                 }
             }
@@ -261,5 +262,20 @@ extension NetworkViewModel {
             attachable: network.Attachable ?? false,
             containerCount: network.Containers?.additionalProperties.count ?? 0
         )
+    }
+}
+
+extension Operations.NetworkInspect.Output {
+    nonisolated var networkForList: Components.Schemas.Network? {
+        get throws {
+            switch self {
+            case .ok(let response):
+                try response.body.json
+            case .notFound:
+                nil
+            case .internalServerError, .undocumented:
+                try ok.body.json
+            }
+        }
     }
 }

--- a/ArcBox/ViewModels/NetworksViewModel.swift
+++ b/ArcBox/ViewModels/NetworksViewModel.swift
@@ -87,7 +87,15 @@ class NetworksViewModel {
         do {
             let response = try await docker.api.NetworkList(.init())
             let networkList = try response.ok.body.json
-            networks = networkList.compactMap(NetworkViewModel.init(fromDocker:))
+            var networks: [NetworkViewModel] = []
+            for network in networkList {
+                guard let id = network.Id else { continue }
+                let response = try await docker.api.NetworkInspect(path: .init(id: id))
+                if let network = NetworkViewModel(fromDocker: try response.ok.body.json) {
+                    networks.append(network)
+                }
+            }
+            self.networks = networks
             Log.network.info("Loaded \(self.networks.count, privacy: .public) networks")
             loadState = .loaded
             refreshError = nil
@@ -109,12 +117,19 @@ class NetworksViewModel {
         guard let network = networks.first(where: { $0.id == id }), !network.isSystem else {
             return
         }
-        guard let docker else { return }
-        if selectedID == network.id { selectedID = nil }
+        guard network.canDelete else {
+            lastError = "Network is in use and cannot be deleted."
+            return
+        }
+        guard let docker else {
+            lastError = "Docker client unavailable."
+            return
+        }
         do {
             let response = try await docker.api.NetworkDelete(path: .init(id: network.id))
-            _ = try response.noContent
-            Log.network.info("Removed network \(network.id, privacy: .private)")
+            if applyNetworkDeletion(response, id: network.id) {
+                Log.network.info("Removed network \(network.id, privacy: .private)")
+            }
         } catch {
             Log.network.error(
                 "Error removing network \(network.id, privacy: .private): \(error.localizedDescription, privacy: .private)"
@@ -123,6 +138,16 @@ class NetworksViewModel {
             lastError = error.localizedDescription
         }
         await loadNetworks(docker: docker)
+    }
+
+    @discardableResult
+    func applyNetworkDeletion(_ response: Operations.NetworkDelete.Output, id: String) -> Bool {
+        if let message = response.deleteFailureMessage {
+            lastError = message
+            return false
+        }
+        if selectedID == id { selectedID = nil }
+        return true
     }
 
     /// Create a bridge network. Returns true on success; the failure message lands in `lastError`.
@@ -189,6 +214,32 @@ class NetworksViewModel {
         }
     }
 
+}
+
+extension Operations.NetworkDelete.Output {
+    nonisolated var deleteFailureMessage: String? {
+        switch self {
+        case .noContent:
+            nil
+        case .forbidden(let response):
+            switch response.body {
+            case .json(let error): error.message
+            case .plainText: "Docker cannot remove this network."
+            }
+        case .notFound(let response):
+            switch response.body {
+            case .json(let error): error.message
+            case .plainText: "Network not found."
+            }
+        case .internalServerError(let response):
+            switch response.body {
+            case .json(let error): error.message
+            case .plainText: "Docker failed to remove the network."
+            }
+        case .undocumented(let statusCode, _):
+            "Unexpected response status \(statusCode)."
+        }
+    }
 }
 
 // MARK: - Docker API → UI Model Conversion

--- a/ArcBox/ViewModels/Volumes/VolumesViewModel+Docker.swift
+++ b/ArcBox/ViewModels/Volumes/VolumesViewModel+Docker.swift
@@ -177,12 +177,15 @@ extension VolumesViewModel {
 
     func removeVolume(_ name: String, docker: DockerClient?) async {
         lastError = nil
-        guard let docker else { return }
-        if selectedID == name { selectedID = nil }
+        guard let docker else {
+            lastError = "Docker client unavailable."
+            return
+        }
         do {
             let response = try await docker.api.VolumeDelete(path: .init(name: name), query: .init(force: true))
-            _ = try response.noContent
-            Log.volume.info("Removed volume \(name, privacy: .private)")
+            if applyVolumeDeletion(response, name: name) {
+                Log.volume.info("Removed volume \(name, privacy: .private)")
+            }
         } catch {
             Log.volume.error(
                 "Error removing volume \(name, privacy: .private): \(error.localizedDescription, privacy: .private)")
@@ -190,5 +193,41 @@ extension VolumesViewModel {
             lastError = error.localizedDescription
         }
         await loadVolumes(docker: docker)
+    }
+
+    @discardableResult
+    func applyVolumeDeletion(_ response: Operations.VolumeDelete.Output, name: String) -> Bool {
+        if let message = response.deleteFailureMessage {
+            lastError = message
+            return false
+        }
+        if selectedID == name { selectedID = nil }
+        return true
+    }
+}
+
+extension Operations.VolumeDelete.Output {
+    nonisolated var deleteFailureMessage: String? {
+        switch self {
+        case .noContent:
+            nil
+        case .notFound(let response):
+            switch response.body {
+            case .json(let error): error.message
+            case .plainText: "Volume not found."
+            }
+        case .conflict(let response):
+            switch response.body {
+            case .json(let error): error.message
+            case .plainText: "Docker cannot remove a volume that is in use."
+            }
+        case .internalServerError(let response):
+            switch response.body {
+            case .json(let error): error.message
+            case .plainText: "Docker failed to remove the volume."
+            }
+        case .undocumented(let statusCode, _):
+            "Unexpected response status \(statusCode)."
+        }
     }
 }

--- a/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerFilesTab.swift
@@ -37,7 +37,7 @@ struct ContainerFilesTab: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(AppColors.background)
         .task(id: outlineReloadID) {
-            await resolveRootPath()
+            await resolveRootPath(requestID: outlineReloadID)
         }
     }
 
@@ -47,7 +47,7 @@ struct ContainerFilesTab: View {
                 .font(.system(size: 12))
                 .foregroundStyle(AppColors.textSecondary)
 
-            Text(stack.rootURL?.path ?? container.resolvedRootFSMountPath ?? "No rootfs mount path")
+            Text("/")
                 .font(.system(size: 12, design: .monospaced))
                 .foregroundStyle(AppColors.textSecondary)
                 .lineLimit(1)
@@ -103,6 +103,7 @@ struct ContainerFilesTab: View {
             LocalRootFSOutlineView(
                 rootURL: rootURL,
                 layers: stack.layers,
+                displayRootPath: "/",
                 showHiddenFiles: showHiddenFiles,
                 reloadID: outlineReloadID,
                 selectedPath: $selectedPath,
@@ -140,7 +141,7 @@ struct ContainerFilesTab: View {
             .multilineTextAlignment(.center)
             .padding(.horizontal, 20)
 
-            Button("Refresh") {
+            Button(FilesTabPathResolution.retryTitle) {
                 refresh()
             }
             .buttonStyle(.bordered)
@@ -154,12 +155,17 @@ struct ContainerFilesTab: View {
         refreshToken = UUID()
     }
 
-    private func resolveRootPath() async {
+    private func resolveRootPath(requestID: String) async {
+        guard requestID == outlineReloadID, !Task.isCancelled else { return }
         errorMessage = nil
         isLoadingRoot = true
         selectedPath = nil
         stack = LayerStack()
-        defer { isLoadingRoot = false }
+        defer {
+            if requestID == outlineReloadID, !Task.isCancelled {
+                isLoadingRoot = false
+            }
+        }
 
         // Inspect-provided path (classic graph drivers) is already a merged
         // rootfs; under the containerd image store inspect carries no paths,
@@ -168,10 +174,22 @@ struct ContainerFilesTab: View {
         if let mountPath = container.resolvedRootFSMountPath {
             guestPaths = [mountPath]
         } else {
-            guestPaths = await resolveViaDaemon()
+            let resolution = await resolveViaDaemon()
+            guard requestID == outlineReloadID, !Task.isCancelled else { return }
+            switch resolution {
+            case .resolved(let paths):
+                guestPaths = paths
+            case .failed(let message):
+                errorMessage = message
+                return
+            case .cancelled:
+                return
+            }
         }
 
-        stack = await LayerStack.resolve(guestPaths: guestPaths)
+        let resolvedStack = await LayerStack.resolve(guestPaths: guestPaths)
+        guard requestID == outlineReloadID, !Task.isCancelled else { return }
+        stack = resolvedStack
         guard stack.rootURL != nil else {
             errorMessage = Self.unresolvedMessage(guestPaths: guestPaths)
             return
@@ -197,24 +215,29 @@ struct ContainerFilesTab: View {
     /// containerd's snapshotter, so the daemon queries the guest and returns
     /// guest paths: the writable (upper) layer the container wrote, followed
     /// by the image layers below it — overlay precedence order.
-    private func resolveViaDaemon() async -> [String] {
-        guard let arcboxClient else { return [] }
+    private func resolveViaDaemon() async -> FilesTabPathResolution {
+        guard let arcboxClient else {
+            return .failed("ArcBox daemon is unavailable.")
+        }
         var request = Arcbox_V1_ResolveContainerFsRequest()
         request.containerID = container.id
-        do {
-            let response = try await arcboxClient.system.resolveContainerFs(
-                request, options: ArcBoxClient.defaultCallOptions)
-            var paths: [String] = []
-            if !response.upperDir.isEmpty {
-                paths.append(response.upperDir)
+        return await FilesTabPathResolution.resolve(
+            subject: "container",
+            operation: {
+                let response = try await arcboxClient.system.resolveContainerFs(
+                    request, options: ArcBoxClient.defaultCallOptions)
+                var paths: [String] = []
+                if !response.upperDir.isEmpty {
+                    paths.append(response.upperDir)
+                }
+                paths.append(contentsOf: response.lowerDirs.filter { !$0.isEmpty })
+                return paths
+            },
+            onFailure: { error in
+                Log.daemon.error(
+                    "Failed to resolve container fs: \(error.localizedDescription, privacy: .private)")
             }
-            paths.append(contentsOf: response.lowerDirs.filter { !$0.isEmpty })
-            return paths
-        } catch {
-            Log.daemon.error(
-                "Failed to resolve container fs: \(error.localizedDescription, privacy: .private)")
-            return []
-        }
+        )
     }
 
     private func revealSelectedInFinder() {

--- a/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineCoordinator+Actions.swift
+++ b/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineCoordinator+Actions.swift
@@ -64,8 +64,11 @@ extension LocalRootFSOutlineCoordinator {
 
     @objc func copySelectedPath() {
         guard let node = selectedNode() else { return }
+        let path =
+            parent.displayRootPath.map { node.displayPath(rootPath: $0) }
+            ?? node.entry.url.path
         NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(node.entry.url.path, forType: .string)
+        NSPasteboard.general.setString(path, forType: .string)
     }
 
 }

--- a/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineCoordinator+DataSource.swift
+++ b/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineCoordinator+DataSource.swift
@@ -119,8 +119,11 @@ extension LocalRootFSOutlineCoordinator: NSOutlineViewDataSource, NSOutlineViewD
             ])
         }
 
-        cell.imageView?.image = NSWorkspace.shared.icon(forFile: node.entry.url.path)
-        cell.imageView?.contentTintColor = nil
+        cell.imageView?.image = NSImage(
+            systemSymbolName: node.entry.systemImageName,
+            accessibilityDescription: node.entry.kind
+        )
+        cell.imageView?.contentTintColor = .secondaryLabelColor
         cell.textField?.stringValue = node.entry.name
         cell.textField?.font = .systemFont(ofSize: 12)
         return cell

--- a/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineModels.swift
+++ b/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineModels.swift
@@ -15,6 +15,18 @@ final class LocalFileNode: NSObject {
         self.entry = entry
         self.parent = parent
     }
+
+    /// The resource path represented by this node, without its host export prefix.
+    func displayPath(rootPath: String) -> String {
+        var components: [String] = []
+        var node: LocalFileNode? = self
+        while let current = node {
+            components.append(current.entry.name)
+            node = current.parent
+        }
+        return (rootPath as NSString).appendingPathComponent(
+            components.reversed().joined(separator: "/"))
+    }
 }
 
 final class ContextOutlineView: NSOutlineView {

--- a/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineView.swift
+++ b/ArcBox/Views/Containers/Tabs/LocalRootFSOutline/LocalRootFSOutlineView.swift
@@ -5,6 +5,8 @@ struct LocalRootFSOutlineView: NSViewRepresentable {
     /// Layer stack to merge while browsing. `nil` browses `rootURL` alone —
     /// the plain single-directory case (volumes, machines, sandboxes).
     var layers: LayeredRootFS?
+    /// Semantic root shown and copied for guest files. Host-only browsers leave this nil.
+    var displayRootPath: String?
     let showHiddenFiles: Bool
     let reloadID: String
     @Binding var selectedPath: String?

--- a/ArcBox/Views/Images/ImageDetailView.swift
+++ b/ArcBox/Views/Images/ImageDetailView.swift
@@ -21,7 +21,9 @@ struct ImageDetailView: View {
                                     InfoRow(label: "Tag", value: "\(image.repository):\(image.tag)")
                                     InfoRow(label: "Created", value: image.createdAgo)
                                     InfoRow(label: "Size", value: image.sizeDisplay)
-                                    InfoRow(label: "Platform", value: "\(image.os)/\(image.architecture)")
+                                    if let platform = image.platformDisplay {
+                                        InfoRow(label: "Platform", value: platform)
+                                    }
                                 }
                                 .infoSectionStyle()
                             }

--- a/ArcBox/Views/Images/ImagesListViewController.swift
+++ b/ArcBox/Views/Images/ImagesListViewController.swift
@@ -216,7 +216,10 @@ final class ImagesListViewController: NSViewController,
                 byExtendingSelection: false
             )
         }
-        menu.items.forEach { $0.isEnabled = contextImage != nil }
+        let canCopy = contextImage != nil
+        menu.item(withTitle: "Copy Name")?.isEnabled = canCopy
+        menu.item(withTitle: "Copy ID")?.isEnabled = canCopy
+        menu.item(withTitle: "Delete")?.isEnabled = contextImage?.canDelete ?? false
     }
 
     private func observeAndRender() {
@@ -437,7 +440,8 @@ final class ImagesListViewController: NSViewController,
 
     private func confirmDelete(_ image: ImageViewModel) {
         guard
-            viewModel.images.contains(where: { $0.id == image.id }),
+            image.canDelete,
+            viewModel.images.first(where: { $0.id == image.id })?.canDelete == true,
             deleteAlert == nil,
             let window = view.window
         else {
@@ -480,6 +484,8 @@ private final class ImageTableCellView: NSTableCellView, ResourceListActionDispl
     private var representedIconURL: URL?
     private var fallbackColor = NSColor.secondaryLabelColor
     private var showsRemoteIcon = false
+    private var canDelete = false
+    private var showsActions = false
     private var onDelete: (@MainActor () -> Void)?
 
     override init(frame frameRect: NSRect) {
@@ -606,9 +612,12 @@ private final class ImageTableCellView: NSTableCellView, ResourceListActionDispl
         nameLabel.stringValue = image.fullName
         architectureBox.isHidden = image.architecture != "amd64"
         detailLabel.stringValue = "\(image.sizeDisplay), \(image.createdAgo)"
-        deleteButton.toolTip = "Delete image"
+        canDelete = image.canDelete
+        deleteButton.isEnabled = image.canDelete
+        deleteButton.toolTip = image.canDelete ? "Delete image" : nil
         deleteButton.setAccessibilityLabel("Delete \(image.fullName)")
-        self.onDelete = onDelete
+        self.onDelete = image.canDelete ? onDelete : nil
+        updateActionVisibility()
 
         fallbackColor = Self.color(for: image.repository)
         showFallbackIcon()
@@ -659,7 +668,12 @@ private final class ImageTableCellView: NSTableCellView, ResourceListActionDispl
     }
 
     func setShowsActions(_ showsActions: Bool) {
-        deleteButton.isHidden = !showsActions
+        self.showsActions = showsActions
+        updateActionVisibility()
+    }
+
+    private func updateActionVisibility() {
+        deleteButton.isHidden = !canDelete || !showsActions
     }
 
     private static func color(for repository: String) -> NSColor {

--- a/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
+++ b/ArcBox/Views/Images/Tabs/ImageFilesTab.swift
@@ -10,6 +10,7 @@ struct ImageFilesTab: View {
         case dockerUnavailable
         case missingRootPath
         case inspectFailed(String)
+        case resolutionFailed(String)
 
         var errorDescription: String? {
             switch self {
@@ -19,6 +20,8 @@ struct ImageFilesTab: View {
                 return "Image has no resolvable filesystem path."
             case .inspectFailed(let reason):
                 return "Failed to inspect image: \(reason)"
+            case .resolutionFailed(let message):
+                return message
             }
         }
     }
@@ -60,7 +63,7 @@ struct ImageFilesTab: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(AppColors.background)
         .task(id: resolveTaskID) {
-            await resolveRootPath()
+            await resolveRootPath(requestID: resolveTaskID)
         }
     }
 
@@ -70,7 +73,7 @@ struct ImageFilesTab: View {
                 .font(.system(size: 12))
                 .foregroundStyle(AppColors.textSecondary)
 
-            Text(stack.rootURL?.path ?? resolvedRootFSMountPath ?? "No rootfs mount path")
+            Text("/")
                 .font(.system(size: 12, design: .monospaced))
                 .foregroundStyle(AppColors.textSecondary)
                 .lineLimit(1)
@@ -126,6 +129,7 @@ struct ImageFilesTab: View {
             LocalRootFSOutlineView(
                 rootURL: rootURL,
                 layers: stack.layers,
+                displayRootPath: "/",
                 showHiddenFiles: showHiddenFiles,
                 reloadID: outlineReloadID,
                 selectedPath: $selectedPath,
@@ -160,7 +164,7 @@ struct ImageFilesTab: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 20)
 
-            Button("Refresh") {
+            Button(FilesTabPathResolution.retryTitle) {
                 refresh()
             }
             .buttonStyle(.bordered)
@@ -174,33 +178,43 @@ struct ImageFilesTab: View {
         refreshToken = UUID()
     }
 
-    private func resolveRootPath() async {
+    private func resolveRootPath(requestID: String) async {
+        guard requestID == resolveTaskID, !Task.isCancelled else { return }
         errorMessage = nil
         isLoadingRoot = true
         selectedPath = nil
         stack = LayerStack()
+        defer {
+            if requestID == resolveTaskID, !Task.isCancelled {
+                isLoadingRoot = false
+            }
+        }
 
         do {
             // The layer directories are guest paths; browse them via ~/ArcBox.
             let mountPoints = try await resolveImageLayerPaths()
+            guard requestID == resolveTaskID, !Task.isCancelled else { return }
             resolvedRootFSMountPath = mountPoints.first
 
-            stack = await LayerStack.resolve(guestPaths: mountPoints)
+            let resolvedStack = await LayerStack.resolve(guestPaths: mountPoints)
+            guard requestID == resolveTaskID, !Task.isCancelled else { return }
+            stack = resolvedStack
             guard stack.rootURL != nil else {
                 errorMessage = Self.unresolvedMessage(guestPaths: mountPoints)
-                isLoadingRoot = false
                 return
             }
             // Listings report further exclusions as they happen — a layer can
             // die after this point — and the badge unions them.
+        } catch is CancellationError {
+            return
         } catch let error as ImageFilesTabError {
+            guard requestID == resolveTaskID, !Task.isCancelled else { return }
             resolvedRootFSMountPath = nil
             errorMessage = error.localizedDescription
         } catch {
+            guard requestID == resolveTaskID, !Task.isCancelled else { return }
             errorMessage = GuestDataMount.unavailableMessage(subject: "This image's layers")
         }
-
-        isLoadingRoot = false
     }
 
     private static func unresolvedMessage(guestPaths: [String]) -> String {
@@ -228,14 +242,24 @@ struct ImageFilesTab: View {
             // Containerd image store: inspect carries no layer paths; ask
             // the daemon to resolve the layer chain, then merge the layers
             // into the filesystem the image would present when run.
-            let resolved = await resolveViaDaemon(diffIDs: snapshot.rootfsLayers)
-            if !resolved.isEmpty {
-                return resolved
+            switch await resolveViaDaemon(diffIDs: snapshot.rootfsLayers) {
+            case .resolved(let paths) where !paths.isEmpty:
+                return paths
+            case .resolved:
+                throw ImageFilesTabError.missingRootPath
+            case .failed(let message):
+                throw ImageFilesTabError.resolutionFailed(message)
+            case .cancelled:
+                throw CancellationError()
             }
-            throw ImageFilesTabError.missingRootPath
         } catch let error as ImageFilesTabError {
             throw error
+        } catch let error as CancellationError {
+            throw error
         } catch {
+            try Task.checkCancellation()
+            Log.image.error(
+                "Failed to inspect image: \(error.localizedDescription, privacy: .private)")
             throw ImageFilesTabError.inspectFailed(error.localizedDescription)
         }
     }
@@ -243,21 +267,27 @@ struct ImageFilesTab: View {
     /// Resolves the image's layer directories via the daemon, keyed by the
     /// layer chain ID computed from the inspect diff IDs. The daemon returns
     /// them in overlay precedence order, topmost layer first.
-    private func resolveViaDaemon(diffIDs: [String]) async -> [String] {
-        guard let arcboxClient,
-            let topChainID = ImageLayerChain.topChainID(diffIDs: diffIDs)
-        else { return [] }
+    private func resolveViaDaemon(diffIDs: [String]) async -> FilesTabPathResolution {
+        guard let topChainID = ImageLayerChain.topChainID(diffIDs: diffIDs) else {
+            return .resolved([])
+        }
+        guard let arcboxClient else {
+            return .failed("ArcBox daemon is unavailable.")
+        }
         var request = Arcbox_V1_ResolveImageFsRequest()
         request.topChainID = topChainID
-        do {
-            let response = try await arcboxClient.system.resolveImageFs(
-                request, options: ArcBoxClient.defaultCallOptions)
-            return response.lowerDirs.filter { !$0.isEmpty }
-        } catch {
-            Log.daemon.error(
-                "Failed to resolve image fs: \(error.localizedDescription, privacy: .private)")
-            return []
-        }
+        return await FilesTabPathResolution.resolve(
+            subject: "image",
+            operation: {
+                let response = try await arcboxClient.system.resolveImageFs(
+                    request, options: ArcBoxClient.defaultCallOptions)
+                return response.lowerDirs.filter { !$0.isEmpty }
+            },
+            onFailure: { error in
+                Log.daemon.error(
+                    "Failed to resolve image fs: \(error.localizedDescription, privacy: .private)")
+            }
+        )
     }
 
     private func revealSelectedInFinder() {

--- a/ArcBox/Views/Images/Tabs/ImageTerminalTab.swift
+++ b/ArcBox/Views/Images/Tabs/ImageTerminalTab.swift
@@ -76,7 +76,8 @@ struct ImageTerminalTab: View {
         }
         .onChange(of: image.id) { _, newID in
             guard newID != connectedImageID else { return }
-            // Only reconnect if terminal is currently visible
+            session.disconnect()
+            connectedImageID = ""
             guard isActive else { return }
             connectToCurrentImage()
         }

--- a/ArcBox/Views/Networks/NetworksListViewController.swift
+++ b/ArcBox/Views/Networks/NetworksListViewController.swift
@@ -213,11 +213,11 @@ final class NetworksListViewController: NSViewController,
         }
 
         let canCopy = contextNetwork != nil
-        let canDelete = contextNetwork.map { !$0.isSystem } ?? false
+        let canDelete = contextNetwork?.canDelete ?? false
         menu.item(withTitle: "Copy Name")?.isEnabled = canCopy
         menu.item(withTitle: "Delete")?.isEnabled = canDelete
-        menu.item(withTitle: "Delete")?.isHidden = !canDelete
-        menu.items.first(where: \.isSeparatorItem)?.isHidden = !canDelete
+        menu.item(withTitle: "Delete")?.isHidden = contextNetwork?.isSystem ?? true
+        menu.items.first(where: \.isSeparatorItem)?.isHidden = contextNetwork?.isSystem ?? true
     }
 
     private func observeAndRender() {
@@ -418,12 +418,17 @@ final class NetworksListViewController: NSViewController,
     }
 
     @objc private func deleteContextNetwork() {
-        guard let contextNetwork, !contextNetwork.isSystem else { return }
+        guard let contextNetwork, contextNetwork.canDelete else { return }
         confirmDelete(contextNetwork)
     }
 
     private func confirmDelete(_ network: NetworkViewModel) {
-        guard !network.isSystem, deleteAlert == nil, let window = view.window else { return }
+        guard
+            network.canDelete,
+            viewModel.networks.first(where: { $0.id == network.id })?.canDelete == true,
+            deleteAlert == nil,
+            let window = view.window
+        else { return }
         let alert = NSAlert()
         alert.messageText = "Delete Network?"
         alert.informativeText =
@@ -540,11 +545,11 @@ private final class NetworkTableCellView: NSTableCellView, ResourceListActionDis
         )
         nameLabel.stringValue = network.name
         driverLabel.stringValue = network.driverDisplay
-        canDelete = !network.isSystem
-        deleteButton.isEnabled = !network.isSystem
-        deleteButton.toolTip = network.isSystem ? nil : "Delete network"
+        canDelete = network.canDelete
+        deleteButton.isEnabled = network.canDelete
+        deleteButton.toolTip = network.canDelete ? "Delete network" : nil
         deleteButton.setAccessibilityLabel("Delete \(network.name)")
-        self.onDelete = network.isSystem ? nil : onDelete
+        self.onDelete = network.canDelete ? onDelete : nil
         updateActionVisibility()
         setAccessibilityElement(true)
         setAccessibilityLabel(

--- a/ArcBoxTests/CreateOperationErrorTests.swift
+++ b/ArcBoxTests/CreateOperationErrorTests.swift
@@ -1,3 +1,4 @@
+import DockerClient
 import XCTest
 
 @testable import ArcBox
@@ -105,5 +106,110 @@ final class CreateOperationErrorTests: XCTestCase {
         vm.lastError = "left over from a previous delete"
         _ = await vm.createVolume(name: "data", docker: nil)
         XCTAssertNotEqual(vm.lastError, "left over from a previous delete")
+    }
+}
+
+@MainActor
+final class ResourceDeletionTests: XCTestCase {
+    func testAttachedImageAndNetworkAreRejectedBeforeDocker() async {
+        let imageViewModel = ImagesViewModel()
+        imageViewModel.images = [
+            ImageViewModel(
+                id: "image",
+                dockerId: "sha256:image",
+                repository: "postgres",
+                tag: "18",
+                sizeBytes: 0,
+                createdAt: nil,
+                inUse: true,
+                os: "linux",
+                architecture: "arm64"
+            )
+        ]
+        imageViewModel.selectedID = "image"
+        await imageViewModel.removeImage("image", dockerId: "sha256:image", docker: nil)
+        XCTAssertEqual(imageViewModel.selectedID, "image")
+        XCTAssertEqual(imageViewModel.lastError, "Image is in use and cannot be deleted.")
+
+        let networkViewModel = NetworksViewModel()
+        networkViewModel.networks = [
+            NetworkViewModel(
+                id: "network",
+                name: "project_default",
+                driver: "bridge",
+                scope: "local",
+                createdAt: .distantPast,
+                internal: false,
+                attachable: false,
+                containerCount: 1
+            )
+        ]
+        networkViewModel.selectedID = "network"
+        await networkViewModel.removeNetwork("network", docker: nil)
+        XCTAssertEqual(networkViewModel.selectedID, "network")
+        XCTAssertEqual(networkViewModel.lastError, "Network is in use and cannot be deleted.")
+    }
+
+    func testImageFailuresPreserveSelectionAndExposeDockerReason() {
+        let viewModel = ImagesViewModel()
+        viewModel.selectedID = "image"
+
+        let inUse = Operations.ImageDelete.Output.conflict(
+            .init(body: .json(.init(message: "image is referenced by a container")))
+        )
+        XCTAssertFalse(viewModel.applyImageDeletion(inUse, id: "image"))
+        XCTAssertEqual(viewModel.selectedID, "image")
+        XCTAssertEqual(viewModel.lastError, "image is referenced by a container")
+
+        let generic = Operations.ImageDelete.Output.internalServerError(
+            .init(body: .json(.init(message: "snapshotter failed")))
+        )
+        XCTAssertFalse(viewModel.applyImageDeletion(generic, id: "image"))
+        XCTAssertEqual(viewModel.selectedID, "image")
+        XCTAssertEqual(viewModel.lastError, "snapshotter failed")
+    }
+
+    func testVolumeFailuresPreserveSelectionAndExposeDockerReason() {
+        let viewModel = VolumesViewModel()
+        viewModel.selectedID = "data"
+
+        let inUse = Operations.VolumeDelete.Output.conflict(
+            .init(body: .json(.init(message: "volume is in use")))
+        )
+        XCTAssertFalse(viewModel.applyVolumeDeletion(inUse, name: "data"))
+        XCTAssertEqual(viewModel.selectedID, "data")
+        XCTAssertEqual(viewModel.lastError, "volume is in use")
+
+        let generic = Operations.VolumeDelete.Output.internalServerError(
+            .init(body: .json(.init(message: "storage driver failed")))
+        )
+        XCTAssertFalse(viewModel.applyVolumeDeletion(generic, name: "data"))
+        XCTAssertEqual(viewModel.selectedID, "data")
+        XCTAssertEqual(viewModel.lastError, "storage driver failed")
+
+        XCTAssertTrue(viewModel.applyVolumeDeletion(.noContent, name: "data"))
+        XCTAssertNil(viewModel.selectedID)
+    }
+
+    func testNetworkFailuresPreserveSelectionAndExposeDockerReason() {
+        let viewModel = NetworksViewModel()
+        viewModel.selectedID = "network"
+
+        let inUse = Operations.NetworkDelete.Output.forbidden(
+            .init(body: .json(.init(message: "network has active endpoints")))
+        )
+        XCTAssertFalse(viewModel.applyNetworkDeletion(inUse, id: "network"))
+        XCTAssertEqual(viewModel.selectedID, "network")
+        XCTAssertEqual(viewModel.lastError, "network has active endpoints")
+
+        let generic = Operations.NetworkDelete.Output.internalServerError(
+            .init(body: .json(.init(message: "network driver failed")))
+        )
+        XCTAssertFalse(viewModel.applyNetworkDeletion(generic, id: "network"))
+        XCTAssertEqual(viewModel.selectedID, "network")
+        XCTAssertEqual(viewModel.lastError, "network driver failed")
+
+        XCTAssertTrue(viewModel.applyNetworkDeletion(.noContent, id: "network"))
+        XCTAssertNil(viewModel.selectedID)
     }
 }

--- a/ArcBoxTests/DockerTerminalSessionIntegrationTests.swift
+++ b/ArcBoxTests/DockerTerminalSessionIntegrationTests.swift
@@ -1,0 +1,169 @@
+import SwiftTerm
+import XCTest
+
+@testable import ArcBox
+
+final class DockerTerminalSessionIntegrationTests: XCTestCase {
+    private struct CommandResult {
+        let status: Int32
+        let output: String
+    }
+
+    private var dockerPath: String?
+    private var dockerHost: String?
+    private var cleanupContainerNames: [String] = []
+    private var cleanupVolumeNames: [String] = []
+
+    override func tearDownWithError() throws {
+        defer {
+            dockerPath = nil
+            dockerHost = nil
+            cleanupContainerNames = []
+            cleanupVolumeNames = []
+        }
+
+        for name in cleanupContainerNames {
+            let result = try docker(["container", "rm", "--force", "--volumes", name])
+            if result.status != 0, !result.output.contains("No such container") {
+                XCTFail("Failed to remove integration container \(name): \(result.output)")
+            }
+        }
+        for name in cleanupVolumeNames {
+            let result = try docker(["volume", "rm", "--force", name])
+            if result.status != 0, !result.output.contains("No such volume") {
+                XCTFail("Failed to remove integration volume \(name): \(result.output)")
+            }
+        }
+    }
+
+    @MainActor
+    func testReplacingAndDisconnectingImageSessionRemovesContainersAndAnonymousVolumes() async throws {
+        try requireDockerWithPostgresImage()
+
+        let terminalView = TerminalView(frame: .zero)
+        let session = DockerTerminalSession()
+
+        session.runImage(imageName: "postgres:18", shell: "/bin/sh", terminalView: terminalView)
+        let firstContainer = try XCTUnwrap(session.activeImageContainerName)
+        cleanupContainerNames.append(firstContainer)
+        let firstVolumes = try await anonymousVolumes(whenContainerAppears: firstContainer)
+        cleanupVolumeNames.append(contentsOf: firstVolumes)
+
+        session.runImage(imageName: "postgres:18", shell: "/bin/sh", terminalView: terminalView)
+        let secondContainer = try XCTUnwrap(session.activeImageContainerName)
+        cleanupContainerNames.append(secondContainer)
+        let secondVolumes = try await anonymousVolumes(whenContainerAppears: secondContainer)
+        cleanupVolumeNames.append(contentsOf: secondVolumes)
+
+        try await assertRemoved(container: firstContainer, volumes: firstVolumes)
+
+        session.disconnect()
+
+        try await assertRemoved(container: secondContainer, volumes: secondVolumes)
+    }
+
+    @MainActor
+    func testImmediateDisconnectDoesNotLeaveALatePublishedContainer() async throws {
+        try requireDockerWithPostgresImage()
+
+        let session = DockerTerminalSession()
+        session.runImage(imageName: "postgres:18", shell: "/bin/sh", terminalView: TerminalView(frame: .zero))
+        let container = try XCTUnwrap(session.activeImageContainerName)
+        cleanupContainerNames.append(container)
+
+        session.disconnect()
+
+        try await Task.sleep(for: .seconds(2))
+        let result = try docker(["container", "inspect", "--format", "{{.Id}}", container])
+        XCTAssertNotEqual(result.status, 0, "Immediate disconnect left image terminal container \(container)")
+    }
+
+    @MainActor
+    private func requireDockerWithPostgresImage() throws {
+        guard let path = DockerCLIResolver.findDockerCLI() else {
+            throw XCTSkip("ABXD-137 integration requires a local Docker CLI")
+        }
+        dockerPath = path
+
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let profile = Bundle.main.object(forInfoDictionaryKey: "ArcBoxProfile") as? String
+        let dataDirectory =
+            profile?.caseInsensitiveCompare("development") == .orderedSame ? ".arcbox-dev" : ".arcbox"
+        let host = "unix://\(home)/\(dataDirectory)/run/docker.sock"
+        dockerHost = host
+
+        let info = try docker(["version", "--format", "{{.Server.Version}}"])
+        guard info.status == 0 else {
+            throw XCTSkip("ABXD-137 integration requires the ArcBox Docker engine at \(host)")
+        }
+
+        let image = try docker(["image", "inspect", "--format", "{{.Id}}", "postgres:18"])
+        guard image.status == 0 else {
+            throw XCTSkip("ABXD-137 integration requires the existing postgres:18 image; the test never pulls images")
+        }
+    }
+
+    @MainActor
+    private func anonymousVolumes(whenContainerAppears name: String) async throws -> [String] {
+        let appeared = try await eventually {
+            try docker(["container", "inspect", "--format", "{{.Id}}", name]).status == 0
+        }
+        XCTAssertTrue(appeared, "Image terminal container \(name) never appeared")
+
+        let result = try docker([
+            "container", "inspect", "--format",
+            "{{range .Mounts}}{{if eq .Type \"volume\"}}{{println .Name}}{{end}}{{end}}", name,
+        ])
+        XCTAssertEqual(result.status, 0, result.output)
+        let volumes = result.output.split(whereSeparator: \.isNewline).map(String.init)
+        XCTAssertFalse(volumes.isEmpty, "postgres:18 should create an anonymous data volume")
+        return volumes
+    }
+
+    @MainActor
+    private func assertRemoved(container: String, volumes: [String]) async throws {
+        let containerRemoved = try await eventually {
+            try docker(["container", "inspect", "--format", "{{.Id}}", container]).status != 0
+        }
+        XCTAssertTrue(containerRemoved, "Image terminal container \(container) still exists after disconnect")
+
+        for volume in volumes {
+            let volumeRemoved = try await eventually {
+                try docker(["volume", "inspect", "--format", "{{.Name}}", volume]).status != 0
+            }
+            XCTAssertTrue(volumeRemoved, "Anonymous volume \(volume) still exists after disconnect")
+        }
+    }
+
+    @MainActor
+    private func eventually(
+        timeout: TimeInterval = 10,
+        condition: () throws -> Bool
+    ) async throws -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if try condition() { return true }
+            try await Task.sleep(for: .milliseconds(200))
+        } while Date() < deadline
+        return false
+    }
+
+    private func docker(_ arguments: [String]) throws -> CommandResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: try XCTUnwrap(dockerPath))
+        process.arguments = ["--host", try XCTUnwrap(dockerHost)] + arguments
+
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = output
+
+        try process.run()
+        process.waitUntilExit()
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        return CommandResult(
+            status: process.terminationStatus,
+            output: try XCTUnwrap(String(data: data, encoding: .utf8))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+}

--- a/ArcBoxTests/DockerTerminalSessionIntegrationTests.swift
+++ b/ArcBoxTests/DockerTerminalSessionIntegrationTests.swift
@@ -41,6 +41,7 @@ final class DockerTerminalSessionIntegrationTests: XCTestCase {
         try requireDockerWithPostgresImage()
 
         let terminalView = TerminalView(frame: .zero)
+        terminalView.resize(cols: 80, rows: 24)
         let session = DockerTerminalSession()
 
         session.runImage(imageName: "postgres:18", shell: "/bin/sh", terminalView: terminalView)
@@ -49,6 +50,18 @@ final class DockerTerminalSessionIntegrationTests: XCTestCase {
         let firstVolumes = try await anonymousVolumes(whenContainerAppears: firstContainer)
         cleanupVolumeNames.append(contentsOf: firstVolumes)
 
+        let trapCommand = Data(
+            "trap 'printf \"OLD-%s\\n\" \"SESSION\"' TERM; printf \"TRAP-%s\\n\" \"READY\"\r".utf8
+        )
+        let trapReady = try await eventually {
+            let output = String(bytes: terminalView.getTerminal().getBufferAsData(), encoding: .utf8)
+            if output?.contains("TRAP-READY") == true { return true }
+            session.send(trapCommand)
+            return false
+        }
+        XCTAssertTrue(trapReady, "Image terminal never installed its TERM trap")
+        terminalView.getTerminal().resetToInitialState()
+
         session.runImage(imageName: "postgres:18", shell: "/bin/sh", terminalView: terminalView)
         let secondContainer = try XCTUnwrap(session.activeImageContainerName)
         cleanupContainerNames.append(secondContainer)
@@ -56,6 +69,23 @@ final class DockerTerminalSessionIntegrationTests: XCTestCase {
         cleanupVolumeNames.append(contentsOf: secondVolumes)
 
         try await assertRemoved(container: firstContainer, volumes: firstVolumes)
+
+        let newShellReadyProbe = Data("printf \"NEW-%s\\n\" \"READY\"\r".utf8)
+        let newShellReady = try await eventually {
+            let output = String(bytes: terminalView.getTerminal().getBufferAsData(), encoding: .utf8)
+            if output?.contains("NEW-READY") == true { return true }
+            session.send(newShellReadyProbe)
+            return false
+        }
+        XCTAssertTrue(newShellReady, "Replacement image terminal shell never became ready")
+
+        let outputAfterReplacement = try XCTUnwrap(
+            String(bytes: terminalView.getTerminal().getBufferAsData(), encoding: .utf8)
+        )
+        XCTAssertFalse(
+            outputAfterReplacement.contains("OLD-SESSION"),
+            "Old image terminal output appeared after replacement"
+        )
 
         session.disconnect()
 

--- a/ArcBoxTests/ImagesListViewControllerTests.swift
+++ b/ArcBoxTests/ImagesListViewControllerTests.swift
@@ -37,52 +37,40 @@ final class ImagesListViewControllerTests: XCTestCase {
         ]
         try await waitUntil { tableView.numberOfRows == 5 }
         XCTAssertFalse(try XCTUnwrap(tableView.enclosingScrollView).isHidden)
+        XCTAssertEqual(sectionTitle(at: 0, in: tableView), "In Use")
+        XCTAssertEqual(sectionTitle(at: 2, in: tableView), "Unused")
         XCTAssertEqual(
             tableView.menu?.items.filter { !$0.isSeparatorItem }.map(\.title),
             ["Copy Name", "Copy ID", "Delete"]
         )
 
-        let nginxRow = try XCTUnwrap(row(named: "nginx:latest", in: tableView))
-        let nginxCell = try XCTUnwrap(
-            tableView.view(atColumn: 0, row: nginxRow, makeIfNecessary: true)
-                as? NSTableCellView
-        )
-        let deleteButton = try XCTUnwrap(deleteButton(in: nginxCell))
-        XCTAssertTrue(deleteButton is ResourceActionButton)
+        let (nginxRow, nginxCell) = try rowAndCell(named: "nginx:latest", in: tableView)
+        let nginxDeleteButton = try XCTUnwrap(deleteButton(in: nginxCell))
+        XCTAssertTrue(nginxDeleteButton is ResourceActionButton)
         nginxCell.frame = NSRect(x: 0, y: 0, width: 360, height: AppMetrics.rowHeight)
         nginxCell.layoutSubtreeIfNeeded()
-        let content = try XCTUnwrap(deleteButton.superview as? NSStackView)
+        let content = try XCTUnwrap(nginxDeleteButton.superview as? NSStackView)
         let labels = content.arrangedSubviews[1]
-        XCTAssertTrue(deleteButton.isHidden)
-        XCTAssertTrue(deleteButton.isEnabled)
+        XCTAssertTrue(nginxDeleteButton.isHidden)
+        XCTAssertFalse(nginxDeleteButton.isEnabled)
         XCTAssertEqual(content.spacing, 12)
         XCTAssertEqual(content.frame.minX, 24, accuracy: 0.5)
         XCTAssertEqual(nginxCell.bounds.maxX - content.frame.maxX, 24, accuracy: 0.5)
         XCTAssertEqual(labels.frame.maxX, content.bounds.maxX, accuracy: 0.5)
 
-        let architectureLabel = try XCTUnwrap(textField(titled: "amd64", in: nginxCell))
-        let architectureBox = try XCTUnwrap(ancestorBox(of: architectureLabel))
-        let architectureLabelFrame = architectureLabel.convert(
-            architectureLabel.bounds,
-            to: architectureBox
-        )
-        XCTAssertEqual(architectureLabelFrame.minX, 6, accuracy: 0.5)
-        XCTAssertEqual(
-            architectureBox.bounds.maxX - architectureLabelFrame.maxX,
-            6,
-            accuracy: 0.5
-        )
-        XCTAssertEqual(architectureLabelFrame.minY, 2, accuracy: 0.5)
-        XCTAssertEqual(
-            architectureBox.bounds.maxY - architectureLabelFrame.maxY,
-            2,
-            accuracy: 0.5
-        )
+        try assertArchitectureBadgeInsets(in: nginxCell)
 
         tableView.selectRowIndexes(IndexSet(integer: nginxRow), byExtendingSelection: false)
         nginxCell.layoutSubtreeIfNeeded()
-        XCTAssertFalse(deleteButton.isHidden)
-        XCTAssertEqual(deleteButton.frame.minX - labels.frame.maxX, 12, accuracy: 0.5)
+        XCTAssertTrue(nginxDeleteButton.isHidden)
+
+        let (postgresRow, postgresCell) = try rowAndCell(named: "postgres:latest", in: tableView)
+        let postgresDeleteButton = try XCTUnwrap(deleteButton(in: postgresCell))
+        postgresCell.frame = NSRect(x: 0, y: 0, width: 360, height: AppMetrics.rowHeight)
+        tableView.selectRowIndexes(IndexSet(integer: postgresRow), byExtendingSelection: false)
+        postgresCell.layoutSubtreeIfNeeded()
+        XCTAssertTrue(postgresDeleteButton.isEnabled)
+        XCTAssertFalse(postgresDeleteButton.isHidden)
         tableView.deselectAll(nil)
         nginxCell.layoutSubtreeIfNeeded()
         XCTAssertEqual(labels.frame.maxX, content.bounds.maxX, accuracy: 0.5)
@@ -171,6 +159,23 @@ final class ImagesListViewControllerTests: XCTestCase {
     }
 
     @MainActor
+    private func sectionTitle(at row: Int, in tableView: NSTableView) -> String? {
+        (tableView.view(atColumn: 0, row: row, makeIfNecessary: true) as? NSTableCellView)?
+            .textField?.stringValue
+    }
+
+    @MainActor
+    private func rowAndCell(
+        named name: String,
+        in tableView: NSTableView
+    ) throws -> (Int, NSTableCellView) {
+        let row = try XCTUnwrap(row(named: name, in: tableView))
+        let cell = try XCTUnwrap(
+            tableView.view(atColumn: 0, row: row, makeIfNecessary: true) as? NSTableCellView)
+        return (row, cell)
+    }
+
+    @MainActor
     private func deleteButton(in view: NSView) -> NSButton? {
         if let button = view as? NSButton,
             button.identifier == NSUserInterfaceItemIdentifier("ImageDeleteButton")
@@ -198,6 +203,17 @@ final class ImagesListViewControllerTests: XCTestCase {
             ancestor = current.superview
         }
         return nil
+    }
+
+    @MainActor
+    private func assertArchitectureBadgeInsets(in cell: NSTableCellView) throws {
+        let label = try XCTUnwrap(textField(titled: "amd64", in: cell))
+        let box = try XCTUnwrap(ancestorBox(of: label))
+        let frame = label.convert(label.bounds, to: box)
+        XCTAssertEqual(frame.minX, 6, accuracy: 0.5)
+        XCTAssertEqual(box.bounds.maxX - frame.maxX, 6, accuracy: 0.5)
+        XCTAssertEqual(frame.minY, 2, accuracy: 0.5)
+        XCTAssertEqual(box.bounds.maxY - frame.maxY, 2, accuracy: 0.5)
     }
 
     private func image(

--- a/ArcBoxTests/ImagesViewModelTests.swift
+++ b/ArcBoxTests/ImagesViewModelTests.swift
@@ -122,6 +122,59 @@ final class ImagesViewModelTests: XCTestCase {
         XCTAssertEqual(vm.sortedImages.map(\.repository), ["small", "big"])
     }
 
+    func testMissingZeroPartialAndValidMetadataDoesNotRenderPlaceholders() {
+        let unknown = makeImage(
+            id: "unknown",
+            repository: "unknown",
+            tag: "latest",
+            createdAt: nil,
+            os: "",
+            architecture: ""
+        )
+        XCTAssertEqual(unknown.createdAgo, "Unknown")
+        XCTAssertNil(unknown.platformDisplay)
+        XCTAssertEqual(
+            makeImage(
+                id: "zero",
+                repository: "zero",
+                tag: "latest",
+                createdAt: Date(timeIntervalSince1970: 0)
+            ).createdAgo,
+            "Unknown"
+        )
+
+        XCTAssertEqual(
+            makeImage(
+                id: "os",
+                repository: "os",
+                tag: "latest",
+                os: "linux",
+                architecture: ""
+            ).platformDisplay,
+            "linux"
+        )
+        XCTAssertEqual(
+            makeImage(
+                id: "architecture",
+                repository: "architecture",
+                tag: "latest",
+                os: "",
+                architecture: "arm64"
+            ).platformDisplay,
+            "arm64"
+        )
+        XCTAssertEqual(
+            makeImage(
+                id: "valid",
+                repository: "valid",
+                tag: "latest",
+                os: "linux",
+                architecture: "arm64"
+            ).platformDisplay,
+            "linux/arm64"
+        )
+    }
+
     // MARK: - Search Filtering
 
     func testSearchFiltersByRepository() {
@@ -158,7 +211,10 @@ final class ImagesViewModelTests: XCTestCase {
         id: String,
         repository: String,
         tag: String,
-        sizeBytes: UInt64 = 0
+        sizeBytes: UInt64 = 0,
+        createdAt: Date? = Date(),
+        os: String = "linux",
+        architecture: String = "arm64"
     ) -> ImageViewModel {
         ImageViewModel(
             id: id,
@@ -166,10 +222,10 @@ final class ImagesViewModelTests: XCTestCase {
             repository: repository,
             tag: tag,
             sizeBytes: sizeBytes,
-            createdAt: Date(),
+            createdAt: createdAt,
             inUse: false,
-            os: "linux",
-            architecture: "arm64"
+            os: os,
+            architecture: architecture
         )
     }
 }

--- a/ArcBoxTests/ImagesViewModelTests.swift
+++ b/ArcBoxTests/ImagesViewModelTests.swift
@@ -1,3 +1,4 @@
+import DockerClient
 import XCTest
 
 @testable import ArcBox
@@ -173,6 +174,33 @@ final class ImagesViewModelTests: XCTestCase {
             ).platformDisplay,
             "linux/arm64"
         )
+    }
+
+    func testImageMetadataInspectionKeepsSuccessfulResultsWhenOneInspectFails() async throws {
+        struct InspectFailure: Error {}
+
+        let metadata = try await ImagesViewModel.inspectImageMetadata(
+            imageIDs: ["missing", "present"]
+        ) { id in
+            if id == "missing" { throw InspectFailure() }
+            return ImageInspectSnapshot(labels: [:], os: "linux", architecture: "arm64")
+        }
+
+        XCTAssertNil(metadata["missing"])
+        XCTAssertEqual(metadata["present"]?.os, "linux")
+        XCTAssertEqual(metadata["present"]?.architecture, "arm64")
+    }
+
+    func testImageMetadataInspectionPropagatesCancellation() async {
+        do {
+            _ = try await ImagesViewModel.inspectImageMetadata(imageIDs: ["image"]) { _ in
+                throw CancellationError()
+            }
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
     }
 
     // MARK: - Search Filtering

--- a/ArcBoxTests/LayerStackTests.swift
+++ b/ArcBoxTests/LayerStackTests.swift
@@ -3,6 +3,12 @@ import XCTest
 @testable import ArcBox
 
 final class LayerStackTests: XCTestCase {
+    private enum ResolutionError: LocalizedError {
+        case permissionDenied
+
+        var errorDescription: String? { "permission denied" }
+    }
+
     func testFreshStackDescribesNothing() {
         let stack = LayerStack()
 
@@ -63,6 +69,54 @@ final class LayerStackTests: XCTestCase {
         XCTAssertEqual(
             LayerStack.unresolved(guestPaths: ["/var/lib/docker/definitely-absent-\(UUID())"]),
             .exportUnavailable)
+    }
+
+    func testPathResolutionDistinguishesEmptySuccessFromRequestFailure() async {
+        var loggedFailure = false
+        let empty = await FilesTabPathResolution.resolve(
+            subject: "container",
+            operation: { [] },
+            onFailure: { _ in loggedFailure = true }
+        )
+
+        XCTAssertEqual(empty, .resolved([]))
+        XCTAssertNil(empty.errorMessage)
+        XCTAssertFalse(loggedFailure)
+
+        let failure = await FilesTabPathResolution.resolve(
+            subject: "container",
+            operation: { throw ResolutionError.permissionDenied },
+            onFailure: { _ in loggedFailure = true }
+        )
+
+        XCTAssertEqual(failure.errorMessage, "Couldn’t load container files. permission denied")
+        XCTAssertEqual(FilesTabPathResolution.retryTitle, "Retry")
+        XCTAssertTrue(loggedFailure)
+    }
+
+    func testCancelledPathResolutionDoesNotPublishStaleSuccessOrLogFailure() async {
+        let task = Task {
+            var loggedFailure = false
+            let resolution = await FilesTabPathResolution.resolve(
+                subject: "container",
+                operation: {
+                    do {
+                        try await Task.sleep(for: .seconds(60))
+                    } catch is CancellationError {
+                        return ["/stale"]
+                    }
+                    return []
+                },
+                onFailure: { _ in loggedFailure = true }
+            )
+            return (resolution, loggedFailure)
+        }
+
+        task.cancel()
+        let (resolution, loggedFailure) = await task.value
+
+        XCTAssertEqual(resolution, .cancelled)
+        XCTAssertFalse(loggedFailure)
     }
 
     func testAnUnbrowsableStackDescribesNothing() async {

--- a/ArcBoxTests/LayeredRootFSTests.swift
+++ b/ArcBoxTests/LayeredRootFSTests.swift
@@ -31,7 +31,6 @@ final class LayeredRootFSTests: XCTestCase {
             url: URL(fileURLWithPath: "/\(layer)/\(name)"),
             name: name,
             isDirectory: false,
-            isPackage: false,
             isSymbolicLink: false,
             sizeBytes: 0,
             modifiedDate: nil,
@@ -205,6 +204,41 @@ final class LayeredRootFSTests: XCTestCase {
         let items = try LocalRootFSService.listLayerItems(at: root, showHiddenFiles: false)
 
         XCTAssertEqual(items.map(\.isWhiteout), [false])
+    }
+
+    func testGuestEntriesUseNeutralKinds() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let file = root.appendingPathComponent("settings.conf")
+        let executable = root.appendingPathComponent("run")
+        let directory = root.appendingPathComponent("Example.app", isDirectory: true)
+        let symlink = root.appendingPathComponent("settings-link")
+        try "config".write(to: file, atomically: true, encoding: .utf8)
+        try "#!/bin/sh".write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: file)
+
+        let entries = try LocalRootFSService.listDirectory(at: root, showHiddenFiles: true)
+        let byName = Dictionary(uniqueKeysWithValues: entries.map { ($0.name, $0) })
+
+        XCTAssertEqual(byName["settings.conf"]?.kind, "File")
+        XCTAssertEqual(byName["run"]?.kind, "Executable")
+        XCTAssertEqual(byName["Example.app"]?.kind, "Directory")
+        XCTAssertTrue(try XCTUnwrap(byName["Example.app"]?.isExpandable))
+        XCTAssertEqual(byName["settings-link"]?.kind, "Symlink")
+    }
+
+    @MainActor
+    func testDisplayPathDoesNotExposeHostLayerPath() {
+        let etc = LocalFileNode(entry: item("etc", layer: "host/snapshot").entry, parent: nil)
+        let hosts = LocalFileNode(entry: item("hosts", layer: "host/snapshot/etc").entry, parent: etc)
+
+        XCTAssertEqual(hosts.displayPath(rootPath: "/"), "/etc/hosts")
     }
 
     func testListDirectoryReportsExcludedLayers() throws {

--- a/ArcBoxTests/NetworkDetailViewControllerTests.swift
+++ b/ArcBoxTests/NetworkDetailViewControllerTests.swift
@@ -56,6 +56,7 @@ final class NetworkDetailViewControllerTests: XCTestCase {
 
         viewModel.networks = [network(containerCount: 1)]
         try await waitUntil { tableView.numberOfRows == 1 }
+        XCTAssertTrue(hasText("1 container", in: rootView))
         XCTAssertTrue(cellText(in: tableView, column: 1, row: 0).contains("Stopped"))
         XCTAssertEqual(attempts, 3)
 

--- a/ArcBoxTests/NetworksListViewControllerTests.swift
+++ b/ArcBoxTests/NetworksListViewControllerTests.swift
@@ -68,12 +68,10 @@ final class NetworksListViewControllerTests: XCTestCase {
         ]
         try await waitUntil { tableView.numberOfRows == 5 }
         XCTAssertFalse(try XCTUnwrap(tableView.enclosingScrollView).isHidden)
+        XCTAssertEqual(sectionTitle(at: 0, in: tableView), "In Use")
+        XCTAssertEqual(sectionTitle(at: 2, in: tableView), "Unused")
 
-        let systemRow = try XCTUnwrap(row(named: "host", in: tableView))
-        let systemCell = try XCTUnwrap(
-            tableView.view(atColumn: 0, row: systemRow, makeIfNecessary: true)
-                as? NSTableCellView
-        )
+        let (systemRow, systemCell) = try rowAndCell(named: "host", in: tableView)
         let systemDeleteButton = try XCTUnwrap(deleteButton(in: systemCell))
         XCTAssertTrue(systemDeleteButton is ResourceActionButton)
         systemCell.frame = NSRect(x: 0, y: 0, width: 360, height: AppMetrics.rowHeight)
@@ -84,11 +82,7 @@ final class NetworksListViewControllerTests: XCTestCase {
         XCTAssertFalse(systemDeleteButton.isEnabled)
         XCTAssertEqual(systemLabels.frame.maxX, systemContent.bounds.maxX, accuracy: 0.5)
 
-        let customRow = try XCTUnwrap(row(named: "frontend", in: tableView))
-        let customCell = try XCTUnwrap(
-            tableView.view(atColumn: 0, row: customRow, makeIfNecessary: true)
-                as? NSTableCellView
-        )
+        let (customRow, customCell) = try rowAndCell(named: "frontend", in: tableView)
         let customDeleteButton = try XCTUnwrap(deleteButton(in: customCell))
         XCTAssertTrue(customDeleteButton is ResourceActionButton)
         customCell.frame = NSRect(x: 0, y: 0, width: 360, height: AppMetrics.rowHeight)
@@ -96,19 +90,22 @@ final class NetworksListViewControllerTests: XCTestCase {
         let customContent = try XCTUnwrap(customDeleteButton.superview as? NSStackView)
         let customLabels = customContent.arrangedSubviews[1]
         XCTAssertTrue(customDeleteButton.isHidden)
-        XCTAssertTrue(customDeleteButton.isEnabled)
+        XCTAssertFalse(customDeleteButton.isEnabled)
         XCTAssertEqual(customContent.spacing, 12)
         XCTAssertEqual(customContent.frame.minX, 24, accuracy: 0.5)
         XCTAssertEqual(customCell.bounds.maxX - customContent.frame.maxX, 24, accuracy: 0.5)
         XCTAssertEqual(customLabels.frame.maxX, customContent.bounds.maxX, accuracy: 0.5)
         tableView.selectRowIndexes(IndexSet(integer: customRow), byExtendingSelection: false)
         customCell.layoutSubtreeIfNeeded()
-        XCTAssertFalse(customDeleteButton.isHidden)
-        XCTAssertEqual(
-            customDeleteButton.frame.minX - customLabels.frame.maxX,
-            12,
-            accuracy: 0.5
-        )
+        XCTAssertTrue(customDeleteButton.isHidden)
+
+        let (unusedRow, unusedCell) = try rowAndCell(named: "backend", in: tableView)
+        let unusedDeleteButton = try XCTUnwrap(deleteButton(in: unusedCell))
+        unusedCell.frame = NSRect(x: 0, y: 0, width: 360, height: AppMetrics.rowHeight)
+        tableView.selectRowIndexes(IndexSet(integer: unusedRow), byExtendingSelection: false)
+        unusedCell.layoutSubtreeIfNeeded()
+        XCTAssertTrue(unusedDeleteButton.isEnabled)
+        XCTAssertFalse(unusedDeleteButton.isHidden)
         XCTAssertEqual(customCell.imageView?.contentTintColor, .secondaryLabelColor)
         tableView.deselectAll(nil)
         customCell.layoutSubtreeIfNeeded()
@@ -197,6 +194,23 @@ final class NetworksListViewControllerTests: XCTestCase {
                 as? NSTableCellView
             return cell?.textField?.stringValue == name
         }
+    }
+
+    @MainActor
+    private func sectionTitle(at row: Int, in tableView: NSTableView) -> String? {
+        (tableView.view(atColumn: 0, row: row, makeIfNecessary: true) as? NSTableCellView)?
+            .textField?.stringValue
+    }
+
+    @MainActor
+    private func rowAndCell(
+        named name: String,
+        in tableView: NSTableView
+    ) throws -> (Int, NSTableCellView) {
+        let row = try XCTUnwrap(row(named: name, in: tableView))
+        let cell = try XCTUnwrap(
+            tableView.view(atColumn: 0, row: row, makeIfNecessary: true) as? NSTableCellView)
+        return (row, cell)
     }
 
     @MainActor

--- a/ArcBoxTests/NetworksListViewControllerTests.swift
+++ b/ArcBoxTests/NetworksListViewControllerTests.swift
@@ -35,6 +35,18 @@ final class NetworksListViewControllerTests: XCTestCase {
         XCTAssertNil(viewModel.lastError)
     }
 
+    func testNetworkInspectNotFoundIsSkippedButServerErrorsSurface() throws {
+        let missing = Operations.NetworkInspect.Output.notFound(
+            .init(body: .json(.init(message: "network disappeared")))
+        )
+        XCTAssertNil(try missing.networkForList)
+
+        let serverError = Operations.NetworkInspect.Output.internalServerError(
+            .init(body: .json(.init(message: "network driver failed")))
+        )
+        XCTAssertThrowsError(try serverError.networkForList)
+    }
+
     @MainActor
     func testStateSearchSelectionAndSystemNetworkDeletionRules() async throws {
         let viewModel = NetworksViewModel()

--- a/Packages/DockerClient/Sources/DockerClient/DockerClient/DockerClient+Inspect.swift
+++ b/Packages/DockerClient/Sources/DockerClient/DockerClient/DockerClient+Inspect.swift
@@ -99,12 +99,16 @@ private struct ContainerInspectDTO: Decodable {
 private struct ImageInspectDTO: Decodable {
     let config: ImageConfigDTO?
     let containerConfig: ImageConfigDTO?
+    let os: String?
+    let architecture: String?
     let graphDriver: GraphDriverDTO?
     let rootFS: RootFSDTO?
 
     var snapshot: ImageInspectSnapshot {
         ImageInspectSnapshot(
             labels: config?.normalizedLabels ?? containerConfig?.normalizedLabels ?? [:],
+            os: DockerClient.normalized(os),
+            architecture: DockerClient.normalized(architecture),
             rootfsMountPath: graphDriver?.imageRootfsMountPath,
             overlayUpperDir: graphDriver?.overlayUpperDir,
             rootfsLayers: rootFS?.layers ?? []
@@ -114,6 +118,8 @@ private struct ImageInspectDTO: Decodable {
     private enum CodingKeys: String, CodingKey {
         case config = "Config"
         case containerConfig = "ContainerConfig"
+        case os = "Os"
+        case architecture = "Architecture"
         case graphDriver = "GraphDriver"
         case rootFS = "RootFS"
     }
@@ -122,6 +128,8 @@ private struct ImageInspectDTO: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         config = try? container.decodeIfPresent(ImageConfigDTO.self, forKey: .config)
         containerConfig = try? container.decodeIfPresent(ImageConfigDTO.self, forKey: .containerConfig)
+        os = try? container.decodeIfPresent(String.self, forKey: .os)
+        architecture = try? container.decodeIfPresent(String.self, forKey: .architecture)
         graphDriver = try? container.decodeIfPresent(GraphDriverDTO.self, forKey: .graphDriver)
         rootFS = try? container.decodeIfPresent(RootFSDTO.self, forKey: .rootFS)
     }

--- a/Packages/DockerClient/Sources/DockerClient/DockerClient/DockerModels.swift
+++ b/Packages/DockerClient/Sources/DockerClient/DockerClient/DockerModels.swift
@@ -38,6 +38,8 @@ public struct ContainerInspectSnapshot: Sendable {
 @available(macOS 15.0, *)
 public struct ImageInspectSnapshot: Sendable {
     public let labels: [String: String]
+    public let os: String?
+    public let architecture: String?
     public let rootfsMountPath: String?
     /// Raw `GraphDriver.Data.UpperDir` of the image's top overlay2 layer.
     public let overlayUpperDir: String?
@@ -60,11 +62,15 @@ public struct ImageInspectSnapshot: Sendable {
 
     public init(
         labels: [String: String],
+        os: String? = nil,
+        architecture: String? = nil,
         rootfsMountPath: String? = nil,
         overlayUpperDir: String? = nil,
         rootfsLayers: [String] = []
     ) {
         self.labels = labels
+        self.os = os
+        self.architecture = architecture
         self.rootfsMountPath = rootfsMountPath
         self.overlayUpperDir = overlayUpperDir
         self.rootfsLayers = rootfsLayers


### PR DESCRIPTION
## Linear issues

- [ABXD-136](https://linear.app/arcboxlabs/issue/ABXD-136) — correct Image/Network in-use classification and destructive affordances
- [ABXD-137](https://linear.app/arcboxlabs/issue/ABXD-137) — clean up Image Terminal ephemeral containers and anonymous volumes
- [ABXD-138](https://linear.app/arcboxlabs/issue/ABXD-138) — handle missing image timestamps and platform metadata
- [ABXD-140](https://linear.app/arcboxlabs/issue/ABXD-140) — stop exposing host overlay paths and macOS file-kind semantics
- [ABXD-149](https://linear.app/arcboxlabs/issue/ABXD-149) — preserve resource selection after failed deletion
- [ABXD-151](https://linear.app/arcboxlabs/issue/ABXD-151) — distinguish Files RPC failures from successful empty results

## Root cause and user impact

Docker's image-list endpoint reports an unusable container count, network list data omits endpoint attachments, and deletion flows cleared selection before Docker confirmed success. Image inspect fallbacks dropped metadata, Image Terminal teardown killed the CLI without reliably removing the named container/volumes, and Files tabs collapsed daemon failures into empty results while presenting host-side paths and Launch Services metadata.

Together these bugs could offer destructive actions for in-use resources, leave hidden containers and volumes behind, show malformed metadata, lose context after a failed delete, and misrepresent guest filesystem data.

## Changes

- Source image usage from system data usage and network usage from per-network inspect; centralize delete eligibility across view models and UI actions.
- Tear down uniquely named Image Terminal containers deterministically, including replacement, EOF, and immediate-close races, with exact-name volume cleanup.
- Render absent image timestamps as Unknown and omit unavailable platform components.
- Keep guest-visible paths and neutral File/Directory/Symlink/Executable kinds while retaining host URLs only for host actions.
- Clear Image/Volume/Network selection only after confirmed deletion success and preserve Docker failure reasons.
- Represent Files results as resolved, failed, or cancelled so empty success, RPC failure, and stale task cancellation remain distinct.

## Verification

- `make generate-xcodeproj`
- `make format`
- `make lint` — 0 violations
- Focused regression suite — 59 tests passed
- Real Docker terminal cleanup integration suite — 2 tests passed, 0 skipped
- `make test` — 238 XCTest tests and 84 Swift Testing tests passed
- `git diff --check`
