### PR TITLE
docs(agents): describe the import order the formatter actually enforces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,4 +55,4 @@ The default tab's view renders during startup. Other tabs render lazily when the
 - Crash reporting: only the app links Sentry. Packages emit through `ClientDiagnostics` and the app installs the sink — a package that imports Sentry drags its ~500 MB of binary artifacts into protobuf regeneration
 - Prefer `async/await` over Combine; use `Task.detached` only for Sendable-isolated gRPC calls
 - No Combine, no third-party UI libraries; only external deps: Sparkle, SwiftTerm, Sentry, PostHog
-- Imports: Foundation/SwiftUI first, then local packages, then third-party; one blank line before body
+- Imports: one alphabetically sorted block, with `@testable` imports in a separate block below it; one blank line before the body. This is enforced by swift-format's `OrderedImports`, so `make format` is authoritative — do not hand-order imports


### PR DESCRIPTION
AGENTS.md asks for `Foundation`/`SwiftUI` first, then local packages, then third-party. No file in the repo is written that way: `.swift-format` has `OrderedImports` enabled, so every import lands in one alphabetical block. `ApplicationCoordinator.swift` opens with `AppKit, ArcBoxAuth, ArcBoxClient, DockerClient, Foundation, OSLog, Observation, Sparkle, SwiftUI`; test files put `@testable` imports in a second block below.

Found while reviewing #366, where an automated reviewer cited this line to flag correctly-formatted code. That is the cost of the stale rule: following the flag produces a diff that `make format` reverts on the next run.

No code changes — the formatter already enforces the real rule.