### PR TITLE
fix(sandboxes): reconcile authoritative port mappings (ABXD-152)

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 		E7E796A682B8956706429D45 /* ContainerListCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52CF09CC08AE563196CE3BED /* ContainerListCells.swift */; };
 		E92C8245EE6AE51D99035E4D /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = B23ADDA7527EDFFFD6615B12 /* SwiftTerm */; };
 		E9B0A374B532221710729A34 /* ContainerTerminalTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1AFAED2CB7429B714C8A06 /* ContainerTerminalTab.swift */; };
+		EC2532F756D371A159AB9A97 /* SandboxPortsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C7AE7CC8DF4C7910C4230B /* SandboxPortsViewModelTests.swift */; };
 		ECA0B439D329FA52C529ABE8 /* ActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3D2AE66CD9DD4A18CADB71 /* ActivityView.swift */; };
 		ED3023CCFF235C0CF302C812 /* MenuBarView+Containers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15C37C29F16DD4E28B30271 /* MenuBarView+Containers.swift */; };
 		ED5B6539D3909308DA1C4AE4 /* TerminalSessionBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312B3A0CBD47EB616127BBE5 /* TerminalSessionBridge.swift */; };
@@ -420,6 +421,7 @@
 		93968609F8E058EAC838DD18 /* UpdaterSettingsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterSettingsModel.swift; sourceTree = "<group>"; };
 		9467D1D1EA60DDF80414B20B /* ContainerListModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerListModels.swift; sourceTree = "<group>"; };
 		95F313C9C7AA84A964728D44 /* AppDelegate+Telemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Telemetry.swift"; sourceTree = "<group>"; };
+		96C7AE7CC8DF4C7910C4230B /* SandboxPortsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxPortsViewModelTests.swift; sourceTree = "<group>"; };
 		9750454C23940C3F74E7690E /* ResourceListRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceListRowView.swift; sourceTree = "<group>"; };
 		97E7E52D3A54846906EB064D /* SortMenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortMenuButton.swift; sourceTree = "<group>"; };
 		98C5CFE4B4D21711F8580690 /* SandboxTerminalTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxTerminalTab.swift; sourceTree = "<group>"; };
@@ -1150,6 +1152,7 @@
 				FA27F4AC273B14038EDB6593 /* NetworksListViewControllerTests.swift */,
 				A517313E1085B62A40075622 /* OnboardingWindowControllerTests.swift */,
 				B084B3E5BD66E2DA018764E8 /* QuitWindowControllerTests.swift */,
+				96C7AE7CC8DF4C7910C4230B /* SandboxPortsViewModelTests.swift */,
 				EBD1F83B573C40DFA09E5633 /* StatePlaceholderTestSupport.swift */,
 				B4BAE047B96D10B4716BA1A2 /* VolumesListViewControllerTests.swift */,
 			);
@@ -1574,6 +1577,7 @@
 				98E7A55FC92F874A28D762FD /* PKCETests.swift in Sources */,
 				D4ECBBCAC3D4631041F292D5 /* QuitWindowControllerTests.swift in Sources */,
 				1CB8AE8C16D0C333B7C0B32F /* ResourceStatsTests.swift in Sources */,
+				EC2532F756D371A159AB9A97 /* SandboxPortsViewModelTests.swift in Sources */,
 				927458F82097ECF1A07412FD /* StatePlaceholderTestSupport.swift in Sources */,
 				17ED6FFFD9A61998178E38B9 /* VolumesListViewControllerTests.swift in Sources */,
 			);

--- a/ArcBox/Models/SandboxModel.swift
+++ b/ArcBox/Models/SandboxModel.swift
@@ -210,15 +210,10 @@ struct SandboxSnapshotViewModel: Identifiable, Hashable {
     }
 }
 
-/// A port mapping exposed via ExposePort during this app session.
-///
-/// sandbox.v1 has no RPC to query existing mappings, so the Ports tab can only
-/// track exposures made from this app; mappings created elsewhere (CLI/SDK)
-/// are not listed.
+/// A host listener currently owned by a sandbox.
 struct SandboxExposedPort: Identifiable, Hashable {
     let sandboxPort: UInt32
     let hostPort: UInt32
-    let guestPort: UInt32
     let networkProtocol: String
 
     var id: String { "\(networkProtocol):\(sandboxPort)" }

--- a/ArcBox/ViewModels/Sandboxes/SandboxesViewModel+PortsFiles.swift
+++ b/ArcBox/ViewModels/Sandboxes/SandboxesViewModel+PortsFiles.swift
@@ -6,11 +6,87 @@ import OSLog
 extension SandboxesViewModel {
     // MARK: - Port Exposure
 
+    /// Load the daemon's authoritative host listeners for one sandbox.
+    func loadExposedPorts(for sandboxID: String, client: ArcBoxClient?) async {
+        guard !Task.isCancelled else { return }
+        guard let client else {
+            prepareExposedPortsLoad(for: sandboxID)
+            exposedPortsLoadState = .waiting
+            exposedPortsRefreshError = nil
+            return
+        }
+
+        let metadata = SandboxMetadata.forMachine(activeMachineID)
+        await loadExposedPorts(for: sandboxID) {
+            var request = Arcbox_Sandbox_V1_ListExposedPortsRequest()
+            request.id = sandboxID
+            let response = try await client.sandboxes.listExposedPorts(
+                request,
+                metadata: metadata,
+                options: ArcBoxClient.defaultCallOptions
+            )
+            return response.ports.map { port in
+                SandboxExposedPort(
+                    sandboxPort: port.sandboxPort,
+                    hostPort: port.hostPort,
+                    networkProtocol: port.protocol == .udp ? "udp" : "tcp"
+                )
+            }
+        }
+    }
+
+    /// Closure-based load seam for deterministic reconciliation tests.
+    func loadExposedPorts(
+        for sandboxID: String,
+        fetch: @MainActor () async throws -> [SandboxExposedPort]
+    ) async {
+        guard !Task.isCancelled else { return }
+        prepareExposedPortsLoad(for: sandboxID)
+
+        let loadToken = UUID()
+        exposedPortsLoadToken = loadToken
+        let isRefresh = exposedPortsLoadState.beginLoading()
+        do {
+            let ports = try await fetch()
+            guard
+                exposedPortsLoadToken == loadToken,
+                exposedPortsSandboxID == sandboxID
+            else { return }
+            exposedPortsLoadToken = nil
+            exposedPorts[sandboxID] = ports
+            exposedPortsLoadState = .loaded
+            exposedPortsRefreshError = nil
+        } catch is CancellationError {
+            guard
+                exposedPortsLoadToken == loadToken,
+                exposedPortsSandboxID == sandboxID
+            else { return }
+            exposedPortsLoadToken = nil
+            exposedPortsLoadState = isRefresh ? .loaded : .waiting
+        } catch {
+            guard
+                exposedPortsLoadToken == loadToken,
+                exposedPortsSandboxID == sandboxID
+            else { return }
+            exposedPortsLoadToken = nil
+            if exposedPortsLoadState.cancelLoading(
+                for: error,
+                retainingLoadedContent: isRefresh
+            ) {
+                return
+            }
+            let message = reportError(error, operation: "list_exposed_ports", surface: false)
+            exposedPortsRefreshError = exposedPortsLoadState.fail(
+                message,
+                retainingLoadedContent: isRefresh
+            )
+        }
+    }
+
     /// Expose a sandbox port on the host. Returns the mapping on success.
     ///
-    /// The daemon binds the host listener on loopback; the API has no RPC
-    /// to enumerate mappings, so the result is also recorded in
-    /// `exposedPorts` for session-local display.
+    /// The daemon binds the host listener on loopback. The result is reflected
+    /// immediately, then reconciled against the daemon's full snapshot.
     @discardableResult
     func exposePort(
         sandboxID: String,
@@ -35,13 +111,12 @@ extension SandboxesViewModel {
             let mapping = SandboxExposedPort(
                 sandboxPort: sandboxPort,
                 hostPort: response.hostPort,
-                guestPort: response.guestPort,
                 networkProtocol: networkProtocol
             )
-            var ports = exposedPorts[sandboxID] ?? []
-            ports.removeAll { $0.id == mapping.id }
-            ports.append(mapping)
-            exposedPorts[sandboxID] = ports
+            recordExposedPort(mapping, for: sandboxID)
+            if exposedPortsSandboxID == sandboxID {
+                await loadExposedPorts(for: sandboxID, client: client)
+            }
             return mapping
         } catch is CancellationError {
             return nil
@@ -70,14 +145,53 @@ extension SandboxesViewModel {
                 metadata: metadata,
                 options: ArcBoxClient.defaultCallOptions
             )
-            exposedPorts[sandboxID]?.removeAll {
-                $0.sandboxPort == sandboxPort && $0.networkProtocol == networkProtocol
+            removeExposedPort(
+                sandboxPort: sandboxPort,
+                networkProtocol: networkProtocol,
+                from: sandboxID
+            )
+            if exposedPortsSandboxID == sandboxID {
+                await loadExposedPorts(for: sandboxID, client: client)
             }
         } catch is CancellationError {
             return
         } catch {
             reportError(error, operation: "unexpose_port")
         }
+    }
+
+    func recordExposedPort(_ mapping: SandboxExposedPort, for sandboxID: String) {
+        guard exposedPortsSandboxID == sandboxID else { return }
+        exposedPortsLoadToken = nil
+        var ports = exposedPorts[sandboxID] ?? []
+        ports.removeAll { $0.id == mapping.id }
+        ports.append(mapping)
+        exposedPorts[sandboxID] = ports
+        exposedPortsLoadState = .loaded
+        exposedPortsRefreshError = nil
+    }
+
+    func removeExposedPort(
+        sandboxPort: UInt32,
+        networkProtocol: String,
+        from sandboxID: String
+    ) {
+        guard exposedPortsSandboxID == sandboxID else { return }
+        exposedPortsLoadToken = nil
+        exposedPorts[sandboxID]?.removeAll {
+            $0.sandboxPort == sandboxPort && $0.networkProtocol == networkProtocol
+        }
+        exposedPortsLoadState = .loaded
+        exposedPortsRefreshError = nil
+    }
+
+    private func prepareExposedPortsLoad(for sandboxID: String) {
+        exposedPortsLoadToken = nil
+        guard exposedPortsSandboxID != sandboxID else { return }
+        exposedPorts[sandboxID] = nil
+        exposedPortsSandboxID = sandboxID
+        exposedPortsLoadState = .waiting
+        exposedPortsRefreshError = nil
     }
 
     // MARK: - File Transfer

--- a/ArcBox/ViewModels/Sandboxes/SandboxesViewModel.swift
+++ b/ArcBox/ViewModels/Sandboxes/SandboxesViewModel.swift
@@ -74,8 +74,16 @@ class SandboxesViewModel {
     /// change or a failed reload.
     var snapshotsSandboxID: String?
 
-    /// Ports exposed from this app session, keyed by sandbox ID.
+    /// Authoritative host listeners, keyed by sandbox ID.
     var exposedPorts: [String: [SandboxExposedPort]] = [:]
+
+    /// Loading state for mappings belonging to `exposedPortsSandboxID`.
+    var exposedPortsLoadState: LoadPhase = .waiting
+    var exposedPortsRefreshError: String?
+    var exposedPortsLoadToken: UUID?
+
+    /// The sandbox whose mappings are currently visible in the Ports tab.
+    var exposedPortsSandboxID: String?
 
     var sandboxCount: Int { sandboxes.count }
 
@@ -108,9 +116,14 @@ class SandboxesViewModel {
         snapshotsLoadToken != nil
     }
 
+    var isLoadingExposedPorts: Bool {
+        exposedPortsLoadToken != nil
+    }
+
     func selectSandbox(_ id: String) {
         if selectedID != id {
             snapshotsLoadToken = nil
+            exposedPortsLoadToken = nil
         }
         selectedID = id
     }
@@ -137,6 +150,12 @@ class SandboxesViewModel {
     func removeSandboxLocally(_ id: String) {
         sandboxes.removeAll { $0.id == id }
         exposedPorts[id] = nil
+        if exposedPortsSandboxID == id {
+            exposedPortsSandboxID = nil
+            exposedPortsLoadToken = nil
+            exposedPortsLoadState = .waiting
+            exposedPortsRefreshError = nil
+        }
         if selectedID == id {
             selectedID = nil
             snapshotsLoadToken = nil

--- a/ArcBox/Views/Sandboxes/Tabs/SandboxPortsTab.swift
+++ b/ArcBox/Views/Sandboxes/Tabs/SandboxPortsTab.swift
@@ -1,16 +1,12 @@
-import AppKit
 import ArcBoxClient
 import SwiftUI
 
 /// Ports tab: expose sandbox ports on the host (loopback) and remove mappings.
-///
-/// sandbox.v1 has no RPC to enumerate mappings, so the list shows only ports
-/// exposed from this app session; the daemon removes all mappings on
-/// Stop/Remove.
 struct SandboxPortsTab: View {
     let sandbox: SandboxViewModel
 
     @Environment(SandboxesViewModel.self) private var vm
+    @Environment(DaemonManager.self) private var daemonManager
     @Environment(\.arcboxClient) private var client
 
     @State private var sandboxPortText = ""
@@ -26,24 +22,27 @@ struct SandboxPortsTab: View {
         VStack(spacing: 0) {
             toolbar
             Divider()
-            scopeNotice
-            Divider()
             content
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(AppColors.background)
-    }
-
-    private var scopeNotice: some View {
-        Label(
-            "This list only tracks mappings created by ArcBox since launch. CLI, SDK, and earlier mappings aren’t shown; listeners bind to localhost.",
-            systemImage: "info.circle"
-        )
-        .font(.system(size: 11))
-        .foregroundStyle(AppColors.textMuted)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
+        .task(
+            id: PortLoadID(
+                sandboxID: sandbox.id,
+                client: client.map(ObjectIdentifier.init),
+                runtimeReady: runtimeReady
+            )
+        ) {
+            await vm.loadExposedPorts(
+                for: sandbox.id,
+                client: runtimeReady ? client : nil
+            )
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .sandboxChanged)) { _ in
+            guard runtimeReady, client != nil else { return }
+            refresh()
+        }
+        .errorToast(message: Bindable(vm).exposedPortsRefreshError)
     }
 
     private var toolbar: some View {
@@ -71,6 +70,15 @@ struct SandboxPortsTab: View {
 
             Button("Expose", action: expose)
                 .disabled(!canExpose)
+
+            Button(action: refresh) {
+                Label("Refresh port mappings", systemImage: "arrow.clockwise")
+                    .labelStyle(.iconOnly)
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.plain)
+            .disabled(!canRefresh)
+            .help("Refresh")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -78,16 +86,41 @@ struct SandboxPortsTab: View {
 
     @ViewBuilder
     private var content: some View {
+        if vm.exposedPortsSandboxID != sandbox.id {
+            loadingPlaceholder("Preparing port mappings…")
+        } else {
+            switch vm.exposedPortsLoadState {
+            case .waiting:
+                loadingPlaceholder("Waiting for ArcBox daemon…")
+            case .loading:
+                loadingPlaceholder("Loading port mappings…")
+            case .failed(let message):
+                ContentUnavailableView {
+                    Label("Couldn’t Load Port Mappings", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(message)
+                } actions: {
+                    Button("Retry", action: refresh)
+                        .disabled(!canRefresh)
+                }
+            case .loaded:
+                loadedContent
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var loadedContent: some View {
         if mappings.isEmpty {
             VStack(spacing: 10) {
                 Spacer()
                 Image(systemName: "network")
                     .font(.system(size: 24))
                     .foregroundStyle(AppColors.textMuted)
-                Text("No port mappings tracked since ArcBox launched.")
+                Text("No exposed ports.")
                     .font(.system(size: 13))
                     .foregroundStyle(AppColors.textSecondary)
-                Text("Expose a port above to add it to this list.")
+                Text("Expose one above, or use the CLI or SDK and refresh.")
                     .font(.system(size: 12))
                     .foregroundStyle(AppColors.textMuted)
                     .multilineTextAlignment(.center)
@@ -105,6 +138,19 @@ struct SandboxPortsTab: View {
                 }
             }
         }
+    }
+
+    private func loadingPlaceholder(_ message: String) -> some View {
+        VStack(spacing: 12) {
+            Spacer()
+            ProgressView()
+                .controlSize(.small)
+            Text(message)
+                .font(.system(size: 13))
+                .foregroundStyle(AppColors.textSecondary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private func mappingRow(_ mapping: SandboxExposedPort) -> some View {
@@ -125,10 +171,6 @@ struct SandboxPortsTab: View {
                     .font(.system(size: 12, design: .monospaced))
             }
 
-            Text("via guest \(mapping.guestPort)")
-                .font(.system(size: 11))
-                .foregroundStyle(AppColors.textMuted)
-
             Spacer()
 
             Button {
@@ -138,6 +180,7 @@ struct SandboxPortsTab: View {
                     .foregroundStyle(AppColors.textSecondary)
             }
             .buttonStyle(.plain)
+            .disabled(!actionsAvailable)
             .help("Remove mapping")
         }
         .padding(.horizontal, 12)
@@ -145,12 +188,29 @@ struct SandboxPortsTab: View {
     }
 
     private var canExpose: Bool {
-        guard !isWorking, client != nil else { return false }
+        guard actionsAvailable else { return false }
         guard let port = UInt32(sandboxPortText), port > 0, port < 65536 else { return false }
         if !hostPortText.isEmpty {
             guard let host = UInt32(hostPortText), host > 0, host < 65536 else { return false }
         }
         return true
+    }
+
+    private var actionsAvailable: Bool {
+        runtimeReady
+            && client != nil
+            && vm.exposedPortsSandboxID == sandbox.id
+            && vm.exposedPortsLoadState == .loaded
+            && !vm.isLoadingExposedPorts
+            && !isWorking
+    }
+
+    private var canRefresh: Bool {
+        runtimeReady && client != nil && !vm.isLoadingExposedPorts && !isWorking
+    }
+
+    private var runtimeReady: Bool {
+        daemonManager.state.isRunning && daemonManager.setupPhase.isDockerReady
     }
 
     private func expose() {
@@ -181,4 +241,23 @@ struct SandboxPortsTab: View {
             isWorking = false
         }
     }
+
+    private func refresh() {
+        let sandboxID = sandbox.id
+        Task {
+            guard
+                !Task.isCancelled,
+                vm.selectedID == sandboxID,
+                runtimeReady,
+                client != nil
+            else { return }
+            await vm.loadExposedPorts(for: sandboxID, client: client)
+        }
+    }
+}
+
+private struct PortLoadID: Equatable {
+    let sandboxID: String
+    let client: ObjectIdentifier?
+    let runtimeReady: Bool
 }

--- a/ArcBoxTests/SandboxPortsViewModelTests.swift
+++ b/ArcBoxTests/SandboxPortsViewModelTests.swift
@@ -1,0 +1,176 @@
+import ArcBoxClient
+import GRPCCore
+import XCTest
+
+@testable import ArcBox
+
+@MainActor
+final class SandboxPortsViewModelTests: XCTestCase {
+    func testSnapshotReplacesMappingsAndEmptySnapshotClearsThem() async {
+        let vm = SandboxesViewModel()
+        let old = port(sandbox: 80, host: 8080)
+        let replacement = port(sandbox: 443, host: 8443)
+        vm.exposedPortsSandboxID = "sandbox"
+        vm.exposedPortsLoadState = .loaded
+        vm.exposedPorts["sandbox"] = [old]
+
+        await vm.loadExposedPorts(for: "sandbox") { [replacement] }
+
+        XCTAssertEqual(vm.exposedPorts["sandbox"], [replacement])
+        XCTAssertEqual(vm.exposedPortsLoadState, .loaded)
+
+        await vm.loadExposedPorts(for: "sandbox") { [] }
+
+        XCTAssertEqual(vm.exposedPorts["sandbox"], [])
+        XCTAssertEqual(vm.exposedPortsLoadState, .loaded)
+    }
+
+    func testStaleSandboxResponseCannotReplaceCurrentSandbox() async {
+        let vm = SandboxesViewModel()
+        let gate = PortFetchGate()
+        let oldTask = Task {
+            await vm.loadExposedPorts(for: "old") {
+                try await gate.fetch()
+            }
+        }
+        await gate.waitUntilStarted()
+
+        let current = port(sandbox: 443, host: 8443)
+        await vm.loadExposedPorts(for: "current") { [current] }
+        gate.succeed([port(sandbox: 80, host: 8080)])
+        await oldTask.value
+
+        let cancelledTask = Task {
+            await vm.loadExposedPorts(for: "cancelled") { [] }
+        }
+        cancelledTask.cancel()
+        await cancelledTask.value
+
+        XCTAssertEqual(vm.exposedPortsSandboxID, "current")
+        XCTAssertEqual(vm.exposedPorts["current"], [current])
+        XCTAssertNil(vm.exposedPorts["old"])
+        XCTAssertNil(vm.exposedPorts["cancelled"])
+        XCTAssertEqual(vm.exposedPortsLoadState, .loaded)
+    }
+
+    func testWaitsFailsAndRetriesInitialLoad() async {
+        let vm = SandboxesViewModel()
+
+        await vm.loadExposedPorts(for: "sandbox", client: nil)
+
+        XCTAssertEqual(vm.exposedPortsSandboxID, "sandbox")
+        XCTAssertEqual(vm.exposedPortsLoadState, .waiting)
+
+        let gate = PortFetchGate()
+        let failedTask = Task {
+            await vm.loadExposedPorts(for: "sandbox") {
+                try await gate.fetch()
+            }
+        }
+        await gate.waitUntilStarted()
+        XCTAssertEqual(vm.exposedPortsLoadState, .loading)
+        XCTAssertTrue(vm.isLoadingExposedPorts)
+
+        gate.fail(RPCError(code: .unavailable, message: "offline"))
+        await failedTask.value
+
+        XCTAssertEqual(
+            vm.exposedPortsLoadState,
+            .failed("Cannot reach ArcBox daemon. Is it running?")
+        )
+        XCTAssertNil(vm.exposedPortsRefreshError)
+        XCTAssertFalse(vm.isLoadingExposedPorts)
+
+        let mapping = port(sandbox: 80, host: 8080)
+        await vm.loadExposedPorts(for: "sandbox") { [mapping] }
+
+        XCTAssertEqual(vm.exposedPortsLoadState, .loaded)
+        XCTAssertEqual(vm.exposedPorts["sandbox"], [mapping])
+    }
+
+    func testRefreshFailurePreservesLoadedMappings() async {
+        let vm = SandboxesViewModel()
+        let mapping = port(sandbox: 80, host: 8080)
+        await vm.loadExposedPorts(for: "sandbox") { [mapping] }
+
+        await vm.loadExposedPorts(for: "sandbox") {
+            throw RPCError(code: .unavailable, message: "offline")
+        }
+
+        XCTAssertEqual(vm.exposedPortsLoadState, .loaded)
+        XCTAssertEqual(vm.exposedPorts["sandbox"], [mapping])
+        XCTAssertEqual(
+            vm.exposedPortsRefreshError,
+            "Cannot reach ArcBox daemon. Is it running?"
+        )
+        XCTAssertFalse(vm.isLoadingExposedPorts)
+    }
+
+    func testStaleRefreshCannotUndoLaterLocalRemoval() async {
+        let vm = SandboxesViewModel()
+        let mapping = port(sandbox: 80, host: 8080)
+        await vm.loadExposedPorts(for: "sandbox") { [mapping] }
+
+        let gate = PortFetchGate()
+        let refreshTask = Task {
+            await vm.loadExposedPorts(for: "sandbox") {
+                try await gate.fetch()
+            }
+        }
+        await gate.waitUntilStarted()
+
+        vm.removeExposedPort(
+            sandboxPort: mapping.sandboxPort,
+            networkProtocol: mapping.networkProtocol,
+            from: "sandbox"
+        )
+        gate.succeed([mapping])
+        await refreshTask.value
+
+        XCTAssertEqual(vm.exposedPorts["sandbox"], [])
+        XCTAssertEqual(vm.exposedPortsLoadState, .loaded)
+        XCTAssertFalse(vm.isLoadingExposedPorts)
+    }
+
+    private func port(
+        sandbox: UInt32,
+        host: UInt32,
+        networkProtocol: String = "tcp"
+    ) -> SandboxExposedPort {
+        SandboxExposedPort(
+            sandboxPort: sandbox,
+            hostPort: host,
+            networkProtocol: networkProtocol
+        )
+    }
+}
+
+@MainActor
+private final class PortFetchGate {
+    private(set) var started = false
+    private var result: Result<[SandboxExposedPort], Error>?
+
+    func fetch() async throws -> [SandboxExposedPort] {
+        started = true
+        while true {
+            if let result {
+                return try result.get()
+            }
+            await Task.yield()
+        }
+    }
+
+    func waitUntilStarted() async {
+        while !started {
+            await Task.yield()
+        }
+    }
+
+    func succeed(_ ports: [SandboxExposedPort]) {
+        result = .success(ports)
+    }
+
+    func fail(_ error: Error) {
+        result = .failure(error)
+    }
+}


### PR DESCRIPTION
## Root cause

ABXD-152: the Ports tab treated mappings created during the current Desktop session as its source of truth. Core v0.6.3 had no read RPC, so CLI, SDK, and pre-launch mappings were invisible, while stale UI-only rows could remain after daemon-side changes.

## User impact

- Replaces the displayed list with the daemon's authoritative `ListExposedPorts` snapshot, including an empty snapshot that clears stale rows.
- Reconciles on initial load and successful daemon reconnect, with an explicit Refresh action for CLI/SDK changes.
- Keeps local expose/unexpose feedback responsive, then refetches authoritative state without duplicate rows.
- Preserves loaded data on refresh failure and exposes accurate waiting, loading, failure, retry, and empty states.
- Removes the non-authoritative guest-port decoration.

## Verification

- `devenv shell -- make format`
- `devenv shell -- make lint` — 0 violations
- `devenv shell -- make verify-arcbox-protobuf` — passed against final Core #585 HEAD `fb4222f3a6aad5250b706e9854bbcaa88a51575b`
- Targeted `SandboxPortsViewModelTests` — 5 passed
- `devenv shell -- make test` — 318 passed, 0 failures

The repository's PR Check workflow only runs for pull requests based on `master`, so GitHub Actions does not create a run while this PR retains its required stacked base. It will become applicable after an authorized retarget; the current external Greptile check passed.

The matching code-bearing Core revision built the CLI, helper, daemon, and Linux guest agents; the daemon was Developer ID signed with the required entitlements. Core #585 changed only documentation between that build and the final pinned HEAD.

Final DMG runtime proof is currently blocked by ABXD-153, a separately owned pre-existing packaging workflow defect unrelated to this diff: `dmg-signed` invokes xtask inside devenv, xtask's direct `xcodebuild` inherits `LD=ld`, and the Release manifest consequently sends clang-driver `-Xlinker` arguments to raw `ld`. The same successful Debug gate uses `clang`. Raw `ld` reproduces `ld: unknown options: -Xlinker`; no Release app or DMG was produced. This PR does not add an environment-specific workaround.

## Dependencies / blocker

This is a stacked Draft based on #370. Two blockers remain:

1. [Core #585](https://github.com/arcboxlabs/arcbox/pull/585) must merge and publish a real `vX.Y.Z` release tag. The immutable Core commit is a reproducible development pin only.
2. ABXD-153 must restore signed end-to-end packaging proof for the matching app and daemon.

Before this PR can become Ready, Desktop must rerun `make bump-arcbox VERSION=vX.Y.Z`, `make verify-arcbox-protobuf`, and final signed runtime verification after both blockers clear. Do not merge or retarget this PR before that authorization.

Generated `agent.pb.swift` also contains reproducible CORE-21 resume-contract output from the same whole-Core revision; it is required by the documented generator/verification workflow and was not hand-edited.
