### PR TITLE
fix(build): isolate signed packaging Xcode environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,6 @@
 #   make dmg-release ARCBOX_DIR=arcbox-core SIGN_IDENTITY="..." NOTARIZE=1
 
 ARCBOX_DIR ?= $(shell cd ../arcbox 2>/dev/null && pwd)
-ifneq ($(strip $(ARCBOX_DIR)),)
-override ARCBOX_DIR := $(abspath $(ARCBOX_DIR))
-endif
 ARCBOX_VERSION := $(strip $(shell /bin/cat arcbox.version))
 SIGN_IDENTITY ?= $(shell security find-identity -v -p codesigning 2>/dev/null \
 	| grep -o '"Developer ID Application: ArcBox, Inc\.[^"]*"' \
@@ -91,6 +88,8 @@ help:
 # specific Xcode, pass XCODE_DEVELOPER_DIR=... (a separate name, so the
 # poisoned DEVELOPER_DIR cannot leak in through it).
 XCODE_DEVELOPER_DIR ?=
+XCODE_SIGN_IDENTITY ?=
+CURRENT_PROJECT_VERSION ?=
 CARGO_BIN_DIR ?= $(dir $(shell command -v cargo 2>/dev/null))
 NODE_BIN_DIR ?= $(dir $(shell command -v node 2>/dev/null))
 SYSTEM_DEVELOPER_DIR = $(shell /usr/bin/env -i PATH=/usr/bin:/bin /usr/bin/xcode-select -p)
@@ -146,7 +145,8 @@ XCODEBUILD_FLAGS = \
 	-skipPackagePluginValidation \
 	-skipMacroValidation \
 	$(XCODEBUILD_EXTRA) \
-	$(if $(filter 1,$(XCODE_AD_HOC_SIGN)),CODE_SIGN_IDENTITY=-) \
+	$(if $(CURRENT_PROJECT_VERSION),CURRENT_PROJECT_VERSION=$(CURRENT_PROJECT_VERSION)) \
+	$(if $(XCODE_SIGN_IDENTITY),CODE_SIGN_IDENTITY='$(XCODE_SIGN_IDENTITY)' CODE_SIGN_STYLE=Manual,$(if $(filter 1,$(XCODE_AD_HOC_SIGN)),CODE_SIGN_IDENTITY=-)) \
 	SKIP_RUST_BUILD=$(SKIP_RUST_BUILD) \
 	ARCBOX_STAGE_RESOURCES=$(ARCBOX_STAGE_RESOURCES) \
 	ARCBOX_CARGO_BIN_DIR='$(CARGO_BIN_DIR)' \

--- a/xtask/src/commands/macos/dmg.rs
+++ b/xtask/src/commands/macos/dmg.rs
@@ -25,7 +25,6 @@ use crate::{MacosDmgArgs, MacosPrepareResourcesArgs, MacosStageResourcesArgs};
 #[cfg(test)]
 mod tests;
 
-const SCHEME_NAME: &str = "ArcBox";
 const PRODUCTION_DAEMON_NAME: &str = "com.arcboxlabs.desktop.daemon";
 const DOCKER_TOOLS: [&str; 4] = [
     "docker",
@@ -138,23 +137,12 @@ fn build_swift_app(
 ) -> Result<PathBuf> {
     println!("--- Building Swift app ---");
     let derived_data = desktop_repo.join(".build").join("DerivedData");
-    let spm_clones = desktop_repo.join(".build").join("SourcePackages");
-
-    let mut cmd = Command::new("xcodebuild");
-    cmd.arg("build")
-        .arg("-project")
-        .arg(desktop_repo.join("ArcBox.xcodeproj"))
-        .args(["-scheme", SCHEME_NAME, "-configuration", "Release"])
-        .arg("-showBuildTimingSummary")
-        .arg("-derivedDataPath")
-        .arg(&derived_data)
-        .arg("-clonedSourcePackagesDirPath")
-        .arg(&spm_clones)
-        .arg("-skipPackagePluginValidation")
-        // A release must ship the dependency versions that were reviewed. Without
-        // this, a stale Package.resolved re-resolves silently and the shipped
-        // binary links something nobody approved.
-        .arg("-onlyUsePackageVersionsFromResolvedFile")
+    let mut cmd = Command::new("make");
+    cmd.current_dir(desktop_repo)
+        .arg("build")
+        .arg("CONFIGURATION=Release")
+        .arg("DERIVED_DATA_PATH=.build/DerivedData")
+        .arg("XCODEBUILD_EXTRA=-showBuildTimingSummary")
         .arg("ARCHS=arm64")
         .arg(format!("ARCBOX_DIR={}", arcbox_dir.display()))
         .arg(format!("CURRENT_PROJECT_VERSION={build_number}"));
@@ -168,8 +156,7 @@ fn build_swift_app(
         .arg(format!("ARCBOX_PROFILE={}", profile.arcbox_profile()));
     }
     if !sign_identity.is_empty() {
-        cmd.arg(format!("CODE_SIGN_IDENTITY={sign_identity}"))
-            .arg("CODE_SIGN_STYLE=Manual");
+        cmd.arg(format!("XCODE_SIGN_IDENTITY={sign_identity}"));
     }
     // Packaging re-embeds host/guest binaries after the Swift build. Skipping
     // the Xcode embed phase avoids a second copy/sign pass (and any residual
@@ -182,9 +169,9 @@ fn build_swift_app(
         println!("  SKIP_RUST_BUILD=1 (packaging will embed binaries)");
     }
 
-    let status = cmd.status().context("running xcodebuild")?;
+    let status = cmd.status().context("running make build")?;
     if !status.success() {
-        bail!("xcodebuild failed");
+        bail!("make build failed");
     }
 
     let products = derived_data.join("Build").join("Products").join("Release");


### PR DESCRIPTION
## Summary

- route the signed packaging Swift build through the Makefile's allowlisted Xcode environment
- pass Release versioning and Developer ID signing settings explicitly
- keep DerivedData relative to the Desktop checkout so relative overrides and paths with spaces remain valid

## Verification

- `devenv shell -- make lint`
- `devenv shell -- make lint-xtask`
- `devenv shell -- make test`
- `devenv shell -- make test-xtask` — 12 passed
- `devenv shell -- make dmg-signed ...` with devenv's `LD=ld` — produced ArcBox 1.34.2
- `hdiutil verify` — valid
- verified the App and daemon inside the DMG with `codesign --deep --strict`
- verified Developer ID team `422ACSY6Y5` and virtualization, hypervisor, and VM networking entitlements

DMG SHA-256: `9ca8756a00be7fc8f8b512ac8a18a43c9b883c67351a420c21b7e336cd2042e9`

Linear: [ABXD-153](https://linear.app/arcbox/issue/ABXD-153)