### PR TITLE
refactor(client): stop linking Sentry from ArcBoxClient, cache the protoc plugin build

### DIFF
--- a/.github/workflows/bump-arcbox.yml
+++ b/.github/workflows/bump-arcbox.yml
@@ -89,6 +89,22 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-cargo-xtask-${{ hashFiles('xtask/Cargo.lock') }}-
             ${{ runner.os }}-${{ runner.arch }}-cargo-xtask-
 
+      # Same key construction as pr.yml's, so a bump reuses the plugin build
+      # master already saved instead of resolving and compiling them cold.
+      - name: Record build environment
+        id: build_environment
+        if: steps.check.outputs.needed == 'true'
+        run: |
+          XCODE_CACHE_KEY=$(xcodebuild -version | awk 'NR == 1 { version = $2 } NR == 2 { build = $3 } END { print version "-" build }')
+          echo "xcode_cache_key=$XCODE_CACHE_KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Restore protoc plugin cache
+        if: steps.check.outputs.needed == 'true'
+        uses: actions/cache/restore@v6
+        with:
+          path: .build/protoc-plugins/
+          key: ${{ runner.os }}-${{ runner.arch }}-protoc-plugins-${{ steps.build_environment.outputs.xcode_cache_key }}-${{ hashFiles('Packages/ArcBoxClient/Package.resolved', 'Packages/ArcBoxClient/Package.swift', 'Packages/ArcBoxClient/generate.sh') }}
+
       - name: Bump the pin and regenerate the client
         if: steps.check.outputs.needed == 'true'
         shell: bash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,6 +28,22 @@ jobs:
           targets: aarch64-unknown-linux-musl
           components: clippy, rustfmt
 
+      # Ahead of the caches below: both key on the toolchain, because Swift
+      # build products are not portable across Xcode versions.
+      - name: Record build environment
+        id: build_environment
+        run: |
+          XCODE_CACHE_KEY=$(xcodebuild -version | awk 'NR == 1 { version = $2 } NR == 2 { build = $3 } END { print version "-" build }')
+          echo "xcode_cache_key=$XCODE_CACHE_KEY" >> "$GITHUB_OUTPUT"
+          echo "=== Build environment ==="
+          echo "Runner architecture: $(uname -m)"
+          echo "CPU: $(sysctl -n machdep.cpu.brand_string)"
+          echo "Logical CPUs: $(sysctl -n hw.logicalcpu)"
+          echo "Memory: $(sysctl -n hw.memsize) bytes"
+          xcodebuild -version
+          swiftc --version
+          df -h "$GITHUB_WORKSPACE"
+
       - name: Restore desktop Rust tooling cache
         id: desktop_rust_cache
         uses: actions/cache/restore@v6
@@ -41,6 +57,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-cargo-xtask-${{ hashFiles('xtask/Cargo.lock') }}-
             ${{ runner.os }}-${{ runner.arch }}-cargo-xtask-
+
+      # generate.sh builds protoc-gen-swift and protoc-gen-grpc-swift from
+      # Packages/ArcBoxClient, so this scratch path holds their SwiftPM
+      # checkouts as well as the built plugins. Caching it keeps a step that
+      # only regenerates protobuf off the network. No restore-keys: a partial
+      # match would seed the generator with plugins built from a different
+      # resolution, and the generated code has to match the runtime the app
+      # compiles it against.
+      - name: Restore protoc plugin cache
+        id: protoc_plugin_cache
+        uses: actions/cache/restore@v6
+        with:
+          path: .build/protoc-plugins/
+          key: ${{ runner.os }}-${{ runner.arch }}-protoc-plugins-${{ steps.build_environment.outputs.xcode_cache_key }}-${{ hashFiles('Packages/ArcBoxClient/Package.resolved', 'Packages/ArcBoxClient/Package.swift', 'Packages/ArcBoxClient/generate.sh') }}
 
       - name: Verify protobuf generated code is up-to-date
         run: |
@@ -74,20 +104,6 @@ jobs:
           brew install xcodegen
           make generate-xcodeproj
           git diff --exit-code ArcBox.xcodeproj ArcBox/Info.plist project.yml
-
-      - name: Record build environment
-        id: build_environment
-        run: |
-          XCODE_CACHE_KEY=$(xcodebuild -version | awk 'NR == 1 { version = $2 } NR == 2 { build = $3 } END { print version "-" build }')
-          echo "xcode_cache_key=$XCODE_CACHE_KEY" >> "$GITHUB_OUTPUT"
-          echo "=== Build environment ==="
-          echo "Runner architecture: $(uname -m)"
-          echo "CPU: $(sysctl -n machdep.cpu.brand_string)"
-          echo "Logical CPUs: $(sysctl -n hw.logicalcpu)"
-          echo "Memory: $(sysctl -n hw.memsize) bytes"
-          xcodebuild -version
-          swiftc --version
-          df -h "$GITHUB_WORKSPACE"
 
       - name: Restore Swift package cache
         id: swift_packages_cache
@@ -144,6 +160,13 @@ jobs:
             DESTINATION='platform=macOS,arch=arm64' \
             ARCHS=arm64 \
             XCODEBUILD_EXTRA=-showBuildTimingSummary
+
+      - name: Save protoc plugin cache
+        if: github.event_name == 'push' && steps.protoc_plugin_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: .build/protoc-plugins/
+          key: ${{ steps.protoc_plugin_cache.outputs.cache-primary-key }}
 
       - name: Save desktop Rust tooling cache
         if: github.event_name == 'push' && steps.desktop_rust_cache.outputs.cache-hit != 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ The default tab's view renders during startup. Other tabs render lazily when the
 - Swift 6 strict concurrency (`SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, `SWIFT_APPROACHABLE_CONCURRENCY = YES`)
 - ViewModels use `@Observable`; environment injection via custom `EnvironmentKey`
 - Logging: use the `Log` enum (OSLog-based) in the app, `ClientLog` in Packages
+- Crash reporting: only the app links Sentry. Packages emit through `ClientDiagnostics` and the app installs the sink — a package that imports Sentry drags its ~500 MB of binary artifacts into protobuf regeneration
 - Prefer `async/await` over Combine; use `Task.detached` only for Sendable-isolated gRPC calls
 - No Combine, no third-party UI libraries; only external deps: Sparkle, SwiftTerm, Sentry, PostHog
 - Imports: Foundation/SwiftUI first, then local packages, then third-party; one blank line before body

--- a/ArcBox/App/AppDelegate+Telemetry.swift
+++ b/ArcBox/App/AppDelegate+Telemetry.swift
@@ -1,3 +1,4 @@
+import ArcBoxClient
 import Foundation
 import OSLog
 import PostHog
@@ -39,6 +40,11 @@ extension AppDelegate {
             scope.setTag(value: "app", key: "process_type")
             scope.setTag(value: version, key: "app_version")
         }
+
+        // ArcBoxClient emits breadcrumbs and errors into a sink it does not
+        // own; without this its diagnostics are dropped.
+        ClientDiagnostics.install(SentryDiagnosticsSink())
+
         Log.startup.info("Sentry initialized")
     }
 

--- a/ArcBox/ErrorReporting.swift
+++ b/ArcBox/ErrorReporting.swift
@@ -1,3 +1,4 @@
+import ArcBoxClient
 @preconcurrency import Sentry
 
 /// Centralized error capture with automatic classification and consistent tagging.
@@ -102,5 +103,42 @@ nonisolated enum ErrorReporting {
         }
 
         return .unknown
+    }
+}
+
+// MARK: - ArcBoxClient Bridge
+
+/// Sends ``ArcBoxClient``'s diagnostics to Sentry.
+///
+/// The client package emits breadcrumbs and errors but deliberately links no
+/// crash reporter — a gRPC client has no business owning one, and depending on
+/// Sentry there dragged its binary artifacts into every protobuf regeneration.
+/// ``AppDelegate/initSentry()`` installs this once Sentry is up.
+///
+/// `nonisolated` because the client calls it from wherever it happens to be —
+/// this target defaults to `MainActor` isolation.
+nonisolated struct SentryDiagnosticsSink: DiagnosticsSink {
+    func add(_ breadcrumb: DiagnosticBreadcrumb) {
+        let crumb = Breadcrumb(level: breadcrumb.level.sentryLevel, category: breadcrumb.category)
+        crumb.message = breadcrumb.message
+        SentrySDK.addBreadcrumb(crumb)
+    }
+
+    func capture(_ error: Error, tags: [String: String]) {
+        SentrySDK.capture(error: error) { scope in
+            for (key, value) in tags {
+                scope.setTag(value: value, key: key)
+            }
+        }
+    }
+}
+
+extension DiagnosticBreadcrumb.Level {
+    nonisolated fileprivate var sentryLevel: SentryLevel {
+        switch self {
+        case .info: .info
+        case .warning: .warning
+        case .error: .error
+        }
     }
 }

--- a/Packages/ArcBoxClient/Package.resolved
+++ b/Packages/ArcBoxClient/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "99272b730ab3dfb1e0e8393ff94f5dbe01a02c9b49ece246423bca30281abe06",
+  "originHash" : "62e028c377431475ff19d076a2528e40cf853a6f5f87ba852629153c180d6acc",
   "pins" : [
     {
       "identity" : "grpc-swift",
@@ -26,15 +26,6 @@
       "state" : {
         "revision" : "53e89e3a5d417307f70a721c7b83e564fefb1e1c",
         "version" : "1.3.1"
-      }
-    },
-    {
-      "identity" : "sentry-cocoa",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/getsentry/sentry-cocoa.git",
-      "state" : {
-        "revision" : "c63a66f1b5107eec3792249bb03e65015eeba905",
-        "version" : "9.7.0"
       }
     },
     {

--- a/Packages/ArcBoxClient/Package.swift
+++ b/Packages/ArcBoxClient/Package.swift
@@ -14,7 +14,6 @@ let package = Package(
         .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.2.0"),
         .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.35.0"),
-        .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.7.0"),
     ],
     targets: [
         .target(
@@ -23,7 +22,6 @@ let package = Package(
                 .product(name: "GRPCNIOTransportHTTP2TransportServices", package: "grpc-swift-nio-transport"),
                 .product(name: "GRPCProtobuf", package: "grpc-swift-protobuf"),
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
-                .product(name: "Sentry", package: "sentry-cocoa"),
             ]
         ),
         .testTarget(

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Watch.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/DaemonManager/DaemonManager+Watch.swift
@@ -1,6 +1,5 @@
 import Foundation
 import OSLog
-@preconcurrency import Sentry
 
 extension DaemonManager {
     // MARK: - gRPC Setup Status Stream
@@ -74,16 +73,12 @@ extension DaemonManager {
                 self?.reconnectCount += 1
                 let graceExceeded = failedAttemptsSinceLastMessage > 6
 
-                // Emit Sentry breadcrumb on stream reconnect for crash debugging.
-                SentrySDK.addBreadcrumb(
-                    {
-                        let b = Breadcrumb(
-                            level: graceExceeded ? .error : .warning,
-                            category: "grpc.stream")
-                        b.message =
-                            "reconnect #\(failedAttemptsSinceLastMessage)"
-                        return b
-                    }())
+                // Leave a breadcrumb on stream reconnect for crash debugging.
+                ClientDiagnostics.add(
+                    DiagnosticBreadcrumb(
+                        level: graceExceeded ? .error : .warning,
+                        category: "grpc.stream",
+                        message: "reconnect #\(failedAttemptsSinceLastMessage)"))
 
                 // A daemon that reported a fatal FAILED phase keeps its .error
                 // state and .failed phase across the stream drop — resetting to
@@ -140,11 +135,13 @@ extension DaemonManager {
         case .UNRECOGNIZED: setupPhase = .unknown
         }
 
-        // Emit a Sentry breadcrumb on phase transitions for crash debugging.
+        // Leave a breadcrumb on phase transitions for crash debugging.
         if setupPhase != oldPhase {
-            let crumb = Breadcrumb(level: .info, category: "daemon.phase")
-            crumb.message = "\(oldPhase) → \(setupPhase)"
-            SentrySDK.addBreadcrumb(crumb)
+            ClientDiagnostics.add(
+                DiagnosticBreadcrumb(
+                    level: .info,
+                    category: "daemon.phase",
+                    message: "\(oldPhase) → \(setupPhase)"))
         }
 
         // A FAILED phase means the daemon gave up. Surface its fatal cause —

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/Diagnostics.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/Diagnostics.swift
@@ -1,0 +1,55 @@
+import Synchronization
+
+/// A breadcrumb recording something the client observed, kept for whatever
+/// failure is diagnosed later.
+public struct DiagnosticBreadcrumb: Sendable {
+    public enum Level: Sendable {
+        case info
+        case warning
+        case error
+    }
+
+    public let level: Level
+    public let category: String
+    public let message: String
+
+    public init(level: Level, category: String, message: String) {
+        self.level = level
+        self.category = category
+        self.message = message
+    }
+}
+
+/// Where this package's diagnostics go.
+///
+/// ArcBoxClient reports what it sees but owns no crash reporter: the host app
+/// installs a sink over whatever backend it already runs, which is what keeps
+/// a gRPC client package from linking one. `ArcBox` implements this over
+/// Sentry; tests and any other consumer get the no-op default.
+public protocol DiagnosticsSink: Sendable {
+    func add(_ breadcrumb: DiagnosticBreadcrumb)
+    func capture(_ error: Error, tags: [String: String])
+}
+
+/// The client's diagnostics channel, sibling to ``ClientLog``.
+///
+/// Diagnostics emitted before ``install(_:)`` — or when the host installs
+/// nothing — are dropped.
+public enum ClientDiagnostics {
+    private static let sink = Mutex<(any DiagnosticsSink)?>(nil)
+
+    /// Route this package's diagnostics to `sink`. Call once during startup.
+    public static func install(_ sink: any DiagnosticsSink) {
+        Self.sink.withLock { $0 = sink }
+    }
+
+    // Read under the lock, deliver outside it: a sink is host code and may do
+    // real work, which is not something to hold a global lock across.
+    static func add(_ breadcrumb: DiagnosticBreadcrumb) {
+        sink.withLock { $0 }?.add(breadcrumb)
+    }
+
+    static func capture(_ error: Error, tags: [String: String]) {
+        sink.withLock { $0 }?.capture(error, tags: tags)
+    }
+}

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/StartupOrchestrator/StartupOrchestrator.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/StartupOrchestrator/StartupOrchestrator.swift
@@ -1,7 +1,6 @@
 import Foundation
 import OSLog
 import Observation
-@preconcurrency import Sentry
 
 // MARK: - Internal Errors
 
@@ -329,9 +328,7 @@ public final class StartupOrchestrator {
             ClientLog.startup.error(
                 "\(step.label, privacy: .public) failed after \(elapsedMs, privacy: .public)ms: \(message, privacy: .private)"
             )
-            SentrySDK.capture(error: error) { scope in
-                scope.setTag(value: step.label, key: "startup_step")
-            }
+            ClientDiagnostics.capture(error, tags: ["startup_step": step.label])
             stepStatuses[step] = .failed(message)
             phase = .failed(step: step, message: message)
             return false


### PR DESCRIPTION
Follow-up to #379. That PR's first CI run went red on this:

```
error: failed downloading '.../sentry-cocoa/releases/download/9.7.0/Sentry.xcframework.zip'
       which is required by binary target 'Sentry': badResponseStatusCode(500)
Error: generate.sh failed with status exit status: 1
```

A protobuf regeneration step, taken out by a crash-reporter download. Two independent causes, one commit each.

## `refactor(client): stop linking Sentry from ArcBoxClient`

`generate.sh` builds `protoc-gen-swift` and `protoc-gen-grpc-swift` from `Packages/ArcBoxClient`, and SwiftPM resolves **per package, not per product** — so producing two protoc plugins resolved ArcBoxClient's entire manifest, `sentry-cocoa` included, and pulled ~500 MB of xcframework binaries that codegen never touches.

Measured, not estimated:

| | packages resolved | binary artifacts |
|---|---|---|
| before | 23 | 5 Sentry xcframeworks (~500 MB) |
| a plugin-only probe package | 4 | none |
| after this PR | 22 | **none** |

The client used Sentry purely for observability — one `capture` and two `addBreadcrumb`, no logic — so it now emits into a `DiagnosticsSink` the host installs, and `ArcBox` provides one over the Sentry it already declares directly in `project.yml`. This is where the app had already drawn the line: `ErrorReporting`'s own comment says it duplicates client heuristics *"without pulling in the client package"*.

`SentryDiagnosticsSink` is explicitly `nonisolated` — the app target runs `SWIFT_DEFAULT_ACTOR_ISOLATION: MainActor` with `-Werror ActorIsolatedCall`, and the client calls the sink from wherever it happens to be.

## `ci: cache the protoc plugin build`

The plugins were rebuilt from scratch on every PR. Caching the scratch path keys on the toolchain as well as the manifests, because Swift build products don't survive an Xcode bump; `Record build environment` moves ahead of the caches so one step supplies that key to all of them. Deliberately **no `restore-keys`** — a partial match would seed the generator with plugins built from a different resolution, and generated code has to match the runtime it compiles against. A miss just costs what today costs.

`bump-arcbox.yml` restores the same key, so a release-time bump reuses what master already built.

## Verification

- `swift build` of ArcBoxClient: clean.
- `make build`: **BUILD SUCCEEDED** — this is the check that matters, since it's what proves the `nonisolated` bridge satisfies `-Werror ActorIsolatedCall`.
- `make lint`: 0 violations in 287 files.
- `make resolve`: no change to the app-level lockfile — Sentry is still resolved for the app via its own direct dependency, so nothing about crash reporting changes at runtime.
- `Packages/ArcBoxClient/Package.resolved` diff is exactly the dropped `sentry-cocoa` pin. **`swift-protobuf` stays at 1.35.1 and `grpc-swift-protobuf` at 1.3.1**, so the generator is byte-identical and `Generated/` is untouched — `verify-arcbox-protobuf` is the real proof of that and it runs on this PR.
- `actionlint` clean on both workflows.

No test added for the sink: asserting that an installed sink receives what you hand it would mirror the implementation line for line. The guarantee that actually matters is enforced by the compiler — `Package.swift` no longer has Sentry, so a package that imports it fails to build.

## Note

`AGENTS.md` gains one line under Code Style recording the constraint, next to the existing `Log`/`ClientLog` rule, so the dependency doesn't creep back.