### PR TITLE
fix(app): resolve ABXD-143/145/146/147/148/150

### DIFF
--- a/ArcBox/App/ApplicationCoordinator.swift
+++ b/ArcBox/App/ApplicationCoordinator.swift
@@ -407,23 +407,27 @@ final class ApplicationCoordinator: NSObject {
 
     @discardableResult
     private func updateDockerContext(useArcBox: Bool) -> Task<Void, Never> {
-        let operation = DockerContextManager.update(useArcBox: useArcBox)
-        let task = Task {
-            do {
-                try await operation.value
+        DockerContextManager.update(useArcBox: useArcBox) { [self] result in
+            switch result {
+            case .success:
+                if let retry = self.appVM.dockerContextRetry, case .preference = retry {
+                    return
+                }
                 appVM.dockerContextError = nil
-                appVM.dockerContextRetryValue = nil
-            } catch {
+                appVM.dockerContextRetry = nil
+            case let .failure(error):
                 Log.context.error(
                     "Failed to update Docker context: \(error.localizedDescription, privacy: .public)"
                 )
+                if let retry = self.appVM.dockerContextRetry, case .preference = retry {
+                    return
+                }
                 appVM.dockerContextError =
                     "The Docker context was not updated: \(error.localizedDescription) "
                     + "Check that the Docker CLI is installed and ~/.docker/config.json is writable, then try again."
-                appVM.dockerContextRetryValue = useArcBox
+                appVM.dockerContextRetry = .lifecycle(useArcBox: useArcBox)
             }
         }
-        return task
     }
 
     private func initClientsAndReturn() throws -> ArcBoxClient {

--- a/ArcBox/App/ApplicationCoordinator.swift
+++ b/ArcBox/App/ApplicationCoordinator.swift
@@ -43,7 +43,6 @@ final class ApplicationCoordinator: NSObject {
     private var menuBarHost: NSHostingController<AnyView>?
     private var startupTask: Task<Void, Never>?
     private var connectionTask: Task<Void, Never>?
-    private var dockerContextTask: Task<Void, Never>?
     private var lastDaemonState: DaemonState?
     private var lastShowInMenuBar: Bool
     private var lastUpdateChannel: String
@@ -408,15 +407,10 @@ final class ApplicationCoordinator: NSObject {
 
     @discardableResult
     private func updateDockerContext(useArcBox: Bool) -> Task<Void, Never> {
-        let previousTask = dockerContextTask
+        let operation = DockerContextManager.update(useArcBox: useArcBox)
         let task = Task {
-            await previousTask?.value
             do {
-                if useArcBox {
-                    try await DockerContextManager.switchToArcBox()
-                } else {
-                    try await DockerContextManager.restorePreviousContext()
-                }
+                try await operation.value
                 appVM.dockerContextError = nil
                 appVM.dockerContextRetryValue = nil
             } catch {
@@ -429,7 +423,6 @@ final class ApplicationCoordinator: NSObject {
                 appVM.dockerContextRetryValue = useArcBox
             }
         }
-        dockerContextTask = task
         return task
     }
 

--- a/ArcBox/App/ApplicationCoordinator.swift
+++ b/ArcBox/App/ApplicationCoordinator.swift
@@ -43,6 +43,7 @@ final class ApplicationCoordinator: NSObject {
     private var menuBarHost: NSHostingController<AnyView>?
     private var startupTask: Task<Void, Never>?
     private var connectionTask: Task<Void, Never>?
+    private var dockerContextTask: Task<Void, Never>?
     private var lastDaemonState: DaemonState?
     private var lastShowInMenuBar: Bool
     private var lastUpdateChannel: String
@@ -232,7 +233,7 @@ final class ApplicationCoordinator: NSObject {
         sandboxEventMonitor.stop()
         machineEventMonitor.stop()
         sleepWakeManager.stop()
-        DockerContextManager.restorePreviousContext()
+        await updateDockerContext(useArcBox: false).value
         arcboxClient?.close()
         connectionTask?.cancel()
         connectionTask = nil
@@ -258,10 +259,6 @@ final class ApplicationCoordinator: NSObject {
         deepLinkRouter.configure(
             .init(
                 appVM: appVM,
-                containersVM: containersVM,
-                volumesVM: volumesVM,
-                imagesVM: imagesVM,
-                networksVM: networksVM,
                 openMainWindow: { [weak self] in self?.showMainWindow() },
                 openSettingsWindow: { [weak self] in self?.showSettings() },
                 oauthCallbackScheme: OIDCClientConfiguration.redirectURI.scheme,
@@ -397,14 +394,43 @@ final class ApplicationCoordinator: NSObject {
                 sandboxEventMonitor.start(client: arcboxClient, machineID: "default")
                 machineEventMonitor.start(client: arcboxClient)
             }
-            DockerContextManager.switchToArcBox()
+            if UserDefaults.standard.bool(forKey: "switchDockerContextAutomatically") {
+                updateDockerContext(useArcBox: true)
+            }
         } else {
             eventMonitor.stop()
             sandboxEventMonitor.stop()
             machineEventMonitor.stop()
             sleepWakeManager.stop()
-            DockerContextManager.restorePreviousContext()
+            updateDockerContext(useArcBox: false)
         }
+    }
+
+    @discardableResult
+    private func updateDockerContext(useArcBox: Bool) -> Task<Void, Never> {
+        let previousTask = dockerContextTask
+        let task = Task {
+            await previousTask?.value
+            do {
+                if useArcBox {
+                    try await DockerContextManager.switchToArcBox()
+                } else {
+                    try await DockerContextManager.restorePreviousContext()
+                }
+                appVM.dockerContextError = nil
+                appVM.dockerContextRetryValue = nil
+            } catch {
+                Log.context.error(
+                    "Failed to update Docker context: \(error.localizedDescription, privacy: .public)"
+                )
+                appVM.dockerContextError =
+                    "The Docker context was not updated: \(error.localizedDescription) "
+                    + "Check that the Docker CLI is installed and ~/.docker/config.json is writable, then try again."
+                appVM.dockerContextRetryValue = useArcBox
+            }
+        }
+        dockerContextTask = task
+        return task
     }
 
     private func initClientsAndReturn() throws -> ArcBoxClient {

--- a/ArcBox/App/DeepLink.swift
+++ b/ArcBox/App/DeepLink.swift
@@ -6,9 +6,8 @@ import Foundation
 /// - `arcbox://main` (or no host) — open and activate the main window
 /// - `arcbox://settings` — open the Settings window
 /// - `arcbox://<section>[/<id>]` — navigate to a sidebar section, where
-///   `<section>` is a `NavItem` raw value (`containers`, `volumes`, `images`,
-///   `networks`, `pods`, `services`, `machines`, `sandboxes`)
-///   and the optional `<id>` selects the item with that exact ID.
+///   `<section>` is a `NavItem` raw value and the optional `<id>` selects the
+///   resource with that exact ID. Activity does not accept an ID.
 enum DeepLink: Equatable {
     static let scheme = "arcbox"
 

--- a/ArcBox/App/DeepLinkRouter.swift
+++ b/ArcBox/App/DeepLinkRouter.swift
@@ -8,10 +8,6 @@ import OSLog
 final class DeepLinkRouter {
     struct Target {
         let appVM: AppViewModel
-        let containersVM: ContainersViewModel
-        let volumesVM: VolumesViewModel
-        let imagesVM: ImagesViewModel
-        let networksVM: NetworksViewModel
         let openMainWindow: () -> Void
         let openSettingsWindow: () -> Void
         /// URL scheme of the OAuth redirect (e.g. `com.arcboxlabs.desktop`).
@@ -65,24 +61,23 @@ final class DeepLinkRouter {
             target.openSettingsWindow()
         case .section(let item, let id):
             target.openMainWindow()
+            let needsExplicitRefresh = target.appVM.currentNav == item
             target.appVM.navigate(to: item)
-            if let id {
-                select(id, in: item, with: target)
+            guard let id else {
+                target.appVM.clearResourceDeepLink()
+                break
+            }
+            if item == .activity {
+                target.appVM.clearResourceDeepLink()
+                target.appVM.deepLinkError = "Activity links don’t support resource IDs."
+            } else {
+                target.appVM.requestResourceDeepLink(
+                    section: item,
+                    id: id,
+                    needsExplicitRefresh: needsExplicitRefresh
+                )
             }
         }
         NSApp.activate()
-    }
-
-    /// Item selection is only wired for Docker resources; the other sections'
-    /// view models are local to `ContentView` and not reachable from here.
-    private func select(_ id: String, in item: NavItem, with target: Target) {
-        switch item {
-        case .containers: target.containersVM.selectedID = id
-        case .volumes: target.volumesVM.selectedID = id
-        case .images: target.imagesVM.selectedID = id
-        case .networks: target.networksVM.selectedID = id
-        case .activity, .pods, .services, .machines, .sandboxes:
-            Log.deepLink.info("Item selection unsupported for \(item.rawValue, privacy: .public)")
-        }
     }
 }

--- a/ArcBox/App/DeepLinkRouter.swift
+++ b/ArcBox/App/DeepLinkRouter.swift
@@ -61,7 +61,6 @@ final class DeepLinkRouter {
             target.openSettingsWindow()
         case .section(let item, let id):
             target.openMainWindow()
-            let needsExplicitRefresh = target.appVM.currentNav == item
             target.appVM.navigate(to: item)
             guard let id else {
                 target.appVM.clearResourceDeepLink()
@@ -71,11 +70,7 @@ final class DeepLinkRouter {
                 target.appVM.clearResourceDeepLink()
                 target.appVM.deepLinkError = "Activity links don’t support resource IDs."
             } else {
-                target.appVM.requestResourceDeepLink(
-                    section: item,
-                    id: id,
-                    needsExplicitRefresh: needsExplicitRefresh
-                )
+                target.appVM.requestResourceDeepLink(section: item, id: id)
             }
         }
         NSApp.activate()

--- a/ArcBox/Integrations/Docker/DockerCLIResolver.swift
+++ b/ArcBox/Integrations/Docker/DockerCLIResolver.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum DockerCLIResolver {
+nonisolated enum DockerCLIResolver {
     private static let dockerSearchPaths = [
         "/usr/local/bin/docker",
         "/opt/homebrew/bin/docker",

--- a/ArcBox/Integrations/Docker/DockerContextManager.swift
+++ b/ArcBox/Integrations/Docker/DockerContextManager.swift
@@ -1,6 +1,23 @@
 import Foundation
 import OSLog
 
+nonisolated private enum DockerContextError: LocalizedError {
+    case invalidConfiguration(String)
+    case dockerCLIUnavailable
+    case contextCreationFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidConfiguration(let detail):
+            "~/.docker/config.json is invalid: \(detail) Repair or move the file, then try again."
+        case .dockerCLIUnavailable:
+            "The Docker CLI was not found. Install it in a standard location, then try again."
+        case .contextCreationFailed(let detail):
+            "docker context create failed: \(detail)"
+        }
+    }
+}
+
 /// Manages Docker CLI context switching to point at the ArcBox daemon socket.
 ///
 /// When enabled, sets the Docker context on app startup and restores the
@@ -8,6 +25,8 @@ import OSLog
 nonisolated enum DockerContextManager {
     private static let logger = Log.context
     private static let previousContextKey = "previousDockerContext"
+    // ponytail: One global lock is enough for rare context changes; use an actor if this becomes a frequent API.
+    private static let operationLock = NSLock()
 
     private static var configPath: String {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
@@ -28,107 +47,105 @@ nonisolated enum DockerContextManager {
 
     /// Switch the Docker CLI context to use ArcBox's socket.
     /// Saves the previous context so it can be restored later.
-    static func switchToArcBox() {
-        guard UserDefaults.standard.bool(forKey: "switchDockerContextAutomatically") else { return }
-
-        Task.detached {
-            do {
-                guard let config = try readConfig() else {
-                    logger.error("Failed to parse ~/.docker/config.json, skipping context switch to avoid data loss")
-                    return
+    static func switchToArcBox() async throws {
+        try await Task.detached {
+            try operationLock.withLock {
+                let config = try readConfig()
+                guard let dockerPath = DockerCLIResolver.findDockerCLI() else {
+                    throw DockerContextError.dockerCLIUnavailable
                 }
 
-                // Always save the current context so we can restore it on quit,
-                // even if it's already ArcBox's context (user may have set it intentionally).
-                if let previousContext = config["currentContext"] as? String {
-                    UserDefaults.standard.set(previousContext, forKey: previousContextKey)
+                // Keep the context from before this ArcBox session, including Docker's
+                // implicit "default" context when the key is absent.
+                let hadSavedContext = UserDefaults.standard.string(forKey: previousContextKey) != nil
+                if !hadSavedContext {
+                    UserDefaults.standard.set(
+                        config["currentContext"] as? String ?? "default",
+                        forKey: previousContextKey
+                    )
                 }
 
-                // Ensure the ArcBox context exists in Docker's context store.
-                guard createArcBoxContext() else {
-                    logger.error("Skipping context switch — failed to create ArcBox context")
-                    return
-                }
+                do {
+                    try createArcBoxContext(dockerPath: dockerPath)
 
-                // Set the current context
-                var updatedConfig = config
-                updatedConfig["currentContext"] = arcboxContextName
-                try writeConfig(updatedConfig)
+                    var updatedConfig = config
+                    updatedConfig["currentContext"] = arcboxContextName
+                    try writeConfig(updatedConfig)
+                } catch {
+                    if !hadSavedContext {
+                        UserDefaults.standard.removeObject(forKey: previousContextKey)
+                    }
+                    throw error
+                }
 
                 logger.info("Switched Docker context to \(arcboxContextName, privacy: .public)")
-            } catch {
-                logger.error("Failed to switch Docker context: \(error.localizedDescription, privacy: .public)")
             }
-        }
+        }.value
     }
 
     /// Restore the Docker CLI context to what it was before ArcBox started.
     /// Always restores if a previous context was saved, regardless of the current toggle state,
     /// to avoid leaving the user's Docker CLI pointing at a dead socket.
-    static func restorePreviousContext() {
-        do {
-            guard var config = try readConfig() else {
-                logger.error("Failed to parse ~/.docker/config.json, skipping context restore to avoid data loss")
-                return
+    static func restorePreviousContext() async throws {
+        try await Task.detached {
+            try operationLock.withLock {
+                // Always restore if we previously saved a context — even if the toggle was turned off since.
+                guard let previousContext = UserDefaults.standard.string(forKey: previousContextKey) else {
+                    // No saved context — nothing to restore.
+                    return
+                }
+                var config = try readConfig()
+                config["currentContext"] = previousContext
+                try writeConfig(config)
+                UserDefaults.standard.removeObject(forKey: previousContextKey)
+                logger.info("Restored previous Docker context")
             }
-
-            // Always restore if we previously saved a context — even if the toggle was turned off since.
-            guard let previousContext = UserDefaults.standard.string(forKey: previousContextKey) else {
-                // No saved context — nothing to restore.
-                return
-            }
-            config["currentContext"] = previousContext
-            try writeConfig(config)
-            UserDefaults.standard.removeObject(forKey: previousContextKey)
-            logger.info("Restored previous Docker context")
-        } catch {
-            logger.error("Failed to restore Docker context: \(error.localizedDescription, privacy: .public)")
-        }
+        }.value
     }
 
     /// Creates the ArcBox context in Docker's context meta store.
-    /// Returns true if the context exists (created or already present), false on failure.
-    @discardableResult
-    private static func createArcBoxContext() -> Bool {
+    private static func createArcBoxContext(dockerPath: String) throws {
         let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        proc.executableURL = URL(fileURLWithPath: dockerPath)
         proc.arguments = [
-            "docker", "context", "create", arcboxContextName,
+            "context", "create", arcboxContextName,
             "--docker", "host=\(arcboxSocketPath)",
             "--description", "ArcBox Desktop",
         ]
         proc.standardOutput = FileHandle.nullDevice
         let errPipe = Pipe()
         proc.standardError = errPipe
-        do {
-            try proc.run()
-            proc.waitUntilExit()
-        } catch {
-            logger.error("Failed to launch docker context create: \(error.localizedDescription, privacy: .public)")
-            return false
-        }
+        try proc.run()
+        proc.waitUntilExit()
         // Exit 0 = created, non-zero with "already exists" = OK, otherwise fail
-        if proc.terminationStatus == 0 { return true }
+        if proc.terminationStatus == 0 { return }
         let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
-        let errMsg = String(data: errData, encoding: .utf8) ?? ""
-        if errMsg.contains("already exists") { return true }
-        logger.error("docker context create failed (status \(proc.terminationStatus)): \(errMsg, privacy: .public)")
-        return false
+        let errMsg = (String(data: errData, encoding: .utf8) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if errMsg.contains("already exists") { return }
+        throw DockerContextError.contextCreationFailed(
+            errMsg.isEmpty ? "exit status \(proc.terminationStatus)" : errMsg
+        )
     }
 
     // MARK: - Config File I/O
 
     /// Read and parse ~/.docker/config.json.
-    /// Returns nil if the file exists but cannot be parsed as a JSON object (to prevent clobbering).
     /// Returns an empty dictionary if the file does not exist.
-    private static func readConfig() throws -> [String: Any]? {
+    private static func readConfig() throws -> [String: Any] {
         let url = URL(fileURLWithPath: configPath)
         guard FileManager.default.fileExists(atPath: configPath) else {
             return [:]
         }
         let data = try Data(contentsOf: url)
-        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return nil
+        let object: Any
+        do {
+            object = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw DockerContextError.invalidConfiguration(error.localizedDescription)
+        }
+        guard let json = object as? [String: Any] else {
+            throw DockerContextError.invalidConfiguration("expected a JSON object.")
         }
         return json
     }

--- a/ArcBox/Integrations/Docker/DockerContextManager.swift
+++ b/ArcBox/Integrations/Docker/DockerContextManager.swift
@@ -25,8 +25,7 @@ nonisolated private enum DockerContextError: LocalizedError {
 nonisolated enum DockerContextManager {
     private static let logger = Log.context
     private static let previousContextKey = "previousDockerContext"
-    // ponytail: One global lock is enough for rare context changes; use an actor if this becomes a frequent API.
-    private static let operationLock = NSLock()
+    @MainActor private static var operationTask: Task<Void, Error>?
 
     private static var configPath: String {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
@@ -45,61 +44,75 @@ nonisolated enum DockerContextManager {
         return profile?.caseInsensitiveCompare("development") == .orderedSame ? "arcbox-dev" : "arcbox"
     }
 
+    /// Serializes every context change in request order, including Settings and app lifecycle calls.
+    @MainActor
+    static func update(useArcBox: Bool) -> Task<Void, Error> {
+        let previousTask = operationTask
+        let task = Task {
+            if let previousTask {
+                _ = await previousTask.result
+            }
+            if useArcBox {
+                try await switchToArcBox()
+            } else {
+                try await restorePreviousContext()
+            }
+        }
+        operationTask = task
+        return task
+    }
+
     /// Switch the Docker CLI context to use ArcBox's socket.
     /// Saves the previous context so it can be restored later.
-    static func switchToArcBox() async throws {
+    private static func switchToArcBox() async throws {
         try await Task.detached {
-            try operationLock.withLock {
-                let config = try readConfig()
-                guard let dockerPath = DockerCLIResolver.findDockerCLI() else {
-                    throw DockerContextError.dockerCLIUnavailable
-                }
-
-                // Keep the context from before this ArcBox session, including Docker's
-                // implicit "default" context when the key is absent.
-                let hadSavedContext = UserDefaults.standard.string(forKey: previousContextKey) != nil
-                if !hadSavedContext {
-                    UserDefaults.standard.set(
-                        config["currentContext"] as? String ?? "default",
-                        forKey: previousContextKey
-                    )
-                }
-
-                do {
-                    try createArcBoxContext(dockerPath: dockerPath)
-
-                    var updatedConfig = config
-                    updatedConfig["currentContext"] = arcboxContextName
-                    try writeConfig(updatedConfig)
-                } catch {
-                    if !hadSavedContext {
-                        UserDefaults.standard.removeObject(forKey: previousContextKey)
-                    }
-                    throw error
-                }
-
-                logger.info("Switched Docker context to \(arcboxContextName, privacy: .public)")
+            let config = try readConfig()
+            guard let dockerPath = DockerCLIResolver.findDockerCLI() else {
+                throw DockerContextError.dockerCLIUnavailable
             }
+
+            // Keep the context from before this ArcBox session, including Docker's
+            // implicit "default" context when the key is absent.
+            let hadSavedContext = UserDefaults.standard.string(forKey: previousContextKey) != nil
+            if !hadSavedContext {
+                UserDefaults.standard.set(
+                    config["currentContext"] as? String ?? "default",
+                    forKey: previousContextKey
+                )
+            }
+
+            do {
+                try createArcBoxContext(dockerPath: dockerPath)
+
+                var updatedConfig = config
+                updatedConfig["currentContext"] = arcboxContextName
+                try writeConfig(updatedConfig)
+            } catch {
+                if !hadSavedContext {
+                    UserDefaults.standard.removeObject(forKey: previousContextKey)
+                }
+                throw error
+            }
+
+            logger.info("Switched Docker context to \(arcboxContextName, privacy: .public)")
         }.value
     }
 
     /// Restore the Docker CLI context to what it was before ArcBox started.
     /// Always restores if a previous context was saved, regardless of the current toggle state,
     /// to avoid leaving the user's Docker CLI pointing at a dead socket.
-    static func restorePreviousContext() async throws {
+    private static func restorePreviousContext() async throws {
         try await Task.detached {
-            try operationLock.withLock {
-                // Always restore if we previously saved a context — even if the toggle was turned off since.
-                guard let previousContext = UserDefaults.standard.string(forKey: previousContextKey) else {
-                    // No saved context — nothing to restore.
-                    return
-                }
-                var config = try readConfig()
-                config["currentContext"] = previousContext
-                try writeConfig(config)
-                UserDefaults.standard.removeObject(forKey: previousContextKey)
-                logger.info("Restored previous Docker context")
+            // Always restore if we previously saved a context — even if the toggle was turned off since.
+            guard let previousContext = UserDefaults.standard.string(forKey: previousContextKey) else {
+                // No saved context — nothing to restore.
+                return
             }
+            var config = try readConfig()
+            config["currentContext"] = previousContext
+            try writeConfig(config)
+            UserDefaults.standard.removeObject(forKey: previousContextKey)
+            logger.info("Restored previous Docker context")
         }.value
     }
 

--- a/ArcBox/Integrations/Docker/DockerContextManager.swift
+++ b/ArcBox/Integrations/Docker/DockerContextManager.swift
@@ -25,7 +25,7 @@ nonisolated private enum DockerContextError: LocalizedError {
 nonisolated enum DockerContextManager {
     private static let logger = Log.context
     private static let previousContextKey = "previousDockerContext"
-    @MainActor private static var operationTask: Task<Void, Error>?
+    @MainActor private static var operationTask: Task<Void, Never>?
 
     private static var configPath: String {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
@@ -46,16 +46,25 @@ nonisolated enum DockerContextManager {
 
     /// Serializes every context change in request order, including Settings and app lifecycle calls.
     @MainActor
-    static func update(useArcBox: Bool) -> Task<Void, Error> {
+    @discardableResult
+    static func update(
+        useArcBox: Bool,
+        completion: @escaping @MainActor (Result<Void, Error>) -> Void
+    ) -> Task<Void, Never> {
         let previousTask = operationTask
         let task = Task {
             if let previousTask {
-                _ = await previousTask.result
+                await previousTask.value
             }
-            if useArcBox {
-                try await switchToArcBox()
-            } else {
-                try await restorePreviousContext()
+            do {
+                if useArcBox {
+                    try await switchToArcBox()
+                } else {
+                    try await restorePreviousContext()
+                }
+                completion(.success(()))
+            } catch {
+                completion(.failure(error))
             }
         }
         operationTask = task

--- a/ArcBox/Integrations/Terminal/ExternalTerminalLauncher.swift
+++ b/ArcBox/Integrations/Terminal/ExternalTerminalLauncher.swift
@@ -3,6 +3,29 @@ import Darwin
 import Foundation
 import os
 
+nonisolated enum ExternalTerminalLaunchError: LocalizedError {
+    case commandFile(String)
+    case appUnavailable(String)
+    case launchFailed(String, String)
+    case automationDenied(String)
+    case automationFailed(String, String)
+
+    var errorDescription: String? {
+        switch self {
+        case .commandFile(let detail):
+            "ArcBox could not prepare the terminal command: \(detail) Check available disk space and try again."
+        case .appUnavailable(let appName):
+            "\(appName) is not available. Choose another terminal in Settings > General."
+        case .launchFailed(let appName, let detail):
+            "ArcBox could not open \(appName): \(detail) Confirm the app can open .command files, or choose another terminal in Settings > General."
+        case .automationDenied(let appName):
+            "Automation access was denied. Open System Settings > Privacy & Security > Automation and allow ArcBox to control \(appName), then try again."
+        case .automationFailed(let appName, let detail):
+            "ArcBox could not control \(appName): \(detail) Check Automation access in System Settings > Privacy & Security, then try again."
+        }
+    }
+}
+
 /// Launches an external terminal app with Docker environment pre-configured.
 enum ExternalTerminalLauncher {
     private static let logger = Log.terminal
@@ -20,15 +43,25 @@ enum ExternalTerminalLauncher {
     ///   - preference: The user's terminal preference stored by `GeneralSettingsView`.
     ///   - containerID: Optional container ID to exec into.
     ///   - shell: Shell to use (e.g. "/bin/sh"). Only used when containerID is provided.
-    static func open(preference: String, containerID: String? = nil, shell: String = "/bin/sh") {
+    /// - Throws: A user-actionable error when the command cannot be prepared or opened.
+    static func open(
+        preference: String,
+        containerID: String? = nil,
+        shell: String = "/bin/sh"
+    ) async throws {
         let command = makeCommand(containerID: containerID, shell: shell)
         let script = makeCommandScript(command: command)
-        guard let scriptURL = writeCommandScript(script) else { return }
+        let scriptURL = try writeCommandScript(script)
 
-        openCommandScript(
-            scriptURL,
-            terminal: ExternalTerminalDiscovery.resolve(preference: preference)
-        )
+        do {
+            try await openCommandScript(
+                scriptURL,
+                terminal: ExternalTerminalDiscovery.resolve(preference: preference)
+            )
+        } catch {
+            removeCommandScript(at: scriptURL)
+            throw error
+        }
     }
 
     private static func makeCommand(containerID: String?, shell: String) -> String {
@@ -72,68 +105,94 @@ enum ExternalTerminalLauncher {
         ].joined(separator: "\n")
     }
 
-    private static func writeCommandScript(_ source: String) -> URL? {
+    private static func writeCommandScript(_ source: String) throws -> URL {
         let scriptURL = FileManager.default.temporaryDirectory
             .appending(path: "arcbox-terminal-\(UUID().uuidString).command")
 
         do {
             try source.write(to: scriptURL, atomically: true, encoding: .utf8)
-            chmod(scriptURL.path, S_IRUSR | S_IWUSR | S_IXUSR)
+            guard chmod(scriptURL.path, S_IRUSR | S_IWUSR | S_IXUSR) == 0 else {
+                let message = String(cString: strerror(errno))
+                removeCommandScript(at: scriptURL)
+                throw ExternalTerminalLaunchError.commandFile(message)
+            }
             return scriptURL
+        } catch let error as ExternalTerminalLaunchError {
+            throw error
         } catch {
             logger.error("Failed to write external terminal command: \(error.localizedDescription, privacy: .public)")
-            return nil
+            throw ExternalTerminalLaunchError.commandFile(error.localizedDescription)
+        }
+    }
+
+    private static func removeCommandScript(at scriptURL: URL) {
+        do {
+            try FileManager.default.removeItem(at: scriptURL)
+        } catch {
+            logger.error("Failed to remove external terminal command: \(error.localizedDescription, privacy: .public)")
         }
     }
 
     private static func openCommandScript(
         _ scriptURL: URL,
         terminal: ExternalTerminalApp
-    ) {
+    ) async throws {
         guard let appURL = terminal.appURL else {
-            NSWorkspace.shared.open(scriptURL)
-            return
+            throw ExternalTerminalLaunchError.appUnavailable(terminal.displayName)
         }
 
         let configuration = NSWorkspace.OpenConfiguration()
         configuration.activates = true
-        NSWorkspace.shared.open([scriptURL], withApplicationAt: appURL, configuration: configuration) { _, error in
-            guard let error else { return }
-            Task { @MainActor in
-                logger.error("Failed to open command script: \(error.localizedDescription, privacy: .public)")
-                if let backend = terminal.appleScriptBackend {
-                    openWithAppleScript(backend: backend, command: fallbackCommand(for: scriptURL))
-                } else {
-                    NSWorkspace.shared.open(scriptURL)
-                }
+        do {
+            _ = try await NSWorkspace.shared.open(
+                [scriptURL],
+                withApplicationAt: appURL,
+                configuration: configuration
+            )
+        } catch {
+            logger.error("Failed to open command script: \(error.localizedDescription, privacy: .public)")
+            guard let backend = terminal.appleScriptBackend else {
+                throw ExternalTerminalLaunchError.launchFailed(
+                    terminal.displayName,
+                    error.localizedDescription
+                )
             }
+            try await openWithAppleScript(
+                backend: backend,
+                appName: terminal.displayName,
+                command: fallbackCommand(for: scriptURL)
+            )
         }
     }
 
-    private static func openWithAppleScript(backend: ExternalTerminalApp.AppleScriptBackend, command: String) {
+    private static func openWithAppleScript(
+        backend: ExternalTerminalApp.AppleScriptBackend,
+        appName: String,
+        command: String
+    ) async throws {
         switch backend {
         case .terminal:
-            openTerminalApp(command: command)
+            try await openTerminalApp(appName: appName, command: command)
         case .iTerm:
-            openITerm(command: command)
+            try await openITerm(appName: appName, command: command)
         }
     }
 
     // MARK: - Terminal.app
 
-    private static func openTerminalApp(command: String) {
+    private static func openTerminalApp(appName: String, command: String) async throws {
         let script = """
             tell application "Terminal"
                 activate
                 do script "\(escapeForAppleScript(command))"
             end tell
             """
-        runAppleScript(script)
+        try await runAppleScript(script, appName: appName)
     }
 
     // MARK: - iTerm
 
-    private static func openITerm(command: String) {
+    private static func openITerm(appName: String, command: String) async throws {
         let script = """
             tell application "iTerm"
                 activate
@@ -143,7 +202,7 @@ enum ExternalTerminalLauncher {
                 end tell
             end tell
             """
-        runAppleScript(script)
+        try await runAppleScript(script, appName: appName)
     }
 
     // MARK: - Helpers
@@ -162,19 +221,25 @@ enum ExternalTerminalLauncher {
             .replacingOccurrences(of: "\"", with: "\\\"")
     }
 
-    private static func runAppleScript(_ source: String) {
-        let scriptSource = source
-        Task.detached {
-            guard let script = NSAppleScript(source: scriptSource) else {
-                await MainActor.run { logger.error("Failed to create AppleScript") }
-                return
+    private static func runAppleScript(_ source: String, appName: String) async throws {
+        let failure = await Task.detached { () -> (number: Int, message: String)? in
+            guard let script = NSAppleScript(source: source) else {
+                return (0, "ArcBox could not create the Automation script.")
             }
             var error: NSDictionary?
             script.executeAndReturnError(&error)
-            if let error {
-                let errorMessage = (error[NSAppleScript.errorMessage] as? String) ?? "Unknown AppleScript error"
-                await MainActor.run { logger.error("AppleScript error: \(errorMessage, privacy: .public)") }
-            }
+            guard let error else { return nil }
+            return (
+                (error[NSAppleScript.errorNumber] as? NSNumber)?.intValue ?? 0,
+                (error[NSAppleScript.errorMessage] as? String) ?? "Unknown AppleScript error"
+            )
+        }.value
+        guard let failure else { return }
+
+        logger.error("AppleScript error: \(failure.message, privacy: .public)")
+        if failure.number == -1743 {
+            throw ExternalTerminalLaunchError.automationDenied(appName)
         }
+        throw ExternalTerminalLaunchError.automationFailed(appName, failure.message)
     }
 }

--- a/ArcBox/Services/DiagnosticBundleExporter.swift
+++ b/ArcBox/Services/DiagnosticBundleExporter.swift
@@ -4,6 +4,20 @@ import Foundation
 import OSLog
 import UniformTypeIdentifiers
 
+nonisolated private enum DiagnosticExportError: LocalizedError {
+    case collection(String)
+    case write(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .collection(let detail):
+            "ArcBox could not collect diagnostics: \(detail) Restart ArcBox and try again."
+        case .write(let detail):
+            "ArcBox could not save the report: \(detail) Choose a writable location and try again."
+        }
+    }
+}
+
 /// Collects and exports a sanitized diagnostic report for troubleshooting.
 ///
 /// The bundle includes system information, daemon status, recent OSLog entries,
@@ -17,13 +31,14 @@ final class DiagnosticBundleExporter {
     ///
     /// Shows an `NSSavePanel` so the user controls where the file goes.
     /// Returns the saved URL on success, or nil if the user cancelled.
+    /// Throws when the report cannot be collected or written.
     @discardableResult
     static func exportInteractively(
         daemonManager: DaemonManager,
         containersVM: ContainersViewModel,
         imagesVM: ImagesViewModel,
         presentingWindow: NSWindow
-    ) async -> URL? {
+    ) async throws -> URL? {
         let panel = NSSavePanel()
         panel.title = "Export Diagnostic Report"
         panel.nameFieldStringValue = "arcbox-diagnostic.txt"
@@ -38,20 +53,26 @@ final class DiagnosticBundleExporter {
             return nil
         }
 
+        let report: String
         do {
-            let report = try await buildReport(
+            report = try await buildReport(
                 daemonManager: daemonManager,
                 containersVM: containersVM,
                 imagesVM: imagesVM
             )
-            let scrubbed = scrubPII(report)
+        } catch {
+            Log.startup.error("Failed to collect diagnostic report: \(error, privacy: .private)")
+            throw DiagnosticExportError.collection(error.localizedDescription)
+        }
+        let scrubbed = scrubPII(report)
+        do {
             try scrubbed.write(to: saveURL, atomically: true, encoding: .utf8)
-            Analytics.capture(.diagnosticExported)
-            return saveURL
         } catch {
             Log.startup.error("Failed to export diagnostic report: \(error, privacy: .private)")
-            return nil
+            throw DiagnosticExportError.write(error.localizedDescription)
         }
+        Analytics.capture(.diagnosticExported)
+        return saveURL
     }
 
     // MARK: - Report Building

--- a/ArcBox/Support/Utilities.swift
+++ b/ArcBox/Support/Utilities.swift
@@ -1,5 +1,75 @@
 import Foundation
 
+nonisolated enum ArgumentList {
+    static let inputHelp =
+        "Parsed as arguments, not run by a shell. Quotes preserve spaces; outside single quotes, backslash escapes the next character."
+
+    enum ParseError: LocalizedError, Equatable {
+        case danglingEscape
+        case unterminatedQuote(Character)
+
+        var errorDescription: String? {
+            switch self {
+            case .danglingEscape:
+                "A trailing backslash must escape a character."
+            case .unterminatedQuote(let quote):
+                "Missing the closing \(quote) quote."
+            }
+        }
+    }
+
+    /// Parses argv-style input without shell expansion or command evaluation.
+    static func parse(_ input: String) throws -> [String] {
+        var arguments: [String] = []
+        var argument = ""
+        var quote: Character?
+        var isEscaping = false
+        var hasArgument = false
+
+        for character in input {
+            if isEscaping {
+                argument.append(character)
+                isEscaping = false
+                hasArgument = true
+            } else if quote == "'" {
+                if character == "'" {
+                    quote = nil
+                } else {
+                    argument.append(character)
+                }
+                hasArgument = true
+            } else if character == "\\" {
+                isEscaping = true
+                hasArgument = true
+            } else if let activeQuote = quote {
+                if character == activeQuote {
+                    quote = nil
+                } else {
+                    argument.append(character)
+                }
+                hasArgument = true
+            } else if character == "'" || character == "\"" {
+                quote = character
+                hasArgument = true
+            } else if character.isWhitespace {
+                if hasArgument {
+                    arguments.append(argument)
+                    argument = ""
+                    hasArgument = false
+                }
+            } else {
+                argument.append(character)
+                hasArgument = true
+            }
+        }
+
+        if isEscaping { throw ParseError.danglingEscape }
+        if let quote { throw ParseError.unterminatedQuote(quote) }
+        if hasArgument { arguments.append(argument) }
+        return arguments
+    }
+}
+
 /// Parse an ISO 8601 date string with automatic fallback from fractional seconds
 /// to plain `.withInternetDateTime`. Returns `.distantPast` when the input is nil
 /// or unparseable.

--- a/ArcBox/ViewModels/AppViewModel.swift
+++ b/ArcBox/ViewModels/AppViewModel.swift
@@ -8,7 +8,6 @@ class AppViewModel {
         let section: NavItem
         let id: String
         let requestedAt: ContinuousClock.Instant
-        let needsExplicitRefresh: Bool
     }
 
     var currentNav: NavItem? = .containers
@@ -24,16 +23,11 @@ class AppViewModel {
         currentNav = item
     }
 
-    func requestResourceDeepLink(
-        section: NavItem,
-        id: String,
-        needsExplicitRefresh: Bool
-    ) {
+    func requestResourceDeepLink(section: NavItem, id: String) {
         pendingResourceDeepLink = ResourceDeepLink(
             section: section,
             id: id,
-            requestedAt: ContinuousClock().now,
-            needsExplicitRefresh: needsExplicitRefresh
+            requestedAt: ContinuousClock().now
         )
         deepLinkError = nil
     }

--- a/ArcBox/ViewModels/AppViewModel.swift
+++ b/ArcBox/ViewModels/AppViewModel.swift
@@ -4,6 +4,18 @@ import Observation
 @MainActor
 @Observable
 class AppViewModel {
+    enum DockerContextRetry {
+        case lifecycle(useArcBox: Bool)
+        case preference(enabled: Bool)
+
+        var useArcBox: Bool {
+            switch self {
+            case let .lifecycle(useArcBox): useArcBox
+            case let .preference(enabled): enabled
+            }
+        }
+    }
+
     struct ResourceDeepLink: Equatable {
         let section: NavItem
         let id: String
@@ -17,7 +29,7 @@ class AppViewModel {
     var pendingResourceDeepLink: ResourceDeepLink?
     var deepLinkError: String?
     var dockerContextError: String?
-    var dockerContextRetryValue: Bool?
+    var dockerContextRetry: DockerContextRetry?
 
     func navigate(to item: NavItem) {
         currentNav = item

--- a/ArcBox/ViewModels/AppViewModel.swift
+++ b/ArcBox/ViewModels/AppViewModel.swift
@@ -4,12 +4,58 @@ import Observation
 @MainActor
 @Observable
 class AppViewModel {
+    struct ResourceDeepLink: Equatable {
+        let section: NavItem
+        let id: String
+        let requestedAt: ContinuousClock.Instant
+        let needsExplicitRefresh: Bool
+    }
+
     var currentNav: NavItem? = .containers
     /// Selected Settings tab, lifted here so other windows can deep-link
     /// (e.g. the sidebar account chip opening Settings > Account).
     var settingsTab: SettingsTab? = .general
+    var pendingResourceDeepLink: ResourceDeepLink?
+    var deepLinkError: String?
+    var dockerContextError: String?
+    var dockerContextRetryValue: Bool?
 
     func navigate(to item: NavItem) {
         currentNav = item
+    }
+
+    func requestResourceDeepLink(
+        section: NavItem,
+        id: String,
+        needsExplicitRefresh: Bool
+    ) {
+        pendingResourceDeepLink = ResourceDeepLink(
+            section: section,
+            id: id,
+            requestedAt: ContinuousClock().now,
+            needsExplicitRefresh: needsExplicitRefresh
+        )
+        deepLinkError = nil
+    }
+
+    func clearResourceDeepLink() {
+        pendingResourceDeepLink = nil
+        deepLinkError = nil
+    }
+
+    @discardableResult
+    func resolveResourceDeepLink(
+        availableIDs: Set<String>,
+        isLoaded: Bool
+    ) -> ResourceDeepLink? {
+        guard let request = pendingResourceDeepLink else { return nil }
+        guard isLoaded else { return nil }
+        if availableIDs.contains(request.id) {
+            pendingResourceDeepLink = nil
+            return request
+        }
+        pendingResourceDeepLink = nil
+        deepLinkError = "Resource “\(request.id)” wasn’t found in \(request.section.label)."
+        return nil
     }
 }

--- a/ArcBox/ViewModels/Containers/ContainersViewModel+Docker.swift
+++ b/ArcBox/ViewModels/Containers/ContainersViewModel+Docker.swift
@@ -46,6 +46,7 @@ extension ContainersViewModel {
             }
             loadState = .loaded
             refreshError = nil
+            lastSuccessfulListLoad = ContinuousClock().now
         } catch {
             if loadState.cancelLoading(for: error, retainingLoadedContent: isRefresh) {
                 return

--- a/ArcBox/ViewModels/Containers/ContainersViewModel+GRPC.swift
+++ b/ArcBox/ViewModels/Containers/ContainersViewModel+GRPC.swift
@@ -92,10 +92,15 @@ extension ContainersViewModel {
         }
         var config = Components.Schemas.ContainerConfig()
         config.Image = options.image
-        let cmdParts = options.command.split(separator: " ").map(String.init)
-        if !cmdParts.isEmpty { config.Cmd = cmdParts }
-        let entrypointParts = options.entrypoint.split(separator: " ").map(String.init)
-        if !entrypointParts.isEmpty { config.Entrypoint = entrypointParts }
+        do {
+            let command = try ArgumentList.parse(options.command)
+            if !command.isEmpty { config.Cmd = command }
+            let entrypoint = try ArgumentList.parse(options.entrypoint)
+            if !entrypoint.isEmpty { config.Entrypoint = entrypoint }
+        } catch {
+            lastError = "Invalid command or entrypoint: \(error.localizedDescription)"
+            return nil
+        }
         if !options.workingDir.isEmpty { config.WorkingDir = options.workingDir }
 
         let policyName: Components.Schemas.RestartPolicy.NamePayload =

--- a/ArcBox/ViewModels/Containers/ContainersViewModel.swift
+++ b/ArcBox/ViewModels/Containers/ContainersViewModel.swift
@@ -18,6 +18,7 @@ class ContainersViewModel {
     var containers: [ContainerViewModel] = []
     var loadState: LoadPhase = .waiting
     var refreshError: String?
+    var lastSuccessfulListLoad: ContinuousClock.Instant?
     let listLoadGate = SingleFlightLoadGate()
     var selectedID: String?
     var activeTab: ContainerDetailTab = .info

--- a/ArcBox/ViewModels/Images/ImagesViewModel+Docker.swift
+++ b/ArcBox/ViewModels/Images/ImagesViewModel+Docker.swift
@@ -74,6 +74,7 @@ extension ImagesViewModel {
             await fetchIcons(client: iconClient)
             loadState = .loaded
             refreshError = nil
+            lastSuccessfulListLoad = ContinuousClock().now
         } catch {
             if loadState.cancelLoading(for: error, retainingLoadedContent: isRefresh) {
                 return

--- a/ArcBox/ViewModels/Images/ImagesViewModel.swift
+++ b/ArcBox/ViewModels/Images/ImagesViewModel.swift
@@ -8,6 +8,7 @@ class ImagesViewModel {
     var images: [ImageViewModel] = []
     var loadState: LoadPhase = .waiting
     var refreshError: String?
+    var lastSuccessfulListLoad: ContinuousClock.Instant?
     let listLoadGate = SingleFlightLoadGate()
     var selectedID: String?
     var activeTab: ImageDetailTab = .info

--- a/ArcBox/ViewModels/MachinesViewModel+GRPC.swift
+++ b/ArcBox/ViewModels/MachinesViewModel+GRPC.swift
@@ -60,6 +60,7 @@ extension MachinesViewModel {
             machines = viewModels
             loadState = .loaded
             refreshError = nil
+            lastSuccessfulListLoad = ContinuousClock().now
         } catch {
             if loadState.cancelLoading(for: error, retainingLoadedContent: isRefresh) {
                 return

--- a/ArcBox/ViewModels/MachinesViewModel.swift
+++ b/ArcBox/ViewModels/MachinesViewModel.swift
@@ -22,6 +22,7 @@ class MachinesViewModel {
     var isSearching: Bool = false
     var loadState: LoadPhase = .waiting
     var refreshError: String?
+    var lastSuccessfulListLoad: ContinuousClock.Instant?
     let listLoadGate = SingleFlightLoadGate()
     var showCreateSheet: Bool = false
 

--- a/ArcBox/ViewModels/NetworksViewModel.swift
+++ b/ArcBox/ViewModels/NetworksViewModel.swift
@@ -16,6 +16,7 @@ class NetworksViewModel {
     var networks: [NetworkViewModel] = []
     var loadState: LoadPhase = .waiting
     var refreshError: String?
+    var lastSuccessfulListLoad: ContinuousClock.Instant?
     private let listLoadGate = SingleFlightLoadGate()
     var selectedID: String?
     var showNewNetworkSheet: Bool = false
@@ -91,6 +92,7 @@ class NetworksViewModel {
             Log.network.info("Loaded \(self.networks.count, privacy: .public) networks")
             loadState = .loaded
             refreshError = nil
+            lastSuccessfulListLoad = ContinuousClock().now
         } catch {
             if loadState.cancelLoading(for: error, retainingLoadedContent: isRefresh) {
                 return

--- a/ArcBox/ViewModels/PodsViewModel.swift
+++ b/ArcBox/ViewModels/PodsViewModel.swift
@@ -6,7 +6,13 @@ import Observation
 @MainActor
 @Observable
 class PodsViewModel {
-    var pods: [PodViewModel] = []
+    var pods: [PodViewModel] = [] {
+        didSet {
+            if let selectedID, !pods.contains(where: { $0.id == selectedID }) {
+                self.selectedID = nil
+            }
+        }
+    }
     var selectedID: String?
     var streamPhase: KubernetesStreamPhase = .connecting
     var searchText: String = ""

--- a/ArcBox/ViewModels/PodsViewModel.swift
+++ b/ArcBox/ViewModels/PodsViewModel.swift
@@ -15,6 +15,7 @@ class PodsViewModel {
     }
     var selectedID: String?
     var streamPhase: KubernetesStreamPhase = .connecting
+    var lastStreamUpdate: ContinuousClock.Instant?
     var searchText: String = ""
     var isSearching: Bool = false
 
@@ -38,6 +39,7 @@ class PodsViewModel {
     /// client and the stream.
     func apply(_ items: [Pod]) {
         pods = items.compactMap { Self.mapPod($0) }
+        lastStreamUpdate = ContinuousClock().now
     }
 
     /// Clear all pod data when K8s is stopped.
@@ -45,6 +47,7 @@ class PodsViewModel {
         pods = []
         selectedID = nil
         streamPhase = .connecting
+        lastStreamUpdate = nil
     }
 
     // MARK: - Mapping

--- a/ArcBox/ViewModels/Sandboxes/SandboxesViewModel+GRPC.swift
+++ b/ArcBox/ViewModels/Sandboxes/SandboxesViewModel+GRPC.swift
@@ -54,6 +54,7 @@ extension SandboxesViewModel {
             sandboxes = viewModels
             loadState = .loaded
             refreshError = nil
+            lastSuccessfulListLoad = ContinuousClock().now
         } catch {
             if loadState.cancelLoading(for: error, retainingLoadedContent: isRefresh) {
                 return

--- a/ArcBox/ViewModels/Sandboxes/SandboxesViewModel.swift
+++ b/ArcBox/ViewModels/Sandboxes/SandboxesViewModel.swift
@@ -43,6 +43,7 @@ class SandboxesViewModel {
     var sandboxes: [SandboxViewModel] = []
     var loadState: LoadPhase = .waiting
     var refreshError: String?
+    var lastSuccessfulListLoad: ContinuousClock.Instant?
     let listLoadGate = SingleFlightLoadGate()
     @ObservationIgnored let terminalSession = SandboxTerminalSession()
     var selectedID: String?

--- a/ArcBox/ViewModels/ServicesViewModel.swift
+++ b/ArcBox/ViewModels/ServicesViewModel.swift
@@ -6,7 +6,13 @@ import Observation
 @MainActor
 @Observable
 class ServicesViewModel {
-    var services: [ServiceViewModel] = []
+    var services: [ServiceViewModel] = [] {
+        didSet {
+            if let selectedID, !services.contains(where: { $0.id == selectedID }) {
+                self.selectedID = nil
+            }
+        }
+    }
     var selectedID: String?
     var streamPhase: KubernetesStreamPhase = .connecting
     var searchText: String = ""

--- a/ArcBox/ViewModels/ServicesViewModel.swift
+++ b/ArcBox/ViewModels/ServicesViewModel.swift
@@ -15,6 +15,7 @@ class ServicesViewModel {
     }
     var selectedID: String?
     var streamPhase: KubernetesStreamPhase = .connecting
+    var lastStreamUpdate: ContinuousClock.Instant?
     var searchText: String = ""
     var isSearching: Bool = false
 
@@ -40,6 +41,7 @@ class ServicesViewModel {
     /// client and the stream.
     func apply(_ items: [K8sService]) {
         services = items.compactMap { Self.mapService($0) }
+        lastStreamUpdate = ContinuousClock().now
     }
 
     /// Clear all service data when K8s is stopped.
@@ -47,6 +49,7 @@ class ServicesViewModel {
         services = []
         selectedID = nil
         streamPhase = .connecting
+        lastStreamUpdate = nil
     }
 
     // MARK: - Mapping

--- a/ArcBox/ViewModels/Volumes/VolumesViewModel+Docker.swift
+++ b/ArcBox/ViewModels/Volumes/VolumesViewModel+Docker.swift
@@ -26,6 +26,7 @@ extension VolumesViewModel {
             Log.volume.info("Loaded \(self.volumes.count, privacy: .public) volumes")
             loadState = .loaded
             refreshError = nil
+            lastSuccessfulListLoad = ContinuousClock().now
         } catch {
             if loadState.cancelLoading(for: error, retainingLoadedContent: isRefresh) {
                 return

--- a/ArcBox/ViewModels/Volumes/VolumesViewModel.swift
+++ b/ArcBox/ViewModels/Volumes/VolumesViewModel.swift
@@ -8,6 +8,7 @@ class VolumesViewModel {
     var volumes: [VolumeViewModel] = []
     var loadState: LoadPhase = .waiting
     var refreshError: String?
+    var lastSuccessfulListLoad: ContinuousClock.Instant?
     let listLoadGate = SingleFlightLoadGate()
     var selectedID: String?
     var activeTab: VolumeDetailTab = .info

--- a/ArcBox/Views/Activity/ActivityContainerTable.swift
+++ b/ArcBox/Views/Activity/ActivityContainerTable.swift
@@ -27,6 +27,7 @@ struct ActivityContainerTable: View {
         KeyPathComparator(\ActivityRow.cpuPercent, order: .reverse)
     ]
     @State private var selection: ActivityRow.ID?
+    @State private var disclosureState = ActivityRowDisclosureState()
     @State private var columnLayout = TableColumnCustomization<ActivityRow>()
     /// `TableColumnCustomization` is `Codable` but not `RawRepresentable`, so it
     /// rides in `AppStorage` as its own encoding rather than through a
@@ -89,7 +90,10 @@ struct ActivityContainerTable: View {
                 if group.children.isEmpty {
                     TableRow(group.summary)
                 } else {
-                    DisclosureTableRow(group.summary) {
+                    DisclosureTableRow(
+                        group.summary,
+                        isExpanded: disclosureBinding(for: group.id)
+                    ) {
                         ForEach(group.children) { TableRow($0) }
                     }
                 }
@@ -145,6 +149,19 @@ struct ActivityContainerTable: View {
         guard let id = row.containerID, let container = docker[id] else { return false }
         return container.image.lowercased().contains(query)
             || (container.project?.lowercased().contains(query) ?? false)
+    }
+
+    private func disclosureBinding(for groupID: String) -> Binding<Bool> {
+        let isFiltering = !searchText.isEmpty
+        return Binding {
+            disclosureState.isExpanded(groupID, isFiltering: isFiltering)
+        } set: { expanded in
+            disclosureState.setExpanded(
+                expanded,
+                for: groupID,
+                isFiltering: isFiltering
+            )
+        }
     }
 
     // MARK: - Cells

--- a/ArcBox/Views/Activity/ActivityRow.swift
+++ b/ArcBox/Views/Activity/ActivityRow.swift
@@ -106,6 +106,23 @@ nonisolated struct ActivityRowGroup: Identifiable, Equatable, Sendable {
     var id: String { summary.id }
 }
 
+nonisolated struct ActivityRowDisclosureState: Equatable, Sendable {
+    private var expandedGroups: Set<String> = []
+
+    func isExpanded(_ groupID: String, isFiltering: Bool) -> Bool {
+        isFiltering || expandedGroups.contains(groupID)
+    }
+
+    mutating func setExpanded(_ expanded: Bool, for groupID: String, isFiltering: Bool) {
+        guard !isFiltering else { return }
+        if expanded {
+            expandedGroups.insert(groupID)
+        } else {
+            expandedGroups.remove(groupID)
+        }
+    }
+}
+
 nonisolated enum ActivityRowGrouping {
     /// Groups rows by Compose project, matching what the Containers list does:
     /// a project for every container that declares one, standalone rows for the

--- a/ArcBox/Views/Containers/NewContainerSheet.swift
+++ b/ArcBox/Views/Containers/NewContainerSheet.swift
@@ -113,7 +113,12 @@ struct NewContainerSheet: View {
 
                 // Payload section
                 Section("Payload") {
-                    TextField("Command", text: $command)
+                    VStack(alignment: .leading, spacing: 2) {
+                        TextField("Command", text: $command)
+                        Text(ArgumentList.inputHelp)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                     TextField("Entrypoint", text: $entrypoint)
                     TextField("Working directory", text: $workdir)
                 }

--- a/ArcBox/Views/Containers/Tabs/ContainerTerminalTab.swift
+++ b/ArcBox/Views/Containers/Tabs/ContainerTerminalTab.swift
@@ -16,6 +16,7 @@ struct ContainerTerminalTab: View {
     @State private var session = DockerTerminalSession()
     @State private var selectedShell = "/bin/sh"
     @State private var terminalToken = UUID()
+    @State private var externalTerminalErrorMessage: String?
 
     private let availableShells = ["/bin/sh", "/bin/bash", "/bin/zsh"]
 
@@ -37,11 +38,17 @@ struct ContainerTerminalTab: View {
 
                     Button(
                         action: {
-                            ExternalTerminalLauncher.open(
-                                preference: externalTerminal,
-                                containerID: container.id,
-                                shell: selectedShell
-                            )
+                            Task {
+                                do {
+                                    try await ExternalTerminalLauncher.open(
+                                        preference: externalTerminal,
+                                        containerID: container.id,
+                                        shell: selectedShell
+                                    )
+                                } catch {
+                                    externalTerminalErrorMessage = error.localizedDescription
+                                }
+                            }
                         },
                         label: {
                             Image(systemName: "rectangle.portrait.and.arrow.right")
@@ -105,6 +112,17 @@ struct ContainerTerminalTab: View {
                 session.disconnect()
             }
         }
+        .alert(
+            "External Terminal Did Not Open",
+            isPresented: Binding(
+                get: { externalTerminalErrorMessage != nil },
+                set: { if !$0 { externalTerminalErrorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(externalTerminalErrorMessage ?? "The terminal could not be opened.")
+        }
     }
 
     private var terminalContent: some View {
@@ -112,13 +130,16 @@ struct ContainerTerminalTab: View {
             delegate: TerminalSessionBridge(session: session),
             onTerminalCreated: { terminalView in
                 configureTerminalAppearance(terminalView)
-
-                // Connect session
-                session.connect(
-                    containerID: container.id,
-                    shell: selectedShell,
-                    terminalView: terminalView
-                )
+                let containerID = container.id
+                let shell = selectedShell
+                // Defer state modifications out of the view update cycle.
+                Task { @MainActor in
+                    session.connect(
+                        containerID: containerID,
+                        shell: shell,
+                        terminalView: terminalView
+                    )
+                }
             }, theme: terminalTheme)
     }
 

--- a/ArcBox/Views/ContentView.swift
+++ b/ArcBox/Views/ContentView.swift
@@ -29,6 +29,8 @@ struct ContentView: View {
     let onAccount: () -> Void
 
     @Environment(AppViewModel.self) private var appVM
+    @Environment(\.arcboxClient) private var arcboxClient
+    @Environment(\.dockerClient) private var dockerClient
 
     // Shared ViewModels (owned by ApplicationCoordinator, shared with the menu bar)
     @Environment(ContainersViewModel.self) private var containersVM
@@ -45,17 +47,33 @@ struct ContentView: View {
 
     @ViewBuilder
     var body: some View {
-        if usesFullWidthDetail {
-            NavigationSplitView {
-                sidebar
-            } detail: {
-                detailPanel
-                    .background(AppColors.sidebar)
-                    .toolbarSeparator()
+        Group {
+            if usesFullWidthDetail {
+                NavigationSplitView {
+                    sidebar
+                } detail: {
+                    detailPanel
+                        .background(AppColors.sidebar)
+                        .toolbarSeparator()
+                }
+            } else {
+                threeColumnLayout
             }
-        } else {
-            threeColumnLayout
         }
+        .task(id: appVM.pendingResourceDeepLink) {
+            await refreshVisibleResourceListIfNeeded()
+        }
+        .onChange(of: resourceDeepLinkAvailability, initial: true) { _, availability in
+            guard
+                let availability,
+                let request = appVM.resolveResourceDeepLink(
+                    availableIDs: availability.ids,
+                    isLoaded: availability.isLoaded
+                )
+            else { return }
+            selectResource(request)
+        }
+        .errorToast(message: Bindable(appVM).deepLinkError)
     }
 
     private var threeColumnLayout: some View {
@@ -108,6 +126,162 @@ struct ContentView: View {
     /// dividers stacked beside the sidebar.
     private var usesFullWidthDetail: Bool {
         appVM.currentNav == .activity
+    }
+
+    private var resourceDeepLinkAvailability: ResourceDeepLinkAvailability? {
+        guard let request = appVM.pendingResourceDeepLink else { return nil }
+        switch request.section {
+        case .activity:
+            return nil
+        case .containers:
+            return ResourceDeepLinkAvailability(
+                request: request,
+                ids: Set(containersVM.containers.map(\.id)),
+                isLoaded: containersVM.loadState == .loaded
+                    && wasLoadedAfterRequest(
+                        containersVM.lastSuccessfulListLoad,
+                        request: request
+                    )
+            )
+        case .volumes:
+            return ResourceDeepLinkAvailability(
+                request: request,
+                ids: Set(volumesVM.volumes.map(\.id)),
+                isLoaded: volumesVM.loadState == .loaded
+                    && wasLoadedAfterRequest(
+                        volumesVM.lastSuccessfulListLoad,
+                        request: request
+                    )
+            )
+        case .images:
+            return ResourceDeepLinkAvailability(
+                request: request,
+                ids: Set(imagesVM.images.map(\.id)),
+                isLoaded: imagesVM.loadState == .loaded
+                    && wasLoadedAfterRequest(
+                        imagesVM.lastSuccessfulListLoad,
+                        request: request
+                    )
+            )
+        case .networks:
+            return ResourceDeepLinkAvailability(
+                request: request,
+                ids: Set(networksVM.networks.map(\.id)),
+                isLoaded: networksVM.loadState == .loaded
+                    && wasLoadedAfterRequest(
+                        networksVM.lastSuccessfulListLoad,
+                        request: request
+                    )
+            )
+        case .pods:
+            return ResourceDeepLinkAvailability(
+                request: request,
+                ids: Set(k8sState.podsModel.pods.map(\.id)),
+                isLoaded: k8sState.podsModel.streamPhase == .live
+            )
+        case .services:
+            return ResourceDeepLinkAvailability(
+                request: request,
+                ids: Set(k8sState.servicesModel.services.map(\.id)),
+                isLoaded: k8sState.servicesModel.streamPhase == .live
+            )
+        case .machines:
+            return ResourceDeepLinkAvailability(
+                request: request,
+                ids: Set(machinesVM.machines.map(\.id)),
+                isLoaded: machinesVM.loadState == .loaded
+                    && wasLoadedAfterRequest(
+                        machinesVM.lastSuccessfulListLoad,
+                        request: request
+                    )
+            )
+        case .sandboxes:
+            return ResourceDeepLinkAvailability(
+                request: request,
+                ids: Set(sandboxesVM.sandboxes.map(\.id)),
+                isLoaded: sandboxesVM.loadState == .loaded
+                    && wasLoadedAfterRequest(
+                        sandboxesVM.lastSuccessfulListLoad,
+                        request: request
+                    )
+            )
+        }
+    }
+
+    private func wasLoadedAfterRequest(
+        _ lastSuccessfulLoad: ContinuousClock.Instant?,
+        request: AppViewModel.ResourceDeepLink
+    ) -> Bool {
+        guard let lastSuccessfulLoad else { return false }
+        return lastSuccessfulLoad >= request.requestedAt
+    }
+
+    private func refreshVisibleResourceListIfNeeded() async {
+        guard
+            let request = appVM.pendingResourceDeepLink,
+            request.needsExplicitRefresh
+        else { return }
+
+        switch request.section {
+        case .activity, .pods, .services:
+            break
+        case .containers:
+            await containersVM.loadContainersFromDocker(
+                docker: dockerClient,
+                iconClient: arcboxClient
+            )
+        case .volumes:
+            await volumesVM.loadVolumes(docker: dockerClient)
+        case .images:
+            await imagesVM.loadImages(docker: dockerClient, iconClient: arcboxClient)
+        case .networks:
+            await networksVM.loadNetworks(docker: dockerClient)
+        case .machines:
+            await machinesVM.loadMachines(client: arcboxClient)
+        case .sandboxes:
+            await sandboxesVM.loadSandboxes(client: arcboxClient)
+        }
+    }
+
+    private func selectResource(_ request: AppViewModel.ResourceDeepLink) {
+        switch request.section {
+        case .activity:
+            break
+        case .containers:
+            containersVM.searchText = ""
+            if let project = containersVM.containers.first(where: { $0.id == request.id })?
+                .composeProject
+            {
+                containersVM.expandedGroups.insert(project)
+            }
+            Task {
+                await containersVM.selectContainer(
+                    request.id,
+                    client: arcboxClient,
+                    docker: dockerClient
+                )
+            }
+        case .volumes:
+            volumesVM.searchText = ""
+            volumesVM.selectVolume(request.id)
+        case .images:
+            imagesVM.searchText = ""
+            imagesVM.selectImage(request.id)
+        case .networks:
+            networksVM.searchText = ""
+            networksVM.selectNetwork(request.id)
+        case .pods:
+            k8sState.podsModel.searchText = ""
+            k8sState.podsModel.selectedID = request.id
+        case .services:
+            k8sState.servicesModel.searchText = ""
+            k8sState.servicesModel.selectedID = request.id
+        case .machines:
+            machinesVM.searchText = ""
+            machinesVM.selectMachine(request.id)
+        case .sandboxes:
+            sandboxesVM.selectSandbox(request.id)
+        }
     }
 
     // MARK: - Content column
@@ -191,4 +365,10 @@ struct ContentView: View {
                 .environment(containersVM)
         }
     }
+}
+
+private struct ResourceDeepLinkAvailability: Equatable {
+    let request: AppViewModel.ResourceDeepLink
+    let ids: Set<String>
+    let isLoaded: Bool
 }

--- a/ArcBox/Views/ContentView.swift
+++ b/ArcBox/Views/ContentView.swift
@@ -178,12 +178,20 @@ struct ContentView: View {
                 request: request,
                 ids: Set(k8sState.podsModel.pods.map(\.id)),
                 isLoaded: k8sState.podsModel.streamPhase == .live
+                    && wasLoadedAfterRequest(
+                        k8sState.podsModel.lastStreamUpdate,
+                        request: request
+                    )
             )
         case .services:
             return ResourceDeepLinkAvailability(
                 request: request,
                 ids: Set(k8sState.servicesModel.services.map(\.id)),
                 isLoaded: k8sState.servicesModel.streamPhase == .live
+                    && wasLoadedAfterRequest(
+                        k8sState.servicesModel.lastStreamUpdate,
+                        request: request
+                    )
             )
         case .machines:
             return ResourceDeepLinkAvailability(
@@ -217,13 +225,10 @@ struct ContentView: View {
     }
 
     private func refreshVisibleResourceListIfNeeded() async {
-        guard
-            let request = appVM.pendingResourceDeepLink,
-            request.needsExplicitRefresh
-        else { return }
+        guard let request = appVM.pendingResourceDeepLink else { return }
 
         switch request.section {
-        case .activity, .pods, .services:
+        case .activity:
             break
         case .containers:
             await containersVM.loadContainersFromDocker(
@@ -236,6 +241,8 @@ struct ContentView: View {
             await imagesVM.loadImages(docker: dockerClient, iconClient: arcboxClient)
         case .networks:
             await networksVM.loadNetworks(docker: dockerClient)
+        case .pods, .services:
+            k8sState.retryStreams(client: arcboxClient)
         case .machines:
             await machinesVM.loadMachines(client: arcboxClient)
         case .sandboxes:

--- a/ArcBox/Views/Kubernetes/PodsListViewController.swift
+++ b/ArcBox/Views/Kubernetes/PodsListViewController.swift
@@ -451,9 +451,6 @@ final class PodsListViewController: NSViewController,
             let rows = snapshot?.rows,
             let row = rows.firstIndex(where: { $0.id == selectedID })
         else {
-            if let selectedID, !viewModel.pods.contains(where: { $0.id == selectedID }) {
-                viewModel.selectedID = nil
-            }
             guard tableView.selectedRow != -1 else { return }
             applyingSelection {
                 tableView.deselectAll(nil)

--- a/ArcBox/Views/Kubernetes/ServicesListViewController.swift
+++ b/ArcBox/Views/Kubernetes/ServicesListViewController.swift
@@ -446,9 +446,6 @@ final class ServicesListViewController: NSViewController,
             let rows = snapshot?.rows,
             let row = rows.firstIndex(where: { $0.id == selectedID })
         else {
-            if let selectedID, !viewModel.services.contains(where: { $0.id == selectedID }) {
-                viewModel.selectedID = nil
-            }
             guard tableView.selectedRow != -1 else { return }
             applyingSelection {
                 tableView.deselectAll(nil)

--- a/ArcBox/Views/Machines/Tabs/MachineTerminalTab.swift
+++ b/ArcBox/Views/Machines/Tabs/MachineTerminalTab.swift
@@ -8,6 +8,7 @@ struct MachineTerminalTab: View {
 
     @Environment(\.arcboxClient) private var client
 
+    @AppStorage("terminalTheme") private var terminalTheme = "system"
     @State private var session = MachineTerminalSession()
     @State private var selectedShell = "/bin/sh"
     @State private var terminalToken = UUID()
@@ -98,23 +99,25 @@ struct MachineTerminalTab: View {
     }
 
     private var terminalContent: some View {
-        SwiftTermView(delegate: TerminalSessionBridge(session: session)) { terminalView in
-            TerminalAppearance.configure(terminalView)
-
-            guard !hasConnected, let client else { return }
-            let machineID = machine.id
-            let shell = selectedShell
-            // Defer state modifications out of the view update cycle.
-            Task { @MainActor in
-                hasConnected = true
-                session.connect(
-                    machineID: machineID,
-                    command: [shell, "-l"],
-                    client: client,
-                    terminalView: terminalView
-                )
-            }
-        }
+        SwiftTermView(
+            delegate: TerminalSessionBridge(session: session),
+            onTerminalCreated: { terminalView in
+                guard !hasConnected, let client else { return }
+                let machineID = machine.id
+                let shell = selectedShell
+                // Defer state modifications out of the view update cycle.
+                Task { @MainActor in
+                    hasConnected = true
+                    session.connect(
+                        machineID: machineID,
+                        command: [shell, "-l"],
+                        client: client,
+                        terminalView: terminalView
+                    )
+                }
+            },
+            theme: terminalTheme
+        )
     }
 
     private var notRunningView: some View {

--- a/ArcBox/Views/Sandboxes/NewSandboxSheet.swift
+++ b/ArcBox/Views/Sandboxes/NewSandboxSheet.swift
@@ -100,7 +100,12 @@ struct NewSandboxSheet: View {
                 }
 
                 Section("Workload") {
-                    TextField("Command", text: $command, prompt: Text("empty = boot to ready"))
+                    VStack(alignment: .leading, spacing: 2) {
+                        TextField("Command", text: $command, prompt: Text("empty = boot to ready"))
+                        Text(ArgumentList.inputHelp)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                     TextField("Working directory", text: $workingDir)
                     TextField("User", text: $user, prompt: Text("e.g. root"))
                 }
@@ -187,8 +192,12 @@ struct NewSandboxSheet: View {
         spec.image = image.trimmingCharacters(in: .whitespaces)
         spec.vcpus = UInt32(vcpus)
         spec.memoryMiB = UInt64(memoryMiB)
-        let trimmedCommand = command.trimmingCharacters(in: .whitespaces)
-        spec.cmd = trimmedCommand.isEmpty ? [] : trimmedCommand.split(separator: " ").map(String.init)
+        do {
+            spec.cmd = try ArgumentList.parse(command)
+        } catch {
+            errorMessage = "Invalid command: \(error.localizedDescription)"
+            return 0
+        }
         spec.workingDir = workingDir.trimmingCharacters(in: .whitespaces)
         spec.user = user.trimmingCharacters(in: .whitespaces)
         spec.networkMode = networkMode.protobufValue

--- a/ArcBox/Views/Sandboxes/Tabs/SandboxTerminalTab.swift
+++ b/ArcBox/Views/Sandboxes/Tabs/SandboxTerminalTab.swift
@@ -11,6 +11,7 @@ struct SandboxTerminalTab: View {
     @Environment(SandboxesViewModel.self) private var vm
     @Environment(\.arcboxClient) private var client
 
+    @AppStorage("terminalTheme") private var terminalTheme = "system"
     @State private var selectedShell = "/bin/sh"
     @State private var terminalToken = UUID()
     @State private var hasConnected = false
@@ -102,25 +103,27 @@ struct SandboxTerminalTab: View {
     }
 
     private var terminalContent: some View {
-        SwiftTermView(delegate: TerminalSessionBridge(session: session)) { terminalView in
-            TerminalAppearance.configure(terminalView)
-
-            guard canStartExecution, !hasConnected, let client else { return }
-            let sandboxID = sandboxID
-            let shell = selectedShell
-            let machineID = vm.activeMachineID
-            // Defer state modifications out of the view update cycle.
-            Task { @MainActor in
-                hasConnected = true
-                session.connect(
-                    sandboxID: sandboxID,
-                    command: [shell],
-                    machineID: machineID,
-                    client: client,
-                    terminalView: terminalView
-                )
-            }
-        }
+        SwiftTermView(
+            delegate: TerminalSessionBridge(session: session),
+            onTerminalCreated: { terminalView in
+                guard canStartExecution, !hasConnected, let client else { return }
+                let sandboxID = sandboxID
+                let shell = selectedShell
+                let machineID = vm.activeMachineID
+                // Defer state modifications out of the view update cycle.
+                Task { @MainActor in
+                    hasConnected = true
+                    session.connect(
+                        sandboxID: sandboxID,
+                        command: [shell],
+                        machineID: machineID,
+                        client: client,
+                        terminalView: terminalView
+                    )
+                }
+            },
+            theme: terminalTheme
+        )
     }
 
     private func errorView(_ message: String) -> some View {

--- a/ArcBox/Views/Settings/GeneralSettingsView.swift
+++ b/ArcBox/Views/Settings/GeneralSettingsView.swift
@@ -12,6 +12,7 @@ struct GeneralSettingsView: View {
     @Environment(ContainersViewModel.self) private var containersVM
     @Environment(ImagesViewModel.self) private var imagesVM
     @Environment(UpdaterSettingsModel.self) private var updaterSettings
+    @Environment(\.scenePhase) private var scenePhase
 
     @AppStorage("startAtLogin") private var startAtLogin = false
     @AppStorage("showInMenuBar") private var showInMenuBar = false
@@ -20,8 +21,9 @@ struct GeneralSettingsView: View {
     @AppStorage("externalTerminal") private var externalTerminal = ExternalTerminalApp.terminalBundleIdentifier
     @AppStorage("telemetryEnabled") private var telemetryEnabled = true
 
-    @State private var isSyncingLoginItem = false
     @State private var isExportingDiagnostics = false
+    @State private var loginItemErrorMessage: String?
+    @State private var diagnosticErrorMessage: String?
     @State private var externalTerminalApps = ExternalTerminalDiscovery.availableTerminals()
     @State private var externalTerminalSelection = ExternalTerminalApp.terminalBundleIdentifier
     @State private var isShowingExternalTerminalImporter = false
@@ -31,11 +33,22 @@ struct GeneralSettingsView: View {
     var body: some View {
         Form {
             Section {
-                Toggle("Start at login", isOn: $startAtLogin)
-                    .onChange(of: startAtLogin) { _, newValue in
-                        guard !isSyncingLoginItem else { return }
-                        updateLoginItem(enabled: newValue)
+                Toggle(
+                    "Start at login",
+                    isOn: Binding(
+                        get: { startAtLogin },
+                        set: { updateLoginItem(enabled: $0) }
+                    )
+                )
+                if let loginItemErrorMessage {
+                    Label(loginItemErrorMessage, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                    Button("Open Login Items Settings") {
+                        SMAppService.openSystemSettingsLoginItems()
                     }
+                    .font(.caption)
+                }
                 Toggle("Show in menu bar", isOn: $showInMenuBar)
             }
 
@@ -118,16 +131,26 @@ struct GeneralSettingsView: View {
 
             Section("Troubleshooting") {
                 Button("Export Diagnostic Report...") {
-                    guard let presentingWindow = NSApp.keyWindow else { return }
+                    guard let presentingWindow = NSApp.keyWindow ?? NSApp.mainWindow else {
+                        diagnosticErrorMessage =
+                            "ArcBox could not present the save panel. Reopen Settings and try again."
+                        return
+                    }
+                    diagnosticErrorMessage = nil
                     isExportingDiagnostics = true
                     Task {
-                        await DiagnosticBundleExporter.exportInteractively(
-                            daemonManager: daemonManager,
-                            containersVM: containersVM,
-                            imagesVM: imagesVM,
-                            presentingWindow: presentingWindow
-                        )
-                        isExportingDiagnostics = false
+                        defer { isExportingDiagnostics = false }
+                        do {
+                            _ = try await DiagnosticBundleExporter.exportInteractively(
+                                daemonManager: daemonManager,
+                                containersVM: containersVM,
+                                imagesVM: imagesVM,
+                                presentingWindow: presentingWindow
+                            )
+                        } catch {
+                            diagnosticErrorMessage =
+                                "Diagnostic report was not exported: \(error.localizedDescription)"
+                        }
                     }
                 }
                 .disabled(isExportingDiagnostics)
@@ -140,6 +163,12 @@ struct GeneralSettingsView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+
+                if let diagnosticErrorMessage {
+                    Label(diagnosticErrorMessage, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
             }
         }
         .formStyle(.grouped)
@@ -147,6 +176,11 @@ struct GeneralSettingsView: View {
         .onAppear {
             syncLoginItemState()
             refreshExternalTerminalApps()
+        }
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active {
+                syncLoginItemState()
+            }
         }
         .fileImporter(
             isPresented: $isShowingExternalTerminalImporter,
@@ -236,12 +270,16 @@ struct GeneralSettingsView: View {
     // MARK: - Login Item
 
     private func syncLoginItemState() {
-        isSyncingLoginItem = true
-        startAtLogin = SMAppService.mainApp.status == .enabled
-        isSyncingLoginItem = false
+        let status = SMAppService.mainApp.status
+        startAtLogin = status == .enabled
+        loginItemErrorMessage =
+            status == .requiresApproval
+            ? "macOS requires approval before ArcBox can start at login."
+            : nil
     }
 
     private func updateLoginItem(enabled: Bool) {
+        var operationError: Error?
         do {
             if enabled {
                 try SMAppService.mainApp.register()
@@ -249,8 +287,23 @@ struct GeneralSettingsView: View {
                 try SMAppService.mainApp.unregister()
             }
         } catch {
-            // Revert on failure
-            startAtLogin = !enabled
+            operationError = error
+        }
+
+        let status = SMAppService.mainApp.status
+        startAtLogin = status == .enabled
+        guard startAtLogin != enabled else {
+            loginItemErrorMessage = nil
+            return
+        }
+
+        if status == .requiresApproval {
+            loginItemErrorMessage = "macOS requires approval before ArcBox can start at login."
+        } else if let operationError {
+            loginItemErrorMessage =
+                "The login item was not changed: \(operationError.localizedDescription)"
+        } else {
+            loginItemErrorMessage = "macOS did not apply the requested login item setting."
         }
     }
 }

--- a/ArcBox/Views/Settings/StorageSettingsView.swift
+++ b/ArcBox/Views/Settings/StorageSettingsView.swift
@@ -1,6 +1,16 @@
 import DockerClient
 import SwiftUI
 
+nonisolated private enum TimeMachineSettingError: LocalizedError {
+    case commandFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .commandFailed(let detail): detail
+        }
+    }
+}
+
 struct StorageSettingsView: View {
     @Environment(\.dockerClient) private var docker
 
@@ -8,6 +18,9 @@ struct StorageSettingsView: View {
     /// Tracks whether the Time Machine exclusion has been applied this session, to avoid
     /// spawning tmutil on every onAppear.
     @State private var timeMachineExclusionApplied = false
+    @State private var isUpdatingTimeMachine = false
+    @State private var timeMachineErrorMessage: String?
+    @State private var failedTimeMachineValue: Bool?
     // Reset state
     @State private var showResetDockerAlert = false
     @State private var isResetting = false
@@ -23,15 +36,36 @@ struct StorageSettingsView: View {
     var body: some View {
         Form {
             Section("Data") {
-                Toggle("Include data in Time Machine backups", isOn: $includeTimeMachine)
-                    .onChange(of: includeTimeMachine) { _, include in
-                        updateTimeMachineExclusion(include: include)
+                Toggle(
+                    "Include data in Time Machine backups",
+                    isOn: Binding(
+                        get: { includeTimeMachine },
+                        set: { updateTimeMachineExclusion(include: $0) }
+                    )
+                )
+                .disabled(isUpdatingTimeMachine)
+                .onAppear {
+                    guard !timeMachineExclusionApplied else { return }
+                    timeMachineExclusionApplied = true
+                    updateTimeMachineExclusion(include: includeTimeMachine)
+                }
+
+                if isUpdatingTimeMachine {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+
+                if let timeMachineErrorMessage {
+                    Label(timeMachineErrorMessage, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                    if let failedTimeMachineValue {
+                        Button("Try Again") {
+                            updateTimeMachineExclusion(include: failedTimeMachineValue)
+                        }
+                        .font(.caption)
                     }
-                    .onAppear {
-                        guard !timeMachineExclusionApplied else { return }
-                        timeMachineExclusionApplied = true
-                        updateTimeMachineExclusion(include: includeTimeMachine)
-                    }
+                }
             }
 
             Section("Danger Zone") {
@@ -73,29 +107,50 @@ struct StorageSettingsView: View {
 
     private func updateTimeMachineExclusion(include: Bool) {
         let path = Self.arcboxDataPath
-        Task.detached {
-            let fm = FileManager.default
-            // Ensure the directory exists before calling tmutil
-            if !fm.fileExists(atPath: path) {
-                try? fm.createDirectory(atPath: path, withIntermediateDirectories: true)
+        timeMachineErrorMessage = nil
+        failedTimeMachineValue = nil
+        isUpdatingTimeMachine = true
+        Task {
+            do {
+                try await Self.setTimeMachineExclusion(include: include, path: path)
+                includeTimeMachine = include
+            } catch {
+                failedTimeMachineValue = include
+                timeMachineErrorMessage =
+                    "The Time Machine setting was not changed: \(error.localizedDescription) "
+                    + "Check Full Disk Access in System Settings > Privacy & Security, then try again."
+            }
+            isUpdatingTimeMachine = false
+        }
+    }
+
+    nonisolated private static func setTimeMachineExclusion(include: Bool, path: String) async throws {
+        try await Task.detached {
+            let fileManager = FileManager.default
+            if !fileManager.fileExists(atPath: path) {
+                try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true)
             }
 
-            let proc = Process()
-            proc.executableURL = URL(fileURLWithPath: "/usr/bin/tmutil")
-            proc.arguments = include ? ["removeexclusion", path] : ["addexclusion", path]
-            proc.standardOutput = FileHandle.nullDevice
-            proc.standardError = FileHandle.nullDevice
-            do {
-                try proc.run()
-                proc.waitUntilExit()
-                if proc.terminationStatus != 0 {
-                    // Revert toggle on failure
-                    await MainActor.run { includeTimeMachine = !include }
-                }
-            } catch {
-                await MainActor.run { includeTimeMachine = !include }
-            }
-        }
+            let process = Process()
+            let errorPipe = Pipe()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/tmutil")
+            process.arguments = include ? ["removeexclusion", path] : ["addexclusion", path]
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = errorPipe
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus != 0 else { return }
+
+            let detail = String(
+                data: errorPipe.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            )?.trimmingCharacters(in: .whitespacesAndNewlines)
+            throw TimeMachineSettingError.commandFailed(
+                detail?.isEmpty == false
+                    ? detail ?? ""
+                    : "tmutil exited with status \(process.terminationStatus)."
+            )
+        }.value
     }
 
     // MARK: - Reset Operations

--- a/ArcBox/Views/Settings/SystemSettingsView.swift
+++ b/ArcBox/Views/Settings/SystemSettingsView.swift
@@ -11,6 +11,7 @@ struct SystemSettingsView: View {
     @AppStorage("pauseContainersWhileSleeping") private var pauseContainersWhileSleeping = true
 
     @Environment(\.arcboxClient) private var arcboxClient
+    @Environment(AppViewModel.self) private var appVM
     @Environment(DaemonManager.self) private var daemonManager
     @Environment(SystemVmBackendModel.self) private var backendModel
 
@@ -19,6 +20,7 @@ struct SystemSettingsView: View {
     @State private var selectedBackend: SystemVmBackend = .vz
     @State private var pendingBackend: SystemVmBackend?
     @State private var showBackendConfirm = false
+    @State private var isUpdatingDockerContext = false
 
     // private let memoryRange: ClosedRange<Double> = 1...14
 
@@ -85,14 +87,31 @@ struct SystemSettingsView: View {
                 //     }
                 // }
 
-                Toggle("Switch Docker context automatically", isOn: $switchContextAutomatically)
-                    .onChange(of: switchContextAutomatically) { _, newValue in
-                        if newValue {
-                            DockerContextManager.switchToArcBox()
-                        } else {
-                            DockerContextManager.restorePreviousContext()
+                Toggle(
+                    "Switch Docker context automatically",
+                    isOn: Binding(
+                        get: { switchContextAutomatically },
+                        set: { updateDockerContext(enabled: $0) }
+                    )
+                )
+                .disabled(isUpdatingDockerContext)
+
+                if isUpdatingDockerContext {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+
+                if let dockerContextError = appVM.dockerContextError {
+                    Label(dockerContextError, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                    if let retryValue = appVM.dockerContextRetryValue {
+                        Button("Try Again") {
+                            updateDockerContext(enabled: retryValue)
                         }
+                        .font(.caption)
                     }
+                }
             }
 
             Section {
@@ -207,6 +226,28 @@ struct SystemSettingsView: View {
     }
 
     // MARK: - System VM Backend
+
+    private func updateDockerContext(enabled: Bool) {
+        appVM.dockerContextError = nil
+        appVM.dockerContextRetryValue = nil
+        isUpdatingDockerContext = true
+        Task {
+            do {
+                if enabled {
+                    try await DockerContextManager.switchToArcBox()
+                } else {
+                    try await DockerContextManager.restorePreviousContext()
+                }
+                switchContextAutomatically = enabled
+            } catch {
+                appVM.dockerContextError =
+                    "The Docker context setting was not changed: \(error.localizedDescription) "
+                    + "Check that the Docker CLI is installed and ~/.docker/config.json is writable, then try again."
+                appVM.dockerContextRetryValue = enabled
+            }
+            isUpdatingDockerContext = false
+        }
+    }
 
     private static let backendCaption =
         "Intel (amd64) code runs via Rosetta on Virtualization.framework, or via FEX on Hypervisor.framework. Switching restarts the System VM."

--- a/ArcBox/Views/Settings/SystemSettingsView.swift
+++ b/ArcBox/Views/Settings/SystemSettingsView.swift
@@ -105,9 +105,9 @@ struct SystemSettingsView: View {
                     Label(dockerContextError, systemImage: "exclamationmark.triangle")
                         .font(.caption)
                         .foregroundStyle(.red)
-                    if let retryValue = appVM.dockerContextRetryValue {
+                    if let retry = appVM.dockerContextRetry {
                         Button("Try Again") {
-                            updateDockerContext(enabled: retryValue)
+                            updateDockerContext(retry: retry)
                         }
                         .font(.caption)
                     }
@@ -228,19 +228,31 @@ struct SystemSettingsView: View {
     // MARK: - System VM Backend
 
     private func updateDockerContext(enabled: Bool) {
+        updateDockerContext(retry: .preference(enabled: enabled))
+    }
+
+    private func updateDockerContext(retry: AppViewModel.DockerContextRetry) {
         appVM.dockerContextError = nil
-        appVM.dockerContextRetryValue = nil
+        appVM.dockerContextRetry = nil
         isUpdatingDockerContext = true
-        let operation = DockerContextManager.update(useArcBox: enabled)
-        Task {
-            do {
-                try await operation.value
-                switchContextAutomatically = enabled
-            } catch {
+        DockerContextManager.update(useArcBox: retry.useArcBox) { result in
+            switch result {
+            case .success:
+                if case let .preference(enabled) = retry {
+                    switchContextAutomatically = enabled
+                }
+                appVM.dockerContextError = nil
+                appVM.dockerContextRetry = nil
+            case let .failure(error):
+                let failure =
+                    switch retry {
+                    case .lifecycle: "The Docker context was not updated: "
+                    case .preference: "The Docker context setting was not changed: "
+                    }
                 appVM.dockerContextError =
-                    "The Docker context setting was not changed: \(error.localizedDescription) "
+                    failure + "\(error.localizedDescription) "
                     + "Check that the Docker CLI is installed and ~/.docker/config.json is writable, then try again."
-                appVM.dockerContextRetryValue = enabled
+                appVM.dockerContextRetry = retry
             }
             isUpdatingDockerContext = false
         }

--- a/ArcBox/Views/Settings/SystemSettingsView.swift
+++ b/ArcBox/Views/Settings/SystemSettingsView.swift
@@ -231,13 +231,10 @@ struct SystemSettingsView: View {
         appVM.dockerContextError = nil
         appVM.dockerContextRetryValue = nil
         isUpdatingDockerContext = true
+        let operation = DockerContextManager.update(useArcBox: enabled)
         Task {
             do {
-                if enabled {
-                    try await DockerContextManager.switchToArcBox()
-                } else {
-                    try await DockerContextManager.restorePreviousContext()
-                }
+                try await operation.value
                 switchContextAutomatically = enabled
             } catch {
                 appVM.dockerContextError =

--- a/ArcBoxTests/ActivityRowGroupingTests.swift
+++ b/ArcBoxTests/ActivityRowGroupingTests.swift
@@ -105,6 +105,20 @@ final class ActivityRowGroupingTests: XCTestCase {
             "a container ID is hex, so the project prefix has to break that")
     }
 
+    func testFilteringTemporarilyExpandsGroupsAndRestoresTheirState() {
+        var state = ActivityRowDisclosureState()
+        state.setExpanded(true, for: "project:expanded", isFiltering: false)
+
+        XCTAssertFalse(state.isExpanded("project:collapsed", isFiltering: false))
+        XCTAssertTrue(state.isExpanded("project:expanded", isFiltering: false))
+        XCTAssertTrue(state.isExpanded("project:collapsed", isFiltering: true))
+        XCTAssertTrue(state.isExpanded("project:expanded", isFiltering: true))
+
+        state.setExpanded(false, for: "project:expanded", isFiltering: true)
+        XCTAssertFalse(state.isExpanded("project:collapsed", isFiltering: false))
+        XCTAssertTrue(state.isExpanded("project:expanded", isFiltering: false))
+    }
+
     // MARK: - Fixtures
 
     private func row(

--- a/ArcBoxTests/CreateOperationErrorTests.swift
+++ b/ArcBoxTests/CreateOperationErrorTests.swift
@@ -107,3 +107,30 @@ final class CreateOperationErrorTests: XCTestCase {
         XCTAssertNotEqual(vm.lastError, "left over from a previous delete")
     }
 }
+
+final class ArgumentListTests: XCTestCase {
+    func testParsesQuotedArgumentInput() throws {
+        let cases: [(String, [String])] = [
+            ("", []),
+            ("one\t two\nthree", ["one", "two", "three"]),
+            (#"sh -c "echo hello world""#, ["sh", "-c", "echo hello world"]),
+            (#"printf '%s %s' "hello world" café"#, ["printf", "%s %s", "hello world", "café"]),
+            (#"one\ two "three\"four" 'five\six'"#, ["one two", "three\"four", #"five\six"#]),
+            ("\"\" ''", ["", ""]),
+            (#"echo "你好 世界" 🐳"#, ["echo", "你好 世界", "🐳"]),
+        ]
+
+        for (input, expected) in cases {
+            XCTAssertEqual(try ArgumentList.parse(input), expected, input)
+        }
+    }
+
+    func testRejectsUnterminatedInput() {
+        XCTAssertThrowsError(try ArgumentList.parse(#""unterminated"#)) {
+            XCTAssertEqual($0 as? ArgumentList.ParseError, .unterminatedQuote("\""))
+        }
+        XCTAssertThrowsError(try ArgumentList.parse("trailing\\")) {
+            XCTAssertEqual($0 as? ArgumentList.ParseError, .danglingEscape)
+        }
+    }
+}

--- a/ArcBoxTests/DeepLinkTests.swift
+++ b/ArcBoxTests/DeepLinkTests.swift
@@ -42,6 +42,72 @@ final class DeepLinkTests: XCTestCase {
         }
     }
 
+    @MainActor func testRoutesEverySectionWithoutID() {
+        let (router, appVM) = makeRouter()
+
+        for item in NavItem.allCases {
+            router.handle(URL(string: "arcbox://\(item.rawValue)")!)
+
+            XCTAssertEqual(appVM.currentNav, item)
+            XCTAssertNil(appVM.pendingResourceDeepLink)
+            XCTAssertNil(appVM.deepLinkError)
+        }
+    }
+
+    @MainActor func testResolvesValidAndReportsMissingIDsForEveryResourceSection() {
+        let (router, appVM) = makeRouter()
+        let resourceSections = NavItem.allCases.filter { $0 != .activity }
+
+        for item in resourceSections {
+            let validID = "valid-\(item.rawValue)"
+            router.handle(URL(string: "arcbox://\(item.rawValue)/\(validID)")!)
+
+            let resolved = appVM.resolveResourceDeepLink(
+                availableIDs: [validID],
+                isLoaded: true
+            )
+            XCTAssertEqual(resolved?.section, item)
+            XCTAssertEqual(resolved?.id, validID)
+            XCTAssertNil(appVM.deepLinkError)
+
+            let missingID = "missing-\(item.rawValue)"
+            router.handle(URL(string: "arcbox://\(item.rawValue)/\(missingID)")!)
+
+            XCTAssertNil(
+                appVM.resolveResourceDeepLink(availableIDs: [validID], isLoaded: true)
+            )
+            XCTAssertEqual(
+                appVM.deepLinkError,
+                "Resource “\(missingID)” wasn’t found in \(item.label)."
+            )
+        }
+    }
+
+    @MainActor func testWaitsForFreshResourceListBeforeResolvingID() {
+        let (router, appVM) = makeRouter()
+        router.handle(URL(string: "arcbox://machines/machine-id")!)
+
+        XCTAssertNil(
+            appVM.resolveResourceDeepLink(
+                availableIDs: ["machine-id"],
+                isLoaded: false
+            )
+        )
+        XCTAssertEqual(appVM.pendingResourceDeepLink?.section, .machines)
+        XCTAssertEqual(appVM.pendingResourceDeepLink?.id, "machine-id")
+        XCTAssertNil(appVM.deepLinkError)
+    }
+
+    @MainActor func testRejectsActivityResourceIDVisibly() {
+        let (router, appVM) = makeRouter()
+
+        router.handle(URL(string: "arcbox://activity/event-id")!)
+
+        XCTAssertEqual(appVM.currentNav, .activity)
+        XCTAssertNil(appVM.pendingResourceDeepLink)
+        XCTAssertEqual(appVM.deepLinkError, "Activity links don’t support resource IDs.")
+    }
+
     @MainActor func testDecodesPercentEncodedID() {
         XCTAssertEqual(parse("arcbox://volumes/my%20volume"), .section(.volumes, id: "my volume"))
     }
@@ -67,5 +133,20 @@ final class DeepLinkTests: XCTestCase {
 
     @MainActor func testRejectsUnavailableTemplatesSection() {
         XCTAssertNil(parse("arcbox://templates"))
+    }
+
+    @MainActor private func makeRouter() -> (DeepLinkRouter, AppViewModel) {
+        let router = DeepLinkRouter()
+        let appVM = AppViewModel()
+        router.configure(
+            .init(
+                appVM: appVM,
+                openMainWindow: {},
+                openSettingsWindow: {},
+                oauthCallbackScheme: nil,
+                onOAuthCallback: { _ in }
+            )
+        )
+        return (router, appVM)
     }
 }

--- a/ArcBoxTests/KubernetesListViewControllerTests.swift
+++ b/ArcBoxTests/KubernetesListViewControllerTests.swift
@@ -8,6 +8,7 @@ final class KubernetesListViewControllerTests: XCTestCase {
     func testPodsStatesRetrySearchAndSelection() async throws {
         let state = KubernetesState(lifecycle: .ready)
         let viewModel = PodsViewModel()
+        viewModel.selectedID = "stale"
         var didRetry = false
         let controller = PodsListViewController(
             state: state,
@@ -20,6 +21,8 @@ final class KubernetesListViewControllerTests: XCTestCase {
         )
         let rootView = controller.view
         let tableView = try XCTUnwrap(findTableView(in: rootView))
+        XCTAssertEqual(viewModel.selectedID, "stale")
+        viewModel.selectedID = nil
 
         XCTAssertFalse(hasText("Loading pods…", in: rootView))
         let loadingPlaceholder = try XCTUnwrap(hostedStateView(in: rootView))
@@ -91,7 +94,8 @@ final class KubernetesListViewControllerTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedID, "alpha")
 
         viewModel.pods.removeAll { $0.id == "alpha" }
-        try await waitUntil { viewModel.selectedID == nil && tableView.selectedRow == -1 }
+        XCTAssertNil(viewModel.selectedID)
+        try await waitUntil { tableView.selectedRow == -1 }
     }
 
     @MainActor
@@ -138,6 +142,7 @@ final class KubernetesListViewControllerTests: XCTestCase {
             service(id: "api", name: "api"),
             service(id: "database", name: "database"),
         ]
+        viewModel.selectedID = "stale"
         viewModel.streamPhase = .live
         let controller = ServicesListViewController(
             state: readyState,
@@ -151,6 +156,8 @@ final class KubernetesListViewControllerTests: XCTestCase {
         let rootView = controller.view
         let tableView = try XCTUnwrap(findTableView(in: rootView))
 
+        XCTAssertEqual(viewModel.selectedID, "stale")
+        viewModel.selectedID = nil
         XCTAssertEqual(tableView.numberOfRows, 2)
         tableView.selectRowIndexes(IndexSet(integer: 1), byExtendingSelection: false)
         XCTAssertEqual(viewModel.selectedID, "database")
@@ -185,6 +192,12 @@ final class KubernetesListViewControllerTests: XCTestCase {
             tableView.numberOfRows == 0
                 && self.hasText("No Results", in: rootView)
         }
+
+        viewModel.searchText = ""
+        try await waitUntil { tableView.numberOfRows == 2 && tableView.selectedRow == 1 }
+        viewModel.services.removeAll { $0.id == "database" }
+        XCTAssertNil(viewModel.selectedID)
+        try await waitUntil { tableView.selectedRow == -1 }
     }
 
     @MainActor

--- a/ArcBoxTests/KubernetesStateTests.swift
+++ b/ArcBoxTests/KubernetesStateTests.swift
@@ -47,6 +47,24 @@ final class KubernetesStateTests: XCTestCase {
     }
 
     @MainActor
+    func testStreamSnapshotsTrackFreshnessUntilCleared() throws {
+        let pods = PodsViewModel()
+        let services = ServicesViewModel()
+        let requestedAt = ContinuousClock().now
+
+        pods.apply([])
+        services.apply([])
+
+        XCTAssertGreaterThanOrEqual(try XCTUnwrap(pods.lastStreamUpdate), requestedAt)
+        XCTAssertGreaterThanOrEqual(try XCTUnwrap(services.lastStreamUpdate), requestedAt)
+
+        pods.clear()
+        services.clear()
+        XCTAssertNil(pods.lastStreamUpdate)
+        XCTAssertNil(services.lastStreamUpdate)
+    }
+
+    @MainActor
     func testUnavailableClientAndStopFailureRemainVisible() async {
         let unavailableState = KubernetesState()
 


### PR DESCRIPTION
## Linear

- [ABXD-143](https://linear.app/arcbox/issue/ABXD-143)
- [ABXD-145](https://linear.app/arcbox/issue/ABXD-145)
- [ABXD-146](https://linear.app/arcbox/issue/ABXD-146)
- [ABXD-147](https://linear.app/arcbox/issue/ABXD-147)
- [ABXD-148](https://linear.app/arcbox/issue/ABXD-148)
- [ABXD-150](https://linear.app/arcbox/issue/ABXD-150)

## Root causes and user impact

- **ABXD-143:** Activity groups relied on implicit disclosure state, so filtering could leave matching children hidden. Filtering now temporarily expands matching groups and clearing the query restores each prior collapsed/expanded state.
- **ABXD-145:** Pods and Services wrote selection back into observable models while their AppKit representables were rendering; terminal creation had the same synchronous mutation shape. Selection reconciliation now happens at the data-update boundary and terminal connection is deferred out of the view update. The negative-geometry messages were reproduced only when selective window capture refreshed: strict AppKit geometry enforcement traced them to `NSThemeFrame._positionSharingIndicator` / `NSWindowSharingSessionRecipientIndicator`, with no ArcBox layout frame. A clean production launch and ordinary navigation emitted none, so this avoids a speculative app-layout workaround.
- **ABXD-146:** The router could directly select only coordinator-owned Docker resources, and cached `.loaded` lists were treated as fresh. Resource-ID requests now survive navigation, trigger an authoritative post-request list/stream refresh, select all supported resource sections (including loading Container details), and show a visible not-found/unsupported error.
- **ABXD-147:** Machine and Sandbox terminals did not consume the shared terminal theme. All terminal surfaces now use the same live System/Light/Dark preference.
- **ABXD-148:** Login-item, Time Machine, Docker-context, diagnostic-export, and external-terminal failures were swallowed or persisted optimistic state. Operations now commit preferences only after success, preserve actionable stderr/system errors with retry or Settings guidance, serialize context transitions through shutdown, and propagate file/launch/Automation failures to the UI.
- **ABXD-150:** Command fields used whitespace splitting, corrupting quoted and escaped argv. Container command/entrypoint and Sandbox command now share one argv parser: whitespace separates arguments, quotes preserve spaces/empty arguments, backslash escapes outside single quotes, and no shell expansion occurs. The contract is shown beside both Command fields.

## Verification

- `make format`
- `make lint` — 285 files, 0 violations
- `make test XCODEBUILD_EXTRA='-only-testing:ArcBoxTests/ActivityRowGroupingTests -only-testing:ArcBoxTests/KubernetesListViewControllerTests -only-testing:ArcBoxTests/KubernetesStateTests -only-testing:ArcBoxTests/DeepLinkTests -only-testing:ArcBoxTests/ArgumentListTests'` — 35 passed
- `make test` — 319 passed (235 XCTest + 84 Swift Testing)
- Runtime warning attribution on macOS 26.4: clean launch/idle emitted 0 negative-geometry messages; selective window-capture refresh reproduced the AppKit titlebar sharing-indicator stack.
