### PR TITLE
fix: align production UX with supported capabilities (ABXD-139, ABXD-141, ABXD-142, ABXD-144, ABXD-152)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,12 @@ jobs:
             --arcbox-ref "${{ inputs.arcbox_ref }}" \
             --tag "${{ inputs.tag }}"
 
+      - name: Extract curated release notes
+        run: |
+          cargo xtask release notes \
+            --version "${{ steps.resolve.outputs.version }}" \
+            --output release-notes.md
+
       - name: Checkout arcbox
         id: checkout_arcbox
         uses: actions/checkout@v6
@@ -650,6 +656,7 @@ jobs:
           path: |
             ${{ steps.dmg.outputs.dmg_path }}
             ${{ steps.dmg.outputs.dmg_path }}.sha256
+            release-notes.md
           retention-days: 30
 
       # Keychain cleanup is handled automatically by apple-actions/import-codesign-certs
@@ -704,8 +711,7 @@ jobs:
     needs: [build-dmg]
     runs-on: ubuntu-latest
     permissions:
-      # The releases/generate-notes API requires contents: write.
-      contents: write
+      contents: read
 
     steps:
       - name: Download DMG artifact
@@ -725,20 +731,13 @@ jobs:
 
       # Sparkle renders these inline in the update dialog. Linking the GitHub
       # release page instead would load the whole GitHub website in the dialog.
-      - name: Generate release notes HTML
-        id: release_notes
-        continue-on-error: true
+      - name: Render curated release notes HTML
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION="${{ needs.build-dmg.outputs.version }}"
-          gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-            -f tag_name="$VERSION" --jq '.body // empty' > notes.md
-          # GitHub-flavored HTML, with PR/compare URLs collapsed to short links
           gh api markdown -f mode=gfm -f context="$GITHUB_REPOSITORY" \
-            -F text=@notes.md > notes.html
+            -F text=@artifacts/release-notes.md > notes.html
           [ -s notes.html ]
-          echo "found=true" >> "$GITHUB_OUTPUT"
 
       - name: Generate appcast + latest.json
         id: feeds
@@ -750,14 +749,13 @@ jobs:
           DMG_NAME: ${{ needs.build-dmg.outputs.dmg }}
           DMG_LENGTH: ${{ needs.build-dmg.outputs.dmg_length }}
           ED_SIGNATURE: ${{ needs.build-dmg.outputs.ed_signature }}
-          HAS_NOTES: ${{ steps.release_notes.outputs.found }}
         with:
           script: |
             const fs = require('fs');
             const path = require('path');
 
             const {
-              VERSION, CHANNEL, BUILD_NUMBER, DMG_NAME, DMG_LENGTH, ED_SIGNATURE, HAS_NOTES,
+              VERSION, CHANNEL, BUILD_NUMBER, DMG_NAME, DMG_LENGTH, ED_SIGNATURE,
             } = process.env;
             const displayVersion = VERSION.replace(/^v/, '');
             const dmgUrl = `https://release.arcboxcdn.com/desktop/${VERSION}/${DMG_NAME}`;
@@ -786,9 +784,7 @@ jobs:
               const channelElement = CHANNEL !== 'stable'
                 ? `\n        <sparkle:channel>${CHANNEL}</sparkle:channel>`
                 : '';
-              const notesElement = releaseNotesHtml
-                ? `        <description>${cdata(releaseNotesHtml)}</description>`
-                : `        <sparkle:releaseNotesLink>https://github.com/arcboxlabs/arcbox-desktop/releases/tag/v${displayVersion}</sparkle:releaseNotesLink>`;
+              const notesElement = `        <description>${cdata(releaseNotesHtml)}</description>`;
               return [
                 '      <item>',
                 `        <title>ArcBox ${displayVersion}</title>`,
@@ -841,12 +837,7 @@ jobs:
               return merged.replace('    </channel>', `${item}\n    </channel>`);
             }
 
-            let releaseNotesHtml = null;
-            if (HAS_NOTES === 'true' && fs.existsSync('notes.html')) {
-              const raw = fs.readFileSync('notes.html', 'utf8').trim();
-              if (raw) releaseNotesHtml = raw;
-            }
-
+            const releaseNotesHtml = fs.readFileSync('notes.html', 'utf8').trim();
             const item = buildItem({ releaseNotesHtml });
             const existingAppcast = await fetchOptional(
               `https://release.arcboxcdn.com/desktop/appcast/${CHANNEL}.xml`,

--- a/ArcBox/App/ApplicationCoordinator.swift
+++ b/ArcBox/App/ApplicationCoordinator.swift
@@ -331,7 +331,7 @@ final class ApplicationCoordinator: NSObject {
     }
 
     private func completeOnboarding() {
-        guard !isTerminating, startupOrchestrator?.isReady == true else { return }
+        guard !isTerminating, startupOrchestrator?.isRuntimeReady == true else { return }
 
         AppPreferences.markOnboardingCompleted()
         isOnboarding = false

--- a/ArcBox/Services/SandboxEventMonitor.swift
+++ b/ArcBox/Services/SandboxEventMonitor.swift
@@ -23,7 +23,7 @@ final class SandboxEventMonitor {
 
     @ObservationIgnored private var debounceTask: Task<Void, Never>?
     private static let debounceInterval: Duration = .milliseconds(300)
-    private static let maxRecentEvents = 500
+    static let maxRecentEvents = 500
 
     // MARK: - Lifecycle
 

--- a/ArcBox/Support/ChangelogParser.swift
+++ b/ArcBox/Support/ChangelogParser.swift
@@ -14,6 +14,7 @@ struct ChangelogRelease: Identifiable, Sendable {
     var id: String { version }
     let version: String
     let date: String
+    let highlights: String?
     let sections: [ChangelogSection]
 }
 
@@ -40,32 +41,52 @@ enum ChangelogParser {
     nonisolated static func parse(_ text: String, limit: Int = 5) -> [ChangelogRelease] {
         let versionPattern = /^## \[(.+?)\](?:\(.+?\))?\s+\((\d{4}-\d{2}-\d{2})\)/
         let sectionPattern = /^### (.+)/
+        let userFacingSectionTitles = Set(["Features", "Bug Fixes", "Performance", "Security"])
 
         var releases: [ChangelogRelease] = []
         var currentVersion: String?
         var currentDate: String?
+        var currentHighlights: String?
         var currentSections: [ChangelogSection] = []
         var currentSectionTitle: String?
-        var currentItems: [String] = []
+        var currentSectionLines: [String] = []
 
         func flushSection() {
-            if let title = currentSectionTitle, !currentItems.isEmpty {
-                currentSections.append(ChangelogSection(title: title, items: currentItems))
+            if let title = currentSectionTitle {
+                if title == "Highlights" {
+                    currentHighlights = cleanHighlights(currentSectionLines)
+                } else if userFacingSectionTitles.contains(title) {
+                    let items = currentSectionLines.compactMap { line -> String? in
+                        let trimmed = line.trimmingCharacters(in: .whitespaces)
+                        guard trimmed.hasPrefix("* ") else { return nil }
+                        let item = cleanItem(String(trimmed.dropFirst(2)))
+                        return item.isEmpty ? nil : item
+                    }
+                    if !items.isEmpty {
+                        currentSections.append(ChangelogSection(title: title, items: items))
+                    }
+                }
             }
             currentSectionTitle = nil
-            currentItems = []
+            currentSectionLines = []
         }
 
         func flushRelease() {
             flushSection()
-            if let version = currentVersion, let date = currentDate {
+            if let version = currentVersion, let date = currentDate,
+                currentHighlights != nil || !currentSections.isEmpty
+            {
                 releases.append(
                     ChangelogRelease(
-                        version: version, date: date, sections: currentSections
+                        version: version,
+                        date: date,
+                        highlights: currentHighlights,
+                        sections: currentSections
                     ))
             }
             currentVersion = nil
             currentDate = nil
+            currentHighlights = nil
             currentSections = []
         }
 
@@ -80,8 +101,8 @@ enum ChangelogParser {
             } else if let match = trimmed.firstMatch(of: sectionPattern) {
                 flushSection()
                 currentSectionTitle = String(match.1)
-            } else if trimmed.hasPrefix("* ") {
-                currentItems.append(cleanItem(String(trimmed.dropFirst(2))))
+            } else if currentSectionTitle != nil {
+                currentSectionLines.append(line)
             }
         }
 
@@ -95,10 +116,10 @@ enum ChangelogParser {
 
     // MARK: - Private
 
-    /// Strip markdown link syntax from a changelog item for display.
+    /// Strip developer-facing markdown plumbing from a legacy changelog item.
     /// - Removes commit hash links: ([abc1234](url))
-    /// - Converts issue links: ([#123](url)) → #123
-    /// - Removes bold scope markers: **scope:** → scope:
+    /// - Removes issue/PR links: ([#123](url))
+    /// - Removes conventional-commit scopes: **scope:**
     nonisolated private static func cleanItem(_ text: String) -> String {
         var result = text
         // Remove commit hash links: ([a771d71](https://...))
@@ -107,18 +128,59 @@ enum ChangelogParser {
             with: "",
             options: .regularExpression
         )
-        // Convert issue links to plain text: ([#202](url)) → #202
+        // Remove issue/PR links: ([#202](url))
         result = result.replacingOccurrences(
-            of: #"\(\[(#\d+)\]\([^)]+\)\)"#,
-            with: "$1",
+            of: #"\s*\(\[#\d+\]\([^)]+\)\)"#,
+            with: "",
             options: .regularExpression
         )
-        // Remove bold scope prefix: **settings:** → settings:
+        // Remove a conventional-commit scope prefix: **settings:**
         result = result.replacingOccurrences(
-            of: #"\*\*(.+?):\*\*"#,
-            with: "$1:",
+            of: #"^\*\*[^*]+:\*\*\s*"#,
+            with: "",
             options: .regularExpression
         )
         return result.trimmingCharacters(in: .whitespaces)
+    }
+
+    /// Convert soft-wrapped Markdown under `### Highlights` into display prose.
+    nonisolated private static func cleanHighlights(_ lines: [String]) -> String? {
+        var paragraphs: [String] = []
+        var currentLines: [String] = []
+
+        func flushParagraph() {
+            if !currentLines.isEmpty {
+                paragraphs.append(currentLines.joined(separator: " "))
+                currentLines = []
+            }
+        }
+
+        for rawLine in lines {
+            var line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.hasPrefix(">") {
+                line = String(line.dropFirst()).trimmingCharacters(in: .whitespaces)
+            }
+            if line == "[!IMPORTANT]" {
+                continue
+            }
+            guard !line.isEmpty else {
+                flushParagraph()
+                continue
+            }
+
+            var cleaned = line.replacingOccurrences(
+                of: #"\[([^]]+)\]\([^)]+\)"#,
+                with: "$1",
+                options: .regularExpression
+            )
+            for marker in ["**", "__", "`"] {
+                cleaned = cleaned.replacingOccurrences(of: marker, with: "")
+            }
+            currentLines.append(cleaned)
+        }
+        flushParagraph()
+
+        let highlights = paragraphs.joined(separator: "\n\n")
+        return highlights.isEmpty ? nil : highlights
     }
 }

--- a/ArcBox/Views/About/AboutView/AboutView+ReleaseRow.swift
+++ b/ArcBox/Views/About/AboutView/AboutView+ReleaseRow.swift
@@ -15,8 +15,18 @@ extension AboutViewController {
         heading.spacing = 6
 
         var views: [NSView] = [heading]
-        for section in release.sections {
-            views.append(releaseSection(section))
+        if let highlights = release.highlights {
+            let summary = label(
+                highlights,
+                font: .systemFont(ofSize: 12),
+                color: .secondaryLabelColor
+            )
+            summary.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+            views.append(summary)
+        } else {
+            for section in release.sections {
+                views.append(releaseSection(section))
+            }
         }
         let row = verticalStack(views, spacing: 8)
         row.setAccessibilityElement(true)

--- a/ArcBox/Views/Activity/ActivityView.swift
+++ b/ArcBox/Views/Activity/ActivityView.swift
@@ -26,7 +26,7 @@ struct ActivityView: View {
             } else if !daemonManager.state.isRunning {
                 DaemonLoadingView(state: daemonManager.state)
             } else if !daemonManager.setupPhase.isDockerReady {
-                ProgressView("Starting ArcBox runtime…")
+                ProgressView(daemonManager.setupMessage)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if arcboxClient == nil {
                 ContentUnavailableView {

--- a/ArcBox/Views/Containers/ContainersListView.swift
+++ b/ArcBox/Views/Containers/ContainersListView.swift
@@ -17,7 +17,7 @@ struct ContainersListView: View {
             } else if !daemonManager.state.isRunning {
                 DaemonLoadingView(state: daemonManager.state)
             } else if !daemonManager.setupPhase.isDockerReady {
-                ProgressView("Starting Docker engine…")
+                ProgressView(daemonManager.setupMessage)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if docker == nil {
                 ContentUnavailableView {

--- a/ArcBox/Views/Images/ImagesListView.swift
+++ b/ArcBox/Views/Images/ImagesListView.swift
@@ -17,7 +17,7 @@ struct ImagesListView: View {
             } else if !daemonManager.state.isRunning {
                 DaemonLoadingView(state: daemonManager.state)
             } else if !daemonManager.setupPhase.isDockerReady {
-                ProgressView("Starting Docker engine…")
+                ProgressView(daemonManager.setupMessage)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if docker == nil {
                 ContentUnavailableView {

--- a/ArcBox/Views/Kubernetes/PodsListView.swift
+++ b/ArcBox/Views/Kubernetes/PodsListView.swift
@@ -5,26 +5,41 @@ import SwiftUI
 struct PodsListView: View {
     @Environment(KubernetesState.self) private var k8s
     @Environment(PodsViewModel.self) private var vm
+    @Environment(DaemonManager.self) private var daemonManager
+    @Environment(\.startupOrchestrator) private var orchestrator
     @Environment(\.arcboxClient) private var arcboxClient
 
     var body: some View {
-        PodsListControllerView(
-            state: k8s,
-            viewModel: vm,
-            canControl: arcboxClient != nil,
-            onCheckStatus: {
-                Task { await k8s.checkStatus(client: arcboxClient) }
-            },
-            onStart: {
-                Task { await k8s.start(client: arcboxClient) }
-            },
-            onStop: {
-                Task { await k8s.stop(client: arcboxClient) }
-            },
-            onRetryStreams: {
-                k8s.retryStreams(client: arcboxClient)
+        Group {
+            if let orchestrator, !orchestrator.isReady {
+                StartupProgressView(orchestrator: orchestrator)
+            } else if !daemonManager.state.isRunning {
+                DaemonLoadingView(state: daemonManager.state)
+            } else if !daemonManager.setupPhase.isDockerReady {
+                ProgressView(daemonManager.setupMessage)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if arcboxClient == nil {
+                DaemonLoadingView(state: .registered)
+            } else {
+                PodsListControllerView(
+                    state: k8s,
+                    viewModel: vm,
+                    canControl: true,
+                    onCheckStatus: {
+                        Task { await k8s.checkStatus(client: arcboxClient) }
+                    },
+                    onStart: {
+                        Task { await k8s.start(client: arcboxClient) }
+                    },
+                    onStop: {
+                        Task { await k8s.stop(client: arcboxClient) }
+                    },
+                    onRetryStreams: {
+                        k8s.retryStreams(client: arcboxClient)
+                    }
+                )
             }
-        )
+        }
         .navigationTitle("Pods")
         .navigationSubtitle(navigationSubtitle)
         .searchable(text: Bindable(vm).searchText, isPresented: Bindable(vm).isSearching)
@@ -49,7 +64,13 @@ struct PodsListView: View {
                     .labelsHidden()
                     .controlSize(.small)
                     .fixedSize()
-                    .disabled(arcboxClient == nil || !k8s.lifecycle.canToggle)
+                    .disabled(
+                        arcboxClient == nil
+                            || !daemonManager.state.isRunning
+                            || orchestrator?.isReady == false
+                            || !daemonManager.setupPhase.isDockerReady
+                            || !k8s.lifecycle.canToggle
+                    )
                     .help(k8s.lifecycle.toggleIsOn ? "Stop Kubernetes" : "Start Kubernetes")
                 }
                 .sharedBackgroundVisibility(.hidden)
@@ -68,18 +89,34 @@ struct PodsListView: View {
                     .labelsHidden()
                     .controlSize(.small)
                     .fixedSize()
-                    .disabled(arcboxClient == nil || !k8s.lifecycle.canToggle)
+                    .disabled(
+                        arcboxClient == nil
+                            || !daemonManager.state.isRunning
+                            || orchestrator?.isReady == false
+                            || !daemonManager.setupPhase.isDockerReady
+                            || !k8s.lifecycle.canToggle
+                    )
                     .help(k8s.lifecycle.toggleIsOn ? "Stop Kubernetes" : "Start Kubernetes")
                 }
             }
         }
-        .task(id: arcboxClient.map(ObjectIdentifier.init)) {
+        .task(id: daemonManager.setupPhase.isDockerReady && arcboxClient != nil) {
+            guard daemonManager.setupPhase.isDockerReady, arcboxClient != nil else { return }
             await k8s.checkStatus(client: arcboxClient)
         }
     }
 
     private var navigationSubtitle: String {
-        switch k8s.lifecycle {
+        if case .error = daemonManager.state {
+            return "Unavailable"
+        }
+        if orchestrator?.isReady == false || !daemonManager.state.isRunning
+            || !daemonManager.setupPhase.isDockerReady
+        {
+            return "Starting…"
+        }
+        guard arcboxClient != nil else { return "Unavailable" }
+        return switch k8s.lifecycle {
         case .checking: "Checking"
         case .disabled: "Disabled"
         case .starting: "Starting"

--- a/ArcBox/Views/Kubernetes/ServicesListView.swift
+++ b/ArcBox/Views/Kubernetes/ServicesListView.swift
@@ -5,26 +5,41 @@ import SwiftUI
 struct ServicesListView: View {
     @Environment(KubernetesState.self) private var k8s
     @Environment(ServicesViewModel.self) private var vm
+    @Environment(DaemonManager.self) private var daemonManager
+    @Environment(\.startupOrchestrator) private var orchestrator
     @Environment(\.arcboxClient) private var arcboxClient
 
     var body: some View {
-        ServicesListControllerView(
-            state: k8s,
-            viewModel: vm,
-            canControl: arcboxClient != nil,
-            onCheckStatus: {
-                Task { await k8s.checkStatus(client: arcboxClient) }
-            },
-            onStart: {
-                Task { await k8s.start(client: arcboxClient) }
-            },
-            onStop: {
-                Task { await k8s.stop(client: arcboxClient) }
-            },
-            onRetryStreams: {
-                k8s.retryStreams(client: arcboxClient)
+        Group {
+            if let orchestrator, !orchestrator.isReady {
+                StartupProgressView(orchestrator: orchestrator)
+            } else if !daemonManager.state.isRunning {
+                DaemonLoadingView(state: daemonManager.state)
+            } else if !daemonManager.setupPhase.isDockerReady {
+                ProgressView(daemonManager.setupMessage)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if arcboxClient == nil {
+                DaemonLoadingView(state: .registered)
+            } else {
+                ServicesListControllerView(
+                    state: k8s,
+                    viewModel: vm,
+                    canControl: true,
+                    onCheckStatus: {
+                        Task { await k8s.checkStatus(client: arcboxClient) }
+                    },
+                    onStart: {
+                        Task { await k8s.start(client: arcboxClient) }
+                    },
+                    onStop: {
+                        Task { await k8s.stop(client: arcboxClient) }
+                    },
+                    onRetryStreams: {
+                        k8s.retryStreams(client: arcboxClient)
+                    }
+                )
             }
-        )
+        }
         .navigationTitle("Services")
         .navigationSubtitle(navigationSubtitle)
         .searchable(text: Bindable(vm).searchText, isPresented: Bindable(vm).isSearching)
@@ -33,13 +48,23 @@ struct ServicesListView: View {
                 vm.searchText = ""
             }
         }
-        .task(id: arcboxClient.map(ObjectIdentifier.init)) {
+        .task(id: daemonManager.setupPhase.isDockerReady && arcboxClient != nil) {
+            guard daemonManager.setupPhase.isDockerReady, arcboxClient != nil else { return }
             await k8s.checkStatus(client: arcboxClient)
         }
     }
 
     private var navigationSubtitle: String {
-        switch k8s.lifecycle {
+        if case .error = daemonManager.state {
+            return "Unavailable"
+        }
+        if orchestrator?.isReady == false || !daemonManager.state.isRunning
+            || !daemonManager.setupPhase.isDockerReady
+        {
+            return "Starting…"
+        }
+        guard arcboxClient != nil else { return "Unavailable" }
+        return switch k8s.lifecycle {
         case .checking: "Checking"
         case .disabled: "Disabled"
         case .starting: "Starting"

--- a/ArcBox/Views/Machines/MachineEmptyStateView.swift
+++ b/ArcBox/Views/Machines/MachineEmptyStateView.swift
@@ -36,7 +36,7 @@ final class MachineEmptyStateView: NSView {
             views: [
                 Self.label("• Ubuntu, Debian, Fedora, and more"),
                 Self.label("• Native ARM64 performance on Apple Silicon"),
-                Self.label("• Seamless file sharing with macOS"),
+                Self.label("• Configurable CPU, memory, and disk"),
             ]
         )
         bulletStack.orientation = .vertical

--- a/ArcBox/Views/Machines/MachinesView.swift
+++ b/ArcBox/Views/Machines/MachinesView.swift
@@ -14,6 +14,9 @@ struct MachinesView: View {
                 StartupProgressView(orchestrator: orchestrator)
             } else if !daemonManager.state.isRunning {
                 DaemonLoadingView(state: daemonManager.state)
+            } else if !daemonManager.setupPhase.isDockerReady {
+                ProgressView(daemonManager.setupMessage)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if client == nil {
                 DaemonLoadingView(state: .registered)
             } else {
@@ -69,6 +72,7 @@ struct MachinesView: View {
                 .disabled(
                     client == nil
                         || !daemonManager.state.isRunning
+                        || !daemonManager.setupPhase.isDockerReady
                         || orchestrator?.isReady == false
                 )
             }
@@ -76,7 +80,8 @@ struct MachinesView: View {
         .sheet(isPresented: Bindable(vm).showCreateSheet) {
             MachineCreateSheet()
         }
-        .task(id: client.map(ObjectIdentifier.init)) {
+        .task(id: daemonManager.setupPhase.isDockerReady && client != nil) {
+            guard daemonManager.setupPhase.isDockerReady, client != nil else { return }
             await vm.loadMachines(client: client)
         }
         // MachineEventMonitor streams MachineService.Events and posts this on
@@ -85,6 +90,7 @@ struct MachinesView: View {
         // its own, a machine reset to stopped after daemon recovery — without
         // polling. loadMachines preserves in-flight transition and detail state.
         .onReceive(NotificationCenter.default.publisher(for: .machineChanged)) { _ in
+            guard daemonManager.setupPhase.isDockerReady, client != nil else { return }
             Task { await vm.loadMachines(client: client) }
         }
         .listErrorToast(
@@ -100,6 +106,9 @@ struct MachinesView: View {
         }
         guard daemonManager.state.isRunning, client != nil else {
             return "Waiting for daemon"
+        }
+        guard daemonManager.setupPhase.isDockerReady else {
+            return "Starting…"
         }
         return switch vm.loadState {
         case .waiting:

--- a/ArcBox/Views/Networks/NetworksListView.swift
+++ b/ArcBox/Views/Networks/NetworksListView.swift
@@ -16,7 +16,7 @@ struct NetworksListView: View {
             } else if !daemonManager.state.isRunning {
                 DaemonLoadingView(state: daemonManager.state)
             } else if !daemonManager.setupPhase.isDockerReady {
-                ProgressView("Starting Docker engine…")
+                ProgressView(daemonManager.setupMessage)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if docker == nil {
                 ContentUnavailableView {

--- a/ArcBox/Views/Onboarding/OnboardingView.swift
+++ b/ArcBox/Views/Onboarding/OnboardingView.swift
@@ -120,7 +120,7 @@ struct OnboardingView: View {
                 capabilityCell(
                     "Kubernetes",
                     symbol: NavItem.pods.sfSymbol,
-                    detail: "Manage local pods and services."
+                    detail: "Inspect local pods and services."
                 )
             }
 
@@ -130,7 +130,7 @@ struct OnboardingView: View {
                 capabilityCell(
                     "Linux VMs",
                     symbol: NavItem.machines.sfSymbol,
-                    detail: "Full Linux machines with terminal and files."
+                    detail: "Full Linux machines with terminal access."
                 )
                 Divider()
                 capabilityCell(
@@ -210,7 +210,7 @@ struct OnboardingView: View {
 
     @ViewBuilder
     private var setupPage: some View {
-        if orchestrator.isReady {
+        if orchestrator.isRuntimeReady {
             VStack(spacing: 16) {
                 Image(systemName: "checkmark.circle.fill")
                     .font(.system(size: 52))
@@ -280,7 +280,7 @@ struct OnboardingView: View {
                     }
                 }
             case .setup:
-                if orchestrator.isReady {
+                if orchestrator.isRuntimeReady {
                     Spacer()
                     primaryButton("Open ArcBox", action: onComplete)
                 } else {

--- a/ArcBox/Views/Sandboxes/SandboxDetailView.swift
+++ b/ArcBox/Views/Sandboxes/SandboxDetailView.swift
@@ -29,12 +29,14 @@ struct SandboxDetailView: View {
                 case .files:
                     if sandbox.state.isDataPlaneReady {
                         SandboxFilesTab(sandbox: sandbox)
+                            .id(sandbox.id)
                     } else {
                         tabUnavailable("Sandbox must be ready for file transfer")
                     }
                 case .ports:
                     if sandbox.state.isDataPlaneReady {
                         SandboxPortsTab(sandbox: sandbox)
+                            .id(sandbox.id)
                     } else {
                         tabUnavailable("Sandbox must be ready to expose ports")
                     }

--- a/ArcBox/Views/Sandboxes/SandboxesListView.swift
+++ b/ArcBox/Views/Sandboxes/SandboxesListView.swift
@@ -17,7 +17,7 @@ struct SandboxesListView: View {
             } else if !daemonManager.state.isRunning {
                 DaemonLoadingView(state: daemonManager.state)
             } else if !daemonManager.setupPhase.isDockerReady {
-                ProgressView("Starting ArcBox runtime…")
+                ProgressView(daemonManager.setupMessage)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if client == nil {
                 DaemonLoadingView(state: .registered)

--- a/ArcBox/Views/Sandboxes/Tabs/SandboxEventsTab.swift
+++ b/ArcBox/Views/Sandboxes/Tabs/SandboxEventsTab.swift
@@ -16,15 +16,20 @@ struct SandboxEventsTab: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            scopeNotice
+            Divider()
             if events.isEmpty {
                 VStack(spacing: 10) {
                     Spacer()
                     Image(systemName: "bolt")
                         .font(.system(size: 24))
                         .foregroundStyle(AppColors.textMuted)
-                    Text("No events received for this sandbox yet.")
+                    Text("No events retained for this sandbox.")
                         .font(.system(size: 13))
                         .foregroundStyle(AppColors.textSecondary)
+                    Text("Events sent before ArcBox connected or while it was disconnected aren’t available.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(AppColors.textMuted)
                     Spacer()
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -41,6 +46,18 @@ struct SandboxEventsTab: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(AppColors.background)
+    }
+
+    private var scopeNotice: some View {
+        Label(
+            "Events received while ArcBox is connected. The latest \(SandboxEventMonitor.maxRecentEvents) across all sandboxes are kept until quit.",
+            systemImage: "info.circle"
+        )
+        .font(.system(size: 11))
+        .foregroundStyle(AppColors.textMuted)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
     }
 
     private func eventRow(_ event: SandboxEventRecord) -> some View {

--- a/ArcBox/Views/Sandboxes/Tabs/SandboxFilesTab.swift
+++ b/ArcBox/Views/Sandboxes/Tabs/SandboxFilesTab.swift
@@ -18,9 +18,6 @@ private struct FileTransferRecord: Identifiable {
 }
 
 /// Files tab: path-based upload/download over the ReadFile/WriteFile RPCs.
-///
-/// sandbox.v1 has no directory-listing RPC, so this is a transfer surface,
-/// not a browser; a tree view needs a future ListDir API.
 struct SandboxFilesTab: View {
     let sandbox: SandboxViewModel
 
@@ -36,10 +33,24 @@ struct SandboxFilesTab: View {
         VStack(spacing: 0) {
             toolbar
             Divider()
+            scopeNotice
+            Divider()
             content
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(AppColors.background)
+    }
+
+    private var scopeNotice: some View {
+        Label(
+            "Use absolute paths; each file is limited to 256 MiB. Directory browsing isn’t available, and transfer results aren’t saved.",
+            systemImage: "info.circle"
+        )
+        .font(.system(size: 11))
+        .foregroundStyle(AppColors.textMuted)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
     }
 
     private var toolbar: some View {
@@ -92,12 +103,9 @@ struct SandboxFilesTab: View {
                 Image(systemName: "arrow.up.arrow.down.circle")
                     .font(.system(size: 24))
                     .foregroundStyle(AppColors.textMuted)
-                Text("Transfer files to and from the sandbox by absolute path.")
+                Text("Enter an absolute path to upload or download a file.")
                     .font(.system(size: 13))
                     .foregroundStyle(AppColors.textSecondary)
-                Text("Limited to 256 MiB per file. Directory browsing is not available in sandbox.v1.")
-                    .font(.system(size: 12))
-                    .foregroundStyle(AppColors.textMuted)
                 Spacer()
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/ArcBox/Views/Sandboxes/Tabs/SandboxPortsTab.swift
+++ b/ArcBox/Views/Sandboxes/Tabs/SandboxPortsTab.swift
@@ -26,10 +26,24 @@ struct SandboxPortsTab: View {
         VStack(spacing: 0) {
             toolbar
             Divider()
+            scopeNotice
+            Divider()
             content
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(AppColors.background)
+    }
+
+    private var scopeNotice: some View {
+        Label(
+            "This list only tracks mappings created by ArcBox since launch. CLI, SDK, and earlier mappings aren’t shown; listeners bind to localhost.",
+            systemImage: "info.circle"
+        )
+        .font(.system(size: 11))
+        .foregroundStyle(AppColors.textMuted)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
     }
 
     private var toolbar: some View {
@@ -70,10 +84,10 @@ struct SandboxPortsTab: View {
                 Image(systemName: "network")
                     .font(.system(size: 24))
                     .foregroundStyle(AppColors.textMuted)
-                Text("No ports exposed from this session.")
+                Text("No port mappings tracked since ArcBox launched.")
                     .font(.system(size: 13))
                     .foregroundStyle(AppColors.textSecondary)
-                Text("Host listeners bind on localhost. Mappings created by the CLI or SDK are not listed here.")
+                Text("Expose a port above to add it to this list.")
                     .font(.system(size: 12))
                     .foregroundStyle(AppColors.textMuted)
                     .multilineTextAlignment(.center)

--- a/ArcBox/Views/Shared/StartupProgressView.swift
+++ b/ArcBox/Views/Shared/StartupProgressView.swift
@@ -20,10 +20,20 @@ struct StartupProgressView: View {
                     ForEach(StartupStep.allCases) { step in
                         stepRow(step)
                     }
+
+                    if orchestrator.isReady, !orchestrator.isRuntimeReady,
+                        orchestrator.runtimeFailureMessage == nil
+                    {
+                        ProgressView(orchestrator.setupMessage)
+                            .controlSize(.small)
+                            .font(.system(size: 11))
+                            .foregroundStyle(AppColors.textSecondary)
+                            .padding(.top, 4)
+                    }
                 }
                 .padding(.horizontal, 40)
 
-                if case .failed(_, let message) = orchestrator.phase {
+                if let message = retryableErrorMessage {
                     VStack(spacing: 8) {
                         Text(message)
                             .font(.system(size: 12))
@@ -129,5 +139,12 @@ struct StartupProgressView: View {
         case .completed: return AppColors.textSecondary
         case .failed: return AppColors.error
         }
+    }
+
+    private var retryableErrorMessage: String? {
+        if case .failed(_, let message) = orchestrator.phase {
+            return message
+        }
+        return orchestrator.runtimeFailureMessage
     }
 }

--- a/ArcBox/Views/Volumes/VolumesListView.swift
+++ b/ArcBox/Views/Volumes/VolumesListView.swift
@@ -16,7 +16,7 @@ struct VolumesListView: View {
             } else if !daemonManager.state.isRunning {
                 DaemonLoadingView(state: daemonManager.state)
             } else if !daemonManager.setupPhase.isDockerReady {
-                ProgressView("Starting Docker engine…")
+                ProgressView(daemonManager.setupMessage)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if docker == nil {
                 ContentUnavailableView {

--- a/ArcBoxTests/ChangelogParserTests.swift
+++ b/ArcBoxTests/ChangelogParserTests.swift
@@ -59,6 +59,31 @@ final class ChangelogParserTests: XCTestCase {
         XCTAssertEqual(sections[1].items.count, 1)
     }
 
+    @MainActor func testParsesHighlightsAsPrimaryProse() {
+        let input = """
+            ## [2.0.0](https://example.com) (2026-04-01)
+
+            ### Highlights
+
+            **Builds finish faster.** Common projects now complete in
+            about half the time.
+
+            > [!IMPORTANT]
+            > Existing projects need no migration.
+
+            ### Features
+
+            * **build:** replace the internal scheduler ([#42](https://example.com/pull/42)) ([abc1234](https://example.com/commit/abc1234))
+            """
+        let release = ChangelogParser.parse(input).first
+
+        XCTAssertEqual(
+            release?.highlights,
+            "Builds finish faster. Common projects now complete in about half the time.\n\nExisting projects need no migration."
+        )
+        XCTAssertEqual(release?.sections.first?.items, ["replace the internal scheduler"])
+    }
+
     // MARK: - Bullet Items
 
     @MainActor func testParsesBulletItems() {
@@ -106,9 +131,9 @@ final class ChangelogParserTests: XCTestCase {
         XCTAssertEqual(item, "fix startup crash")
     }
 
-    // MARK: - cleanItem: Issue Link Conversion
+    // MARK: - cleanItem: Issue Link Removal
 
-    @MainActor func testConvertsIssueLinksToPlainText() {
+    @MainActor func testRemovesIssueLinks() {
         let input = """
             ## [1.0.0](https://example.com) (2026-01-01)
 
@@ -118,7 +143,7 @@ final class ChangelogParserTests: XCTestCase {
             """
         let releases = ChangelogParser.parse(input)
         let item = releases.first!.sections.first!.items.first!
-        XCTAssertEqual(item, "fix timeout #202")
+        XCTAssertEqual(item, "fix timeout")
     }
 
     // MARK: - cleanItem: Bold Scope Removal
@@ -133,7 +158,7 @@ final class ChangelogParserTests: XCTestCase {
             """
         let releases = ChangelogParser.parse(input)
         let item = releases.first!.sections.first!.items.first!
-        XCTAssertEqual(item, "settings: wire up functional settings")
+        XCTAssertEqual(item, "wire up functional settings")
     }
 
     // MARK: - cleanItem: Combined Cleanup
@@ -148,7 +173,7 @@ final class ChangelogParserTests: XCTestCase {
             """
         let releases = ChangelogParser.parse(input)
         let item = releases.first!.sections.first!.items.first!
-        XCTAssertEqual(item, "completions: install all bundled completions #205")
+        XCTAssertEqual(item, "install all bundled completions")
     }
 
     // MARK: - Limit Parameter
@@ -183,6 +208,37 @@ final class ChangelogParserTests: XCTestCase {
         XCTAssertEqual(one.first?.version, "3.0.0")
     }
 
+    @MainActor func testSkipsMechanicalOnlyReleasesBeforeApplyingLimit() {
+        let input = """
+            ## [3.0.0](https://example.com) (2026-03-01)
+
+            ### Miscellaneous
+
+            * chore(master): release 3.0.0
+
+            ### CI
+
+            * update the build runner
+
+            ## [2.0.0](https://example.com) (2026-02-01)
+
+            ### Bug Fixes
+
+            * **files:** keep mounted folders visible ([#20](https://example.com/pull/20)) ([abc1234](https://example.com/commit/abc1234))
+
+            ## [1.0.0](https://example.com) (2026-01-01)
+
+            ### Security
+
+            * validate downloaded updates
+            """
+
+        let releases = ChangelogParser.parse(input, limit: 2)
+
+        XCTAssertEqual(releases.map(\.version), ["2.0.0", "1.0.0"])
+        XCTAssertEqual(releases.first?.sections.first?.items, ["keep mounted folders visible"])
+    }
+
     // MARK: - Empty / Malformed Input
 
     @MainActor func testEmptyInputReturnsEmpty() {
@@ -202,16 +258,16 @@ final class ChangelogParserTests: XCTestCase {
         XCTAssertTrue(releases.isEmpty)
     }
 
-    @MainActor func testReleaseWithNoSectionsIsIncluded() {
-        // A version header with no ### sections and no items still produces a release
-        // (with empty sections array).
+    @MainActor func testReleaseWithNoUserFacingSectionsIsExcluded() {
         let input = """
             ## [1.0.0](https://example.com) (2026-01-01)
 
+            ### Refactoring
+
+            * migrate the internal presentation layer
             """
         let releases = ChangelogParser.parse(input)
-        XCTAssertEqual(releases.count, 1)
-        XCTAssertTrue(releases.first!.sections.isEmpty)
+        XCTAssertTrue(releases.isEmpty)
     }
 
     @MainActor func testReleaseWithEmptySectionsAreExcluded() {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [1.34.1](https://github.com/arcboxlabs/arcbox-desktop/compare/v1.34.0...v1.34.1) (2026-08-04)
 
+### Highlights
+
+Settings, onboarding, file pickers, and quit progress now open in the expected place and behave more like native macOS surfaces. Container domains also remain visible and show their configured addresses, making local services easier to identify.
+
 
 ### Bug Fixes
 
@@ -21,6 +25,10 @@
 
 ## [1.34.0](https://github.com/arcboxlabs/arcbox-desktop/compare/v1.33.0...v1.34.0) (2026-08-03)
 
+### Highlights
+
+Sandbox creation and terminal sessions are now more reliable when connections drop. Retried creation keeps one sandbox identity, while reconnected terminal sessions avoid replaying input.
+
 
 ### Features
 
@@ -32,6 +40,12 @@
 * bump arcbox version to v0.6.2 ([#360](https://github.com/arcboxlabs/arcbox-desktop/issues/360)) ([7d849f0](https://github.com/arcboxlabs/arcbox-desktop/commit/7d849f0dfcacadb60c8d67ddb4c4b78d275e2465))
 
 ## [1.33.0](https://github.com/arcboxlabs/arcbox-desktop/compare/v1.32.1...v1.33.0) (2026-08-02)
+
+### Highlights
+
+New installs now include guided setup and a replayable Getting Started tour for Machines, Containers, Kubernetes, and Sandboxes.
+
+The main window also behaves more like a native Mac app, with more consistent navigation, resource lists, detail tabs, window sizing, and quit flows.
 
 
 ### Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,10 @@ make test
   in the changelog.
 - Keep commits atomic and buildable.
 - No `Co-Authored-By` lines.
-- `CHANGELOG.md` and `Version.xcconfig` are generated. Never hand-edit them.
+- `CHANGELOG.md` and `Version.xcconfig` are generated. Do not edit them outside
+  the release-please PR. Before merging that PR, add a `### Highlights` section
+  under the new release with concise user-facing changes and impact; release
+  publication fails when it is missing.
 
 ## Reporting security issues
 

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Lifecycle.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Lifecycle.swift
@@ -84,22 +84,25 @@ extension DaemonManager {
 
     /// Force re-register the daemon with launchd, regardless of current status.
     ///
-    /// This is a **recovery-only** path for when the daemon is registered but
-    /// unreachable — typically after Xcode "Replace" (SIGKILL) prevents the
-    /// normal `disableDaemon()` cleanup from running, leaving a stale
-    /// registration with no live daemon process behind it.
+    /// This is a **recovery-only** path for when the daemon reported terminal
+    /// setup failure or is registered but unreachable — typically after Xcode
+    /// "Replace" (SIGKILL) prevents the normal `disableDaemon()` cleanup from
+    /// running, leaving a stale registration with no live daemon process behind it.
     ///
     /// ⚠️ REGRESSION GUARD — DO NOT call from `enableDaemon()` or any path
     /// reachable by SwiftUI `.task` re-entrancy.  The `enableDaemon()` "skip
     /// if .enabled" guard exists to prevent a **known bug** where redundant
     /// calls each unregister+register the daemon, killing it before it
-    /// finishes initializing.  This method must only be invoked **after** a
-    /// full poll timeout has confirmed the daemon is truly unreachable, not
-    /// merely slow to start.
+    /// finishes initializing. This method must only be invoked after a terminal
+    /// `FAILED` status or a full poll timeout confirms the daemon is unreachable,
+    /// not merely slow to start.
     public func forceReregisterDaemon() async {
         ClientLog.daemon.warning("Force re-registering daemon (recovery path)")
+        stopWatching()
         errorMessage = nil
         state = .starting
+        setupPhase = .unknown
+        setupMessage = ""
 
         do {
             try? await daemonService.unregister()

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/StartupOrchestrator/StartupOrchestrator.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/StartupOrchestrator/StartupOrchestrator.swift
@@ -48,10 +48,22 @@ public final class StartupOrchestrator {
     /// Whether all steps have completed successfully.
     public var isReady: Bool { phase == .completed }
 
+    /// Whether the daemon has also finished preparing the shared runtime.
+    public var isRuntimeReady: Bool { isReady && daemonManager.setupPhase.isDockerReady }
+
+    /// Current daemon-provided setup detail for progress UI.
+    public var setupMessage: String { daemonManager.setupMessage }
+
+    /// Fatal runtime setup error reported after the gRPC connection succeeds.
+    public var runtimeFailureMessage: String? {
+        guard isReady, case .error(let message) = daemonManager.state else { return nil }
+        return message
+    }
+
     /// Whether a retry is possible.
     public var canRetry: Bool {
         if case .failed = phase { return true }
-        return false
+        return runtimeFailureMessage != nil
     }
 
     // Dependencies

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/StartupOrchestrator/StartupOrchestrator.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/StartupOrchestrator/StartupOrchestrator.swift
@@ -261,6 +261,9 @@ public final class StartupOrchestrator {
     ///   itself an explicit administrator-approval action.
     @available(macOS 15.0, *)
     public func retry(allowingAdministratorPrompt: Bool = false) async {
+        if daemonManager.setupPhase == .failed {
+            await daemonManager.forceReregisterDaemon()
+        }
         await start(allowingAdministratorPrompt: allowingAdministratorPrompt)
     }
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ One three-column window — sources, list, detail — over everything the daemon
   opens onto info, streaming logs, an interactive terminal, and a file browser that reads through the
   overlay layers.
 - **Kubernetes** — pods and services from the daemon-managed k3s cluster.
-- **Machines** — full Linux VMs: create from a distro image, drive the lifecycle, then attach a terminal
-  or browse the guest filesystem.
+- **Machines** — full Linux VMs: create from a distro image, drive the lifecycle, and attach an
+  interactive terminal.
 - **Sandboxes** — disposable microVMs from templates, with ports, snapshots, and an event log.
 - **Activity** — live CPU, memory, and network for the system VM and every running container.
 

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -31,6 +31,7 @@ cargo xtask macos dmg --sign "Developer ID Application: …" --notarize
 | `protocol bump` | Update `arcbox.version` and regenerate the Swift protobuf client atomically. |
 | `protocol verify` | Regenerate the Swift protobuf client from `arcbox.version` and fail if checked-in generated files drift. |
 | `release resolve` | Resolve build version, channel, prerelease flag, and arcbox ref into `GITHUB_OUTPUT`. |
+| `release notes` | Extract the required curated Highlights for one release from `CHANGELOG.md`. |
 | `release appcast` | Generate or merge a Sparkle 2.x appcast XML feed. |
 | `release latest-json` | Update the `latest.json` channel manifest. |
 
@@ -44,8 +45,8 @@ src/
     macos/{embed,bundle,dmg}.rs      prepare-resources lives in dmg.rs
     macos/dmg/tests.rs
     protocol.rs           arcbox.version + protobuf client codegen
-    release.rs            dispatch: resolve / appcast / latest-json
-    release/{resolve,appcast,latest_json}.rs
+    release.rs            dispatch: resolve / notes / appcast / latest-json
+    release/{resolve,notes,appcast,latest_json}.rs
   support/fs.rs           generic helpers shared by macOS commands
 ```
 

--- a/xtask/src/commands/release.rs
+++ b/xtask/src/commands/release.rs
@@ -1,5 +1,6 @@
 pub mod appcast;
 pub mod latest_json;
+pub mod notes;
 pub mod resolve;
 
 use anyhow::Result;
@@ -9,6 +10,7 @@ use crate::{ReleaseArgs, ReleaseCommand};
 pub fn run(args: ReleaseArgs) -> Result<()> {
     match args.command {
         ReleaseCommand::Resolve(args) => resolve::run(args),
+        ReleaseCommand::Notes(args) => notes::run(args),
         ReleaseCommand::Appcast(args) => appcast::run(args),
         ReleaseCommand::LatestJson(args) => latest_json::run(args),
     }

--- a/xtask/src/commands/release/notes.rs
+++ b/xtask/src/commands/release/notes.rs
@@ -1,0 +1,121 @@
+//! Extract the curated `### Highlights` block for a release.
+
+use anyhow::{Context, Result, bail};
+
+use crate::ReleaseNotesArgs;
+
+fn changelog_version(line: &str) -> Option<&str> {
+    let rest = line.trim().strip_prefix("## [")?;
+    Some(&rest[..rest.find(']')?])
+}
+
+fn extract_highlights(changelog: &str, version: &str) -> Result<String> {
+    let wanted = version.trim_start_matches('v');
+    let mut found_release = false;
+    let mut in_release = false;
+    let mut in_highlights = false;
+    let mut lines = Vec::new();
+
+    for line in changelog.lines() {
+        if let Some(candidate) = changelog_version(line) {
+            if in_release {
+                break;
+            }
+            in_release = candidate == wanted;
+            found_release |= in_release;
+            continue;
+        }
+        if !in_release {
+            continue;
+        }
+
+        let trimmed = line.trim();
+        if trimmed == "### Highlights" {
+            in_highlights = true;
+        } else if trimmed.starts_with("### ") && in_highlights {
+            break;
+        } else if in_highlights {
+            lines.push(line);
+        }
+    }
+
+    if !found_release {
+        bail!("release {wanted} is missing from the changelog");
+    }
+    let highlights = lines.join("\n").trim().to_string();
+    if highlights.is_empty() {
+        bail!("release {wanted} has no non-empty ### Highlights section");
+    }
+    Ok(highlights)
+}
+
+pub fn run(args: ReleaseNotesArgs) -> Result<()> {
+    let changelog = std::fs::read_to_string(&args.changelog)
+        .with_context(|| format!("reading {}", args.changelog.display()))?;
+    let highlights = extract_highlights(&changelog, &args.version)?;
+
+    if let Some(parent) = args
+        .output
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    std::fs::write(&args.output, format!("{highlights}\n"))
+        .with_context(|| format!("writing {}", args.output.display()))?;
+    println!("Release notes: {}", args.output.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_only_the_requested_releases_highlights() {
+        let changelog = r#"
+# Changelog
+
+## [1.2.0](https://example.com) (2026-08-10)
+
+### Highlights
+
+**Faster startup.** ArcBox now reports each startup phase.
+
+### Bug Fixes
+
+* internal fallback
+
+## [1.1.0](https://example.com) (2026-08-01)
+
+### Highlights
+
+Older notes.
+"#;
+
+        assert_eq!(
+            extract_highlights(changelog, "v1.2.0").unwrap(),
+            "**Faster startup.** ArcBox now reports each startup phase."
+        );
+    }
+
+    #[test]
+    fn rejects_missing_or_empty_highlights() {
+        let changelog = r#"
+## [1.2.0] (2026-08-10)
+
+### Bug Fixes
+
+* fixed a crash
+"#;
+
+        assert!(
+            extract_highlights(changelog, "1.2.0")
+                .unwrap_err()
+                .to_string()
+                .contains("no non-empty ### Highlights")
+        );
+        assert!(extract_highlights(changelog, "1.1.0").is_err());
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -208,6 +208,8 @@ struct ReleaseArgs {
 enum ReleaseCommand {
     /// Resolve build version, channel, prerelease flag, and arcbox ref into GITHUB_OUTPUT.
     Resolve(ReleaseResolveArgs),
+    /// Extract curated Highlights for one release from CHANGELOG.md.
+    Notes(ReleaseNotesArgs),
     /// Generate or update a Sparkle 2.x appcast XML feed.
     Appcast(ReleaseAppcastArgs),
     /// Update (or create) the latest.json channel manifest.
@@ -229,6 +231,19 @@ struct ReleaseResolveArgs {
     /// Git ref (e.g. refs/tags/v1.2.0 on a tag push).
     #[arg(long, env = "GITHUB_REF", default_value = "")]
     github_ref: String,
+}
+
+#[derive(Args)]
+struct ReleaseNotesArgs {
+    /// Release version (leading "v" is stripped automatically).
+    #[arg(long)]
+    version: String,
+    /// Changelog containing the release entry.
+    #[arg(long, default_value = "CHANGELOG.md")]
+    changelog: PathBuf,
+    /// Markdown file to write with the curated Highlights prose.
+    #[arg(long)]
+    output: PathBuf,
 }
 
 #[derive(Args)]


### PR DESCRIPTION
## Linear issues

- [ABXD-139](https://linear.app/arcbox/issue/ABXD-139)
- [ABXD-141](https://linear.app/arcbox/issue/ABXD-141)
- [ABXD-142](https://linear.app/arcbox/issue/ABXD-142)
- [ABXD-144](https://linear.app/arcbox/issue/ABXD-144)
- [ABXD-152](https://linear.app/arcbox/issue/ABXD-152)

## Root cause

Several user-facing promises had drifted ahead of the Desktop and daemon contracts: Machines has an interactive terminal but no filesystem browser, Kubernetes resources are inspect-only, and Sandbox port/event/file history is intentionally process-local or bounded. Startup UI also treated the first gRPC setup snapshot as usable runtime readiness and replaced the daemon's concrete phase messages with generic spinners. About and Sparkle consumed mechanical generated changelogs instead of the curated Highlights already maintained for releases.

## User impact

- Makes Machine and Kubernetes capability copy match the actions users can actually perform.
- Uses curated Highlights for About and Sparkle, while filtering bot, PR, chore, and internal-migration noise.
- Shows daemon-provided startup phases across resource surfaces, waits for shared-runtime readiness, and keeps terminal setup failures actionable.
- Documents the exact Sandbox Files, Ports, and Events limits and prevents view-local state from leaking across sandbox selection.
- Keeps normal-Quit daemon teardown intact because Desktop currently owns the service for the app lifetime; healthy surviving daemons are still reused on reconnect.

## Deliberate boundaries

This does not add speculative Machine file browsing, Kubernetes mutation actions, daemon persistence after normal Quit, or authoritative Sandbox port reconciliation. The last item needs a daemon list-mappings RPC. ABXD-144's numeric cold/warm target also still needs a product definition of the measured scenario.

## Validation

- `make format`
- `make lint` — 285 Swift files, 0 violations
- targeted `ChangelogParserTests` — 16 passed
- `make test` — 229 XCTest + 84 Swift Testing tests passed
- `make lint-xtask`
- `make test-xtask` — 12 passed
- `actionlint` (excluding the unchanged pre-existing SC2174 finding)
- `git diff --check`
