### PR TITLE
feat(notifications): notify when a container exits on its own

### DIFF
--- a/ArcBox.xcodeproj/project.pbxproj
+++ b/ArcBox.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		14F016496706C25F9CF50D75 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06688AB84392716F1108AE36 /* Logging.swift */; };
 		15FFC6590CB1CDFE38CFD3EA /* DockerEventMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DB22F8A7AA46286F186A73F /* DockerEventMonitor.swift */; };
 		172FA4919687A4616E0BC135 /* DaemonLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8FB9C9E3349126EF773522 /* DaemonLoadingView.swift */; };
+		17908606AF5BAB2C1CF57AE0 /* ContainerCrashDigest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7374C3209C972DE43E00DB60 /* ContainerCrashDigest.swift */; };
 		17ED6FFFD9A61998178E38B9 /* VolumesListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4BAE047B96D10B4716BA1A2 /* VolumesListViewControllerTests.swift */; };
 		1941A5EBBFB259911F7E9ADE /* SandboxesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A764F03F9EA5C3149B777338 /* SandboxesViewModel.swift */; };
 		1BC0DF2E6DAA6E0A94058B5F /* ContainerListModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9467D1D1EA60DDF80414B20B /* ContainerListModels.swift */; };
@@ -60,6 +61,7 @@
 		33DEED20119675484C189E77 /* LocalRootFSOutlineCoordinator+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F932C1467A5FB5CFBD0444 /* LocalRootFSOutlineCoordinator+DataSource.swift */; };
 		34ECB9725E062C6A0372AA0C /* EnvironmentValues+Clients.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794F192F207790B1A137A816 /* EnvironmentValues+Clients.swift */; };
 		351718A1033DD049AED78108 /* DaemonNotificationRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535894F6E4F12A71E906ED02 /* DaemonNotificationRulesTests.swift */; };
+		356E130785578DE1A09A7F56 /* ContainerCrashDigestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CE179496F58DB669A5A929 /* ContainerCrashDigestTests.swift */; };
 		361A7AD4626352A09571245C /* ContainerLogsTab+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200F15F29A3634EC779554D4 /* ContainerLogsTab+Actions.swift */; };
 		3B38458299F141A08B8C7107 /* ImageTerminalTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB477EF803A15EDFF2685A23 /* ImageTerminalTab.swift */; };
 		3B6BCFE408976AA0CDD0A5F8 /* SandboxesViewModel+PortsFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B80964B0A136E03F5FDA0FE /* SandboxesViewModel+PortsFiles.swift */; };
@@ -76,6 +78,7 @@
 		442FF72709337D1BCAA0643D /* SandboxEventMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C68609B67AC82FF386CB92 /* SandboxEventMonitor.swift */; };
 		44974322E172A05817F3D858 /* KubernetesListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83FBFE31C0C7B96918BFCC6 /* KubernetesListViewControllerTests.swift */; };
 		45029921A85B7F5C86F49E3B /* AboutView+ReleaseRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0100B138714BA1626E5E8D48 /* AboutView+ReleaseRow.swift */; };
+		45778022E8C486C6A3D5F374 /* ContainerNotificationRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D14D8CCDFD8775C585050EE /* ContainerNotificationRules.swift */; };
 		45BD43408706D6F5044BDEB2 /* VolumeTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEDB1A7E6E5F0EEA2214D21 /* VolumeTypes.swift */; };
 		466BD76F6F334FBAEA392BD5 /* HelperInstallErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF45523D23D3F96612423943 /* HelperInstallErrorTests.swift */; };
 		46717964B62163546276C1D1 /* AboutView+Sections.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC98017408ED56AFF734125A /* AboutView+Sections.swift */; };
@@ -154,6 +157,7 @@
 		868F62A98F4BD1023DD79167 /* FleetEnrollmentCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FD51B5947EFEEFD73D00F9 /* FleetEnrollmentCoordinatorTests.swift */; };
 		869B14DB25CD44955C7C32AE /* ContainersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23C69EC561EEA79ADE5A9000 /* ContainersViewModel.swift */; };
 		8939A06F20FE4F92A72E3372 /* ImageTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E17CF68FBBA9447E1B15371 /* ImageTypes.swift */; };
+		8AF453BEA1520C931470A491 /* ContainerNotificationRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A17EA6466F0BD7B28FF7EE /* ContainerNotificationRulesTests.swift */; };
 		8BBBA54130403D89D35986F7 /* ImageLayerChainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C964312D5336EE55A8E4680B /* ImageLayerChainTests.swift */; };
 		8BEEBFC0F4E258C46C1A347E /* AboutView+LinkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E06B22BB8B92AF78C2B87ADC /* AboutView+LinkButton.swift */; };
 		8C3C03A50C1B7D97829F9DA5 /* SandboxEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE7897EE0D976BB19ADC2C5 /* SandboxEmptyState.swift */; };
@@ -226,6 +230,7 @@
 		C19B191AF0DE9179608BF40A /* RunnersViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6ABF0A0B6218A3FE504C7DA /* RunnersViewState.swift */; };
 		C1CEE635A115E843DF66A65B /* FleetSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69E766A830CB3A26231BA11 /* FleetSettingsView.swift */; };
 		C38303D18080C9AED2BD8D20 /* FleetRunnerImageReadiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0656F14604E5C2380BFA93 /* FleetRunnerImageReadiness.swift */; };
+		C3EEEE180810C9D5C5A1CC39 /* ContainerCrashReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9773282E754B05EDF5527CAB /* ContainerCrashReporter.swift */; };
 		C8181916F2EBD889B0C8046B /* MachineTerminalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8632512053E9C750CAA97F9 /* MachineTerminalSession.swift */; };
 		C8C56406446AE0906E11100C /* InfoTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED1683EF0A3490B8B7B5CF6 /* InfoTableView.swift */; };
 		C94515858BC220B73B93EC5D /* ArcBoxClientErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC5F65FECB2F80BA3AF1D84 /* ArcBoxClientErrorTests.swift */; };
@@ -320,6 +325,7 @@
 		08A76C0B459745654F31B3B2 /* PodsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodsListView.swift; sourceTree = "<group>"; };
 		0B8670CF269C853BD2039B34 /* NetworkModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkModel.swift; sourceTree = "<group>"; };
 		0CE7897EE0D976BB19ADC2C5 /* SandboxEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxEmptyState.swift; sourceTree = "<group>"; };
+		0D14D8CCDFD8775C585050EE /* ContainerNotificationRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerNotificationRules.swift; sourceTree = "<group>"; };
 		0EDE93A683D2613C431BEBF2 /* DockerCLIResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockerCLIResolver.swift; sourceTree = "<group>"; };
 		0F065A1CBDA891A5647FE6F6 /* K8sWatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K8sWatchTests.swift; sourceTree = "<group>"; };
 		0FA3C6B6F10198DFC435A33E /* NetworkDetailViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDetailViewControllerTests.swift; sourceTree = "<group>"; };
@@ -420,6 +426,7 @@
 		6DFE1C88F20E40C1A36A384C /* CreateOperationErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateOperationErrorTests.swift; sourceTree = "<group>"; };
 		7058C8975F3F2684714E24E2 /* SleepWakeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepWakeManager.swift; sourceTree = "<group>"; };
 		725E693E00BCEB4D0ADE7A25 /* FleetControlClient */ = {isa = PBXFileReference; lastKnownFileType = folder; name = FleetControlClient; path = Packages/FleetControlClient; sourceTree = SOURCE_ROOT; };
+		7374C3209C972DE43E00DB60 /* ContainerCrashDigest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerCrashDigest.swift; sourceTree = "<group>"; };
 		738233A82C7BAA825F73EE2F /* GuestExportFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestExportFixture.swift; sourceTree = "<group>"; };
 		747AB46D7603C23FB9112444 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		7607A876F6C88A440DA53BE1 /* SidebarAccountButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarAccountButton.swift; sourceTree = "<group>"; };
@@ -466,6 +473,7 @@
 		95F313C9C7AA84A964728D44 /* AppDelegate+Telemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Telemetry.swift"; sourceTree = "<group>"; };
 		96C7AE7CC8DF4C7910C4230B /* SandboxPortsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxPortsViewModelTests.swift; sourceTree = "<group>"; };
 		9750454C23940C3F74E7690E /* ResourceListRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceListRowView.swift; sourceTree = "<group>"; };
+		9773282E754B05EDF5527CAB /* ContainerCrashReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerCrashReporter.swift; sourceTree = "<group>"; };
 		97E7E52D3A54846906EB064D /* SortMenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortMenuButton.swift; sourceTree = "<group>"; };
 		98123C19CE4AB275C8D899E2 /* AppNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNotification.swift; sourceTree = "<group>"; };
 		98C5CFE4B4D21711F8580690 /* SandboxTerminalTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxTerminalTab.swift; sourceTree = "<group>"; };
@@ -495,6 +503,7 @@
 		B050286A2450880AC2C95342 /* ActivityContainerTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityContainerTable.swift; sourceTree = "<group>"; };
 		B0841C2969EC1A1BC07489C8 /* SandboxTerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxTerminalSession.swift; sourceTree = "<group>"; };
 		B084B3E5BD66E2DA018764E8 /* QuitWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitWindowControllerTests.swift; sourceTree = "<group>"; };
+		B0A17EA6466F0BD7B28FF7EE /* ContainerNotificationRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerNotificationRulesTests.swift; sourceTree = "<group>"; };
 		B2387BC90EBBF4477B65367E /* RunnerJobsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerJobsView.swift; sourceTree = "<group>"; };
 		B2CC2B117E020C62C1E9952E /* ContainerLogsTab+Views.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContainerLogsTab+Views.swift"; sourceTree = "<group>"; };
 		B38661BA5859384BCCE61B0C /* PodDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodDetailView.swift; sourceTree = "<group>"; };
@@ -535,6 +544,7 @@
 		D02391823A10B16B12627E6C /* RunnerHostStatusBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerHostStatusBar.swift; sourceTree = "<group>"; };
 		D0A680191505746F5F6F5A0B /* SandboxTemplateModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxTemplateModelTests.swift; sourceTree = "<group>"; };
 		D12C2D038DE6CC49702F85F0 /* ContainersViewModel+Docker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContainersViewModel+Docker.swift"; sourceTree = "<group>"; };
+		D4CE179496F58DB669A5A929 /* ContainerCrashDigestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerCrashDigestTests.swift; sourceTree = "<group>"; };
 		D4ED3EC883A488801DE03195 /* NetworksViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworksViewModel.swift; sourceTree = "<group>"; };
 		D6F75C788ADEDBC9B1F007E3 /* QuitWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitWindowController.swift; sourceTree = "<group>"; };
 		DAE5A29026FA64A7C0A47122 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -1210,6 +1220,9 @@
 			isa = PBXGroup;
 			children = (
 				98123C19CE4AB275C8D899E2 /* AppNotification.swift */,
+				7374C3209C972DE43E00DB60 /* ContainerCrashDigest.swift */,
+				9773282E754B05EDF5527CAB /* ContainerCrashReporter.swift */,
+				0D14D8CCDFD8775C585050EE /* ContainerNotificationRules.swift */,
 				FEA9D33B25DF9BB204D4B637 /* DaemonNotificationRules.swift */,
 				3D649CF8EC65915ED940D02A /* NotificationCoordinator.swift */,
 				665F6200AEC097082B2C43CA /* SandboxNotificationRules.swift */,
@@ -1252,6 +1265,8 @@
 				1DC5F65FECB2F80BA3AF1D84 /* ArcBoxClientErrorTests.swift */,
 				3750055AEC4C49576A78A909 /* ByteFormattingTests.swift */,
 				A10ED4BA65D6B9CC56B6B329 /* ChangelogParserTests.swift */,
+				D4CE179496F58DB669A5A929 /* ContainerCrashDigestTests.swift */,
+				B0A17EA6466F0BD7B28FF7EE /* ContainerNotificationRulesTests.swift */,
 				80010452354615CAC08FAF1D /* ContainersListViewControllerTests.swift */,
 				E610512C9106BB92A47DC044 /* ContainersViewModelTests.swift */,
 				DE7E377F9D8C89E24989DE3D /* ContentViewColumnLayoutTests.swift */,
@@ -1500,6 +1515,8 @@
 				50CCDEFCA186BCD1E99D291F /* ChangelogParser.swift in Sources */,
 				0A2CD753BB4FE0991213273A /* CommandEmptyStateView.swift in Sources */,
 				7DABE0FBDD17F88D47333964 /* CommandHint.swift in Sources */,
+				17908606AF5BAB2C1CF57AE0 /* ContainerCrashDigest.swift in Sources */,
+				C3EEEE180810C9D5C5A1CC39 /* ContainerCrashReporter.swift in Sources */,
 				7910184754585B4CF647FA92 /* ContainerDetailView.swift in Sources */,
 				967B79B7F3A20ACDDC610AD4 /* ContainerFilesTab.swift in Sources */,
 				766ECB0DA60ABA79FE21CE2C /* ContainerInfoTab.swift in Sources */,
@@ -1511,6 +1528,7 @@
 				012B6BCE79F6FAE406EE97A0 /* ContainerLogsTab+Views.swift in Sources */,
 				48014023336A8AD5D1B21A27 /* ContainerLogsTab.swift in Sources */,
 				8E9980682D9BB81A4CB35673 /* ContainerModel.swift in Sources */,
+				45778022E8C486C6A3D5F374 /* ContainerNotificationRules.swift in Sources */,
 				E9B0A374B532221710729A34 /* ContainerTerminalTab.swift in Sources */,
 				BF22080E6092E730A9DD1424 /* ContainerTypes.swift in Sources */,
 				FBE7E964F895EFE9C7818256 /* ContainerViewModel+Mapping.swift in Sources */,
@@ -1703,6 +1721,8 @@
 				AF8784321B0BF66F476749C5 /* BetterAuthClientTests.swift in Sources */,
 				70996419B03971A57B1DCF0F /* ByteFormattingTests.swift in Sources */,
 				31474CB365691C57A5568D14 /* ChangelogParserTests.swift in Sources */,
+				356E130785578DE1A09A7F56 /* ContainerCrashDigestTests.swift in Sources */,
+				8AF453BEA1520C931470A491 /* ContainerNotificationRulesTests.swift in Sources */,
 				DB19F0073D84ED7A7C937D49 /* ContainersListViewControllerTests.swift in Sources */,
 				4D2029E55A7979B8BD9EE89A /* ContainersViewModelTests.swift in Sources */,
 				A537498E1D8181BB0230E199 /* ContentViewColumnLayoutTests.swift in Sources */,

--- a/ArcBox/App/AppPreferences.swift
+++ b/ArcBox/App/AppPreferences.swift
@@ -37,9 +37,15 @@ enum AppPreferences {
             "includeTimeMachine": false,
             "switchDockerContextAutomatically": true,
             "pauseContainersWhileSleeping": true,
-            AppNotification.Category.sandbox.preferenceKey: true,
-            AppNotification.Category.daemonHealth.preferenceKey: true,
         ])
+
+        // Delivery is gated by `bool(forKey:)`, which reads an unregistered key
+        // as false. Registering from `allCases` is what stops a new category
+        // from silently shipping switched off.
+        userDefaults.register(
+            defaults: Dictionary(
+                uniqueKeysWithValues: AppNotification.Category.allCases.map { ($0.preferenceKey, true) }
+            ))
     }
 
     static func hasCompletedOnboarding(in userDefaults: UserDefaults = .standard) -> Bool {

--- a/ArcBox/App/ApplicationCoordinator.swift
+++ b/ArcBox/App/ApplicationCoordinator.swift
@@ -325,6 +325,9 @@ final class ApplicationCoordinator: NSObject {
         sandboxEventMonitor.onEvent = { [weak self] event in
             self?.notifications.handleSandboxEvent(event)
         }
+        eventMonitor.onEvent = { [weak self] event in
+            self?.notifications.handleDockerEvent(event)
+        }
         notifications.start()
     }
 
@@ -530,6 +533,7 @@ final class ApplicationCoordinator: NSObject {
             sandboxEventMonitor.stop()
             machineEventMonitor.stop()
             sleepWakeManager.stop()
+            notifications.runtimeStopped()
             updateDockerContext(useArcBox: false)
         }
     }

--- a/ArcBox/Services/DockerEventMonitor.swift
+++ b/ArcBox/Services/DockerEventMonitor.swift
@@ -21,6 +21,11 @@ extension Notification.Name {
 @Observable
 final class DockerEventMonitor {
 
+    /// Called for every event as it arrives, before whitelisting and debounce.
+    /// The posted notifications carry no payload, so consumers that need the
+    /// event itself — notifications — take it from here.
+    @ObservationIgnored var onEvent: ((DockerClient.DockerEvent) -> Void)?
+
     // MARK: Action Whitelists
 
     private static let containerActions: Set<String> = [
@@ -107,6 +112,11 @@ final class DockerEventMonitor {
 
     /// Visible to tests via @testable import.
     func handleEvent(_ event: DockerClient.DockerEvent) {
+        // Every event, before the whitelist below: that filter exists to
+        // decide which list to refresh, and notification rules need actions
+        // it has no reason to carry.
+        onEvent?(event)
+
         switch event.type {
         case "container":
             guard Self.containerActions.contains(event.action) else { return }

--- a/ArcBox/Services/Notifications/AppNotification.swift
+++ b/ArcBox/Services/Notifications/AppNotification.swift
@@ -22,6 +22,7 @@ struct AppNotification: Equatable {
 extension AppNotification {
     enum Category: String, CaseIterable {
         case sandbox
+        case container
         case daemonHealth
 
         /// Preference gating delivery. Registered in `AppPreferences`, so an
@@ -29,6 +30,7 @@ extension AppNotification {
         var preferenceKey: String {
             switch self {
             case .sandbox: "notifySandboxResults"
+            case .container: "notifyContainerCrashes"
             case .daemonHealth: "notifyDaemonProblems"
             }
         }

--- a/ArcBox/Services/Notifications/ContainerCrashDigest.swift
+++ b/ArcBox/Services/Notifications/ContainerCrashDigest.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Renders a batch of container deaths as one notification.
+enum ContainerCrashDigest {
+    /// Names listed in full before the body switches to a count.
+    private static let namesShown = 3
+
+    /// One rolling identifier: the latest digest is the current state of
+    /// things, and should replace whatever it superseded.
+    private static let identifier = "container.crashes"
+
+    static func notification(for crashes: [ContainerCrash]) -> AppNotification? {
+        // A container that died several times inside one window is one story.
+        var seen = Set<String>()
+        let unique = crashes.filter { seen.insert($0.containerID).inserted }
+
+        guard let first = unique.first else { return nil }
+
+        if unique.count == 1 {
+            return AppNotification(
+                identifier: identifier,
+                title: "Container exited",
+                body: "\(first.name) exited with code \(first.exitCode).",
+                destination: .section(.containers, id: first.containerID),
+                category: .container
+            )
+        }
+
+        let shown = unique.prefix(namesShown)
+        let names = shown.map(\.name).joined(separator: ", ")
+        let remainder = unique.count - shown.count
+        return AppNotification(
+            identifier: identifier,
+            title: "\(unique.count) containers exited",
+            body: remainder > 0 ? "\(names) and \(remainder) more." : "\(names).",
+            // No single container to select, so this lands on the list.
+            destination: .section(.containers, id: nil),
+            category: .container
+        )
+    }
+}

--- a/ArcBox/Services/Notifications/ContainerCrashReporter.swift
+++ b/ArcBox/Services/Notifications/ContainerCrashReporter.swift
@@ -1,0 +1,50 @@
+import DockerClient
+import Foundation
+
+/// Turns container deaths into at most one notification per batch window.
+///
+/// A failing `compose up` brings several containers down at once, and one
+/// banner per container is unusable. The first crash opens a window, every
+/// crash inside it joins the same digest, and the window always fires — a
+/// sliding window would let a crash loop defer the report forever.
+@MainActor
+final class ContainerCrashReporter {
+    static let batchWindow: Duration = .seconds(3)
+
+    private var rules = ContainerNotificationRules()
+    private var pending: [ContainerCrash] = []
+    private var flushTask: Task<Void, Never>?
+    private let post: (AppNotification) -> Void
+
+    init(post: @escaping (AppNotification) -> Void) {
+        self.post = post
+    }
+
+    func handle(_ event: DockerClient.DockerEvent) {
+        guard let crash = rules.crash(for: event) else { return }
+        pending.append(crash)
+
+        guard flushTask == nil else { return }
+        flushTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.batchWindow)
+            guard !Task.isCancelled else { return }
+            self?.flush()
+        }
+    }
+
+    /// Drop anything in flight. The daemon going away is already its own
+    /// notification; the containers it took with it are not news.
+    func stop() {
+        flushTask?.cancel()
+        flushTask = nil
+        pending = []
+    }
+
+    private func flush() {
+        let crashes = pending
+        pending = []
+        flushTask = nil
+        guard let notification = ContainerCrashDigest.notification(for: crashes) else { return }
+        post(notification)
+    }
+}

--- a/ArcBox/Services/Notifications/ContainerNotificationRules.swift
+++ b/ArcBox/Services/Notifications/ContainerNotificationRules.swift
@@ -1,0 +1,129 @@
+import DockerClient
+import Foundation
+
+/// A container that died on its own.
+struct ContainerCrash: Equatable {
+    let containerID: String
+    let name: String
+    let exitCode: Int
+}
+
+/// Decides which container deaths are worth interrupting the user for.
+///
+/// Exit codes alone cannot answer this: `docker stop` produces the same
+/// `die`/`exitCode=137` a killed container does. What separates them is that
+/// Docker announces an intentional exit first — the observed sequence for
+/// `docker stop` is `kill` (SIGTERM), `kill` (SIGKILL), `stop`, then `die`.
+struct ContainerNotificationRules {
+    /// How long the same container stays quiet after being announced. A
+    /// container under `restart: always` with a broken image dies every few
+    /// seconds forever; the first report is news and the rest are not.
+    static let repeatCooldown: TimeInterval = 300
+
+    /// How long a `kill` or `stop` explains a death.
+    ///
+    /// A container that traps SIGTERM and keeps running would otherwise leave
+    /// intent sitting there forever, silently swallowing the next genuine
+    /// crash. A signal that does end a container ends it within milliseconds,
+    /// and a long `docker stop -t N` is covered regardless because Docker emits
+    /// `stop` immediately before the `die` — so this window only has to be
+    /// longer than a kill takes, not longer than a grace period.
+    static let intentWindow: TimeInterval = 10
+
+    /// The signals that ask a container to end, as Linux numbers: the daemon
+    /// writes `strconv.Itoa(int(signal))` into the event regardless of the name
+    /// the caller used.
+    ///
+    /// `docker kill` delivers whatever it is given, and most of what people
+    /// send that way is addressed to a container expected to keep running —
+    /// SIGHUP to reload configuration, SIGUSR1 for something the application
+    /// defines. Those explain no death.
+    ///
+    /// An image's own `STOPSIGNAL` is deliberately absent (httpd's is SIGWINCH)
+    /// and does not need to be here: `docker stop` announces `stop` before the
+    /// `die` whichever signal it sent.
+    private static let terminationSignals: Set<Int> = [
+        2,  // SIGINT
+        3,  // SIGQUIT
+        9,  // SIGKILL
+        15,  // SIGTERM
+    ]
+
+    /// Containers whose imminent exit the user asked for, and when they asked.
+    private var intentionalExits: [String: Date] = [:]
+    /// When each container was last announced, to apply `repeatCooldown`.
+    private var lastAnnounced: [String: Date] = [:]
+
+    mutating func crash(for event: DockerClient.DockerEvent) -> ContainerCrash? {
+        guard event.type == "container", let id = event.actorID else { return nil }
+
+        switch event.action {
+        case "kill":
+            if asksToTerminate(event) {
+                intentionalExits[id] = event.date
+            }
+            return nil
+
+        case "stop":
+            intentionalExits[id] = event.date
+            return nil
+
+        case "die":
+            return death(of: id, event: event)
+
+        case "start":
+            // A restart is a fresh life: whatever was asked of the previous
+            // one no longer explains the next exit.
+            intentionalExits.removeValue(forKey: id)
+            return nil
+
+        case "destroy":
+            intentionalExits.removeValue(forKey: id)
+            lastAnnounced.removeValue(forKey: id)
+            return nil
+
+        // Everything else, including `exec_die` — health check probes emit
+        // that with a non-zero exit code every few seconds on a container
+        // whose probe is failing, and it says nothing about the container
+        // itself.
+        default:
+            return nil
+        }
+    }
+
+    // MARK: - Private
+
+    /// Whether a `kill` asked the container to end.
+    ///
+    /// A signal that cannot be read is taken as a termination request, which
+    /// keeps a stop quiet rather than announcing it as a crash.
+    private func asksToTerminate(_ event: DockerClient.DockerEvent) -> Bool {
+        guard let signal = event.attributes["signal"].flatMap(Int.init) else { return true }
+        return Self.terminationSignals.contains(signal)
+    }
+
+    private mutating func death(of id: String, event: DockerClient.DockerEvent) -> ContainerCrash? {
+        // Consume the intent either way: it explains exactly one death, and a
+        // stale one explains nothing.
+        let intent = intentionalExits.removeValue(forKey: id)
+        if let intent, event.date.timeIntervalSince(intent) <= Self.intentWindow {
+            return nil
+        }
+
+        guard let exitCode = event.attributes["exitCode"].flatMap(Int.init), exitCode != 0 else {
+            return nil
+        }
+        if let announced = lastAnnounced[id],
+            event.date.timeIntervalSince(announced) < Self.repeatCooldown
+        {
+            return nil
+        }
+        lastAnnounced[id] = event.date
+
+        return ContainerCrash(
+            containerID: id,
+            name: event.attributes["name"] ?? String(id.prefix(12)),
+            exitCode: exitCode
+        )
+    }
+}

--- a/ArcBox/Services/Notifications/NotificationCoordinator.swift
+++ b/ArcBox/Services/Notifications/NotificationCoordinator.swift
@@ -1,4 +1,5 @@
 import ArcBoxClient
+import DockerClient
 import Foundation
 
 /// Owns everything between an event and a delivered notification: which rules
@@ -15,6 +16,9 @@ final class NotificationCoordinator {
 
     private var sandboxRules = SandboxNotificationRules()
     private var pendingDaemonAlert: Task<Void, Never>?
+    private lazy var containerCrashes = ContainerCrashReporter { [weak self] notification in
+        self?.service.post(notification)
+    }
 
     init(
         service: UserNotificationService = UserNotificationService(),
@@ -37,11 +41,22 @@ final class NotificationCoordinator {
     func stop() {
         pendingDaemonAlert?.cancel()
         pendingDaemonAlert = nil
+        containerCrashes.stop()
     }
 
     func handleSandboxEvent(_ event: SandboxEventRecord) {
         guard let notification = sandboxRules.notification(for: event) else { return }
         service.post(notification)
+    }
+
+    func handleDockerEvent(_ event: DockerClient.DockerEvent) {
+        containerCrashes.handle(event)
+    }
+
+    /// The runtime went away and took every container with it. Those deaths
+    /// are not news — the daemon has its own notification for exactly this.
+    func runtimeStopped() {
+        containerCrashes.stop()
     }
 
     /// Tell the user about a daemon problem, but only once it has outlasted the

--- a/ArcBox/Views/Settings/GeneralSettingsView.swift
+++ b/ArcBox/Views/Settings/GeneralSettingsView.swift
@@ -20,6 +20,7 @@ struct GeneralSettingsView: View {
     @AppStorage("externalTerminal") private var externalTerminal = ExternalTerminalApp.terminalBundleIdentifier
     @AppStorage("telemetryEnabled") private var telemetryEnabled = true
     @AppStorage(AppNotification.Category.sandbox.preferenceKey) private var notifySandboxResults = true
+    @AppStorage(AppNotification.Category.container.preferenceKey) private var notifyContainerCrashes = true
     @AppStorage(AppNotification.Category.daemonHealth.preferenceKey) private var notifyDaemonProblems = true
 
     @State private var isExportingDiagnostics = false
@@ -84,6 +85,17 @@ struct GeneralSettingsView: View {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Sandbox execution results")
                         Text("Every failure, and successful runs longer than 30 seconds.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                LabeledContent {
+                    Toggle("", isOn: $notifyContainerCrashes)
+                        .labelsHidden()
+                } label: {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Container crashes")
+                        Text("When a container exits on its own with a non-zero code.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }

--- a/ArcBoxTests/ContainerCrashDigestTests.swift
+++ b/ArcBoxTests/ContainerCrashDigestTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+
+@testable import ArcBox
+
+/// Tests for how a batch of container deaths is rendered as one notification.
+@MainActor
+final class ContainerCrashDigestTests: XCTestCase {
+
+    private func crash(_ name: String, id: String? = nil, exitCode: Int = 1) -> ContainerCrash {
+        ContainerCrash(containerID: id ?? name, name: name, exitCode: exitCode)
+    }
+
+    func testEmptyBatchSaysNothing() {
+        XCTAssertNil(ContainerCrashDigest.notification(for: []))
+    }
+
+    func testSingleCrashNamesTheContainerAndSelectsIt() {
+        let notification = ContainerCrashDigest.notification(for: [crash("api", id: "abc", exitCode: 137)])
+
+        XCTAssertEqual(notification?.title, "Container exited")
+        XCTAssertEqual(notification?.body, "api exited with code 137.")
+        XCTAssertEqual(notification?.destination, .section(.containers, id: "abc"))
+    }
+
+    /// A failing `compose up` takes several containers down at once; one banner
+    /// per container is what this exists to prevent.
+    func testBatchIsCountedAndListed() {
+        let notification = ContainerCrashDigest.notification(
+            for: [crash("api"), crash("worker"), crash("db")])
+
+        XCTAssertEqual(notification?.title, "3 containers exited")
+        XCTAssertEqual(notification?.body, "api, worker, db.")
+        XCTAssertEqual(notification?.destination, .section(.containers, id: nil))
+    }
+
+    /// Fewer names than the cap: nothing is held back, so nothing trails.
+    func testShortBatchListsEveryName() {
+        let notification = ContainerCrashDigest.notification(for: [crash("api"), crash("worker")])
+
+        XCTAssertEqual(notification?.title, "2 containers exited")
+        XCTAssertEqual(notification?.body, "api, worker.")
+    }
+
+    func testLongBatchTruncatesTheNameList() {
+        let notification = ContainerCrashDigest.notification(
+            for: [crash("api"), crash("worker"), crash("db"), crash("cache"), crash("proxy")])
+
+        XCTAssertEqual(notification?.title, "5 containers exited")
+        XCTAssertEqual(notification?.body, "api, worker, db and 2 more.")
+    }
+
+    /// One container dying repeatedly inside a single window is one story.
+    func testRepeatsOfOneContainerCollapse() {
+        let notification = ContainerCrashDigest.notification(
+            for: [crash("api", id: "abc"), crash("api", id: "abc"), crash("api", id: "abc")])
+
+        XCTAssertEqual(notification?.title, "Container exited")
+    }
+
+    /// The digest is the current state of things, so a later one replaces it.
+    func testDigestsShareAnIdentifier() {
+        let single = ContainerCrashDigest.notification(for: [crash("api")])
+        let batch = ContainerCrashDigest.notification(for: [crash("api"), crash("worker")])
+
+        XCTAssertEqual(single?.identifier, batch?.identifier)
+    }
+
+    func testDigestIsSwitchableOnItsOwn() {
+        XCTAssertEqual(ContainerCrashDigest.notification(for: [crash("api")])?.category, .container)
+    }
+}

--- a/ArcBoxTests/ContainerNotificationRulesTests.swift
+++ b/ArcBoxTests/ContainerNotificationRulesTests.swift
@@ -1,0 +1,186 @@
+import XCTest
+
+@testable import ArcBox
+@testable import DockerClient
+
+/// Tests for which container deaths are worth interrupting the user for.
+///
+/// The event shapes here were captured from a live Docker 29.6 daemon rather
+/// than assumed: `docker stop` really does produce `kill`, `kill`, `stop`,
+/// `die` in that order, and its `die` carries the same `exitCode=137` a killed
+/// container does — which is why intent, not the exit code, is what separates
+/// them.
+@MainActor
+final class ContainerNotificationRulesTests: XCTestCase {
+
+    private var rules = ContainerNotificationRules()
+    private let start = Date(timeIntervalSince1970: 1_700_000_000)
+
+    override func setUp() {
+        super.setUp()
+        rules = ContainerNotificationRules()
+    }
+
+    // MARK: - Helpers
+
+    private func event(
+        _ action: String,
+        id: String = "container-abcdef123456",
+        after seconds: TimeInterval = 0,
+        type: String = "container",
+        _ attributes: [String: String] = [:]
+    ) -> DockerClient.DockerEvent {
+        DockerClient.DockerEvent(
+            type: type,
+            action: action,
+            actorID: id,
+            attributes: attributes,
+            date: start.addingTimeInterval(seconds)
+        )
+    }
+
+    // MARK: - Crashes
+
+    func testNonZeroExitNotifies() {
+        let crash = rules.crash(for: event("die", ["exitCode": "137", "name": "api"]))
+
+        XCTAssertEqual(crash, ContainerCrash(containerID: "container-abcdef123456", name: "api", exitCode: 137))
+    }
+
+    func testCleanExitIsSilent() {
+        XCTAssertNil(rules.crash(for: event("die", ["exitCode": "0", "name": "migrate"])))
+    }
+
+    func testMissingExitCodeIsSilent() {
+        XCTAssertNil(rules.crash(for: event("die", ["name": "api"])))
+    }
+
+    func testUnnamedContainerFallsBackToShortID() {
+        let crash = rules.crash(for: event("die", id: "0123456789abcdef", ["exitCode": "1"]))
+
+        XCTAssertEqual(crash?.name, "0123456789ab")
+    }
+
+    // MARK: - Intent
+
+    /// `docker stop` produces the same non-zero `die` a crash does; what marks
+    /// it is the `stop` that precedes it.
+    func testStopSuppressesTheFollowingDie() {
+        XCTAssertNil(rules.crash(for: event("stop")))
+
+        XCTAssertNil(rules.crash(for: event("die", after: 1, ["exitCode": "137", "name": "api"])))
+    }
+
+    func testKillSuppressesTheFollowingDie() {
+        _ = rules.crash(for: event("kill", ["signal": "15"]))
+
+        XCTAssertNil(rules.crash(for: event("die", after: 1, ["exitCode": "137"])))
+    }
+
+    /// Intent explains exactly one death. A container stopped, restarted, then
+    /// crashing on its own is news.
+    func testIntentIsConsumedByOneDeath() {
+        _ = rules.crash(for: event("stop"))
+        _ = rules.crash(for: event("die", after: 1, ["exitCode": "137"]))
+        _ = rules.crash(for: event("start", after: 2))
+
+        XCTAssertNotNil(rules.crash(for: event("die", after: 400, ["exitCode": "1", "name": "api"])))
+    }
+
+    /// A restart clears intent even when no `die` consumed it.
+    func testStartClearsPendingIntent() {
+        _ = rules.crash(for: event("kill"))
+        _ = rules.crash(for: event("start", after: 1))
+
+        XCTAssertNotNil(rules.crash(for: event("die", after: 2, ["exitCode": "1"])))
+    }
+
+    /// `docker kill` sends any signal the caller asks for. SIGHUP addresses a
+    /// container that is expected to keep running, so a death that follows it
+    /// is the container's own doing.
+    func testNonTerminatingSignalIsNotIntent() {
+        _ = rules.crash(for: event("kill", ["signal": "1"]))
+
+        XCTAssertNotNil(rules.crash(for: event("die", after: 3, ["exitCode": "1", "name": "api"])))
+    }
+
+    /// The other half: a container that traps SIGTERM and carries on must not
+    /// leave intent sitting there to swallow an unrelated crash later.
+    func testTrappedTerminationSignalStopsExplainingDeathsAfterTheWindow() {
+        _ = rules.crash(for: event("kill", ["signal": "15"]))
+
+        let later = ContainerNotificationRules.intentWindow + 1
+        XCTAssertNotNil(rules.crash(for: event("die", after: later, ["exitCode": "1", "name": "api"])))
+    }
+
+    /// An image can name its own `STOPSIGNAL` — httpd's is SIGWINCH — so the
+    /// `kill` that `docker stop` sends is not always a termination signal. The
+    /// `stop` it emits before the `die` is what covers it.
+    func testCustomStopSignalIsStillSuppressed() {
+        _ = rules.crash(for: event("kill", ["signal": "28"]))
+        _ = rules.crash(for: event("stop", after: 1))
+
+        XCTAssertNil(rules.crash(for: event("die", after: 1, ["exitCode": "137"])))
+    }
+
+    /// A long `docker stop -t 60` is still covered: Docker emits `stop`
+    /// immediately before the `die`, refreshing the intent no matter how long
+    /// the grace period ran.
+    func testLongGracePeriodStopIsStillSuppressed() {
+        _ = rules.crash(for: event("kill", ["signal": "15"]))
+        _ = rules.crash(for: event("stop", after: 60))
+
+        XCTAssertNil(rules.crash(for: event("die", after: 60, ["exitCode": "137"])))
+    }
+
+    func testIntentIsTrackedPerContainer() {
+        _ = rules.crash(for: event("stop", id: "stopped"))
+
+        XCTAssertNil(rules.crash(for: event("die", id: "stopped", ["exitCode": "137"])))
+        XCTAssertNotNil(rules.crash(for: event("die", id: "crashed", ["exitCode": "137"])))
+    }
+
+    // MARK: - Noise
+
+    /// The trap: a failing health check emits `exec_die` with a non-zero exit
+    /// code every few seconds, on a `type=container` event, and says nothing
+    /// about the container itself.
+    func testFailingHealthCheckProbesAreSilent() {
+        for second in 0..<5 {
+            XCTAssertNil(
+                rules.crash(for: event("exec_die", after: TimeInterval(second), ["exitCode": "1"])),
+                "exec_die must never notify"
+            )
+        }
+    }
+
+    /// A container under `restart: always` with a broken image dies forever.
+    func testRepeatedCrashesAreRateLimited() {
+        XCTAssertNotNil(rules.crash(for: event("die", ["exitCode": "1"])))
+
+        _ = rules.crash(for: event("start", after: 2))
+        XCTAssertNil(rules.crash(for: event("die", after: 5, ["exitCode": "1"])))
+        _ = rules.crash(for: event("start", after: 7))
+        XCTAssertNil(rules.crash(for: event("die", after: 10, ["exitCode": "1"])))
+    }
+
+    func testCrashIsReportedAgainAfterTheCooldown() {
+        _ = rules.crash(for: event("die", ["exitCode": "1"]))
+
+        let later = ContainerNotificationRules.repeatCooldown + 1
+        XCTAssertNotNil(rules.crash(for: event("die", after: later, ["exitCode": "1"])))
+    }
+
+    /// A recreated container is a different container, so its cooldown is not
+    /// inherited from the one it replaced.
+    func testDestroyForgetsTheCooldown() {
+        _ = rules.crash(for: event("die", ["exitCode": "1"]))
+        _ = rules.crash(for: event("destroy", after: 1))
+
+        XCTAssertNotNil(rules.crash(for: event("die", after: 2, ["exitCode": "1"])))
+    }
+
+    func testNonContainerEventsAreIgnored() {
+        XCTAssertNil(rules.crash(for: event("die", type: "image", ["exitCode": "1"])))
+    }
+}

--- a/ArcBoxTests/DockerEventMonitorTests.swift
+++ b/ArcBoxTests/DockerEventMonitorTests.swift
@@ -26,7 +26,7 @@ final class DockerEventMonitorTests: XCTestCase {
     // MARK: - Helpers
 
     private func event(_ type: String, _ action: String) -> DockerClient.DockerEvent {
-        DockerClient.DockerEvent(type: type, action: action, actorID: nil)
+        DockerClient.DockerEvent(type: type, action: action, actorID: nil, date: Date())
     }
 
     /// Wait for a notification within a timeout, returning true if received.

--- a/Packages/DockerClient/Sources/DockerClient/DockerClient/DockerClient+Events.swift
+++ b/Packages/DockerClient/Sources/DockerClient/DockerClient/DockerClient+Events.swift
@@ -9,6 +9,26 @@ extension DockerClient {
         public let type: String  // "container", "image", "network", "volume", …
         public let action: String  // "start", "stop", "die", "create", "destroy", …
         public let actorID: String?
+        /// The event's `Actor.Attributes`. On a container `die` this carries
+        /// `exitCode`, `name` and `image`; Compose-managed containers also
+        /// carry their `com.docker.compose.*` labels.
+        public let attributes: [String: String]
+        /// When the daemon recorded the event.
+        public let date: Date
+
+        public init(
+            type: String,
+            action: String,
+            actorID: String?,
+            attributes: [String: String] = [:],
+            date: Date
+        ) {
+            self.type = type
+            self.action = action
+            self.actorID = actorID
+            self.attributes = attributes
+            self.date = date
+        }
     }
 
     /// Stream real-time events from the Docker daemon.
@@ -56,9 +76,22 @@ extension DockerClient {
 
                             let actor = json["Actor"] as? [String: Any]
                             let actorID = actor?["ID"] as? String
+                            let attributes = actor?["Attributes"] as? [String: String] ?? [:]
+                            // `timeNano` is finer, but at present-day values it
+                            // is past the range where a Double holds every
+                            // integer, so reading it back loses the precision
+                            // it was for. `time` is whole seconds, which is all
+                            // any consumer needs.
+                            let date = (json["time"] as? TimeInterval).map(Date.init(timeIntervalSince1970:))
 
                             continuation.yield(
-                                DockerEvent(type: type, action: action, actorID: actorID))
+                                DockerEvent(
+                                    type: type,
+                                    action: action,
+                                    actorID: actorID,
+                                    attributes: attributes,
+                                    date: date ?? Date()
+                                ))
                         }
                     }
                     continuation.finish()


### PR DESCRIPTION
The first follow-up ABXD-132 left open. #366 has landed, so this is now rebased straight onto `master` and stands alone.

`DockerClient.DockerEvent` kept only `type`/`action`/`actorID` and threw away `Actor.Attributes`, which is where the exit code lives. It now carries the attributes and the event time.

## Telling a crash from a shutdown

Exit codes cannot do it. Captured against a live Docker 29.6 daemon:

```
arcbox-evt-crash  create → attach → start → die (exitCode=137)
arcbox-evt-stop   create → start → kill (signal=15) → kill (signal=9) → stop → die (exitCode=137)
```

`docker stop` produces the same `die`/`exitCode=137` a killed container does. What separates them is that Docker announces the intent *first* — note the ordering, `stop` precedes `die`, not the other way round. So a `kill` or `stop` seen for a container suppresses exactly one following death, and a `start` clears any intent that no death consumed.

Two things keep that intent honest, both from review:

**`docker kill` delivers whatever signal it is given.** Only the four that ask a container to end — SIGINT, SIGQUIT, SIGKILL, SIGTERM — establish intent. SIGHUP to reload configuration is addressed to a container expected to keep running, so a death that follows it is the container's own doing and gets announced. Numbers rather than names because that is what the daemon writes (`strconv.Itoa(int(stopSignal))`, moby `daemon/kill.go`). An image's own `STOPSIGNAL` is deliberately not in the set — httpd's is SIGWINCH — and needs no special case, because `docker stop` emits `stop` before the `die` whichever signal it sent.

**Intent expires after ten seconds.** A container that traps SIGTERM and carries on is indistinguishable, by signal number, from one that dies of it; without an expiry its intent would sit there and swallow the next genuine crash. A long `docker stop -t 60` stays covered regardless, since `stop` arrives immediately before the `die` and refreshes it.

## Noise, found the same way

**Failing health checks.** A container whose probe fails emits `exec_die` with a non-zero exit code every few seconds, on a `type=container` event — three of them were streaming on the test machine throughout. Matching the action by prefix or substring would turn a single unhealthy container into a permanent banner source. The action is matched exactly, and there is a test that says so.

**Crash loops.** A container under `restart: always` with a broken image dies forever. The same container stays quiet for five minutes after being announced; `destroy` clears that, since a recreated container is a different container.

**Simultaneous deaths.** A failing `compose up` takes several containers down at once, so deaths inside a three-second window are announced together — "3 containers exited: api, worker, db". The window opens on the first crash rather than sliding, because a sliding window lets a crash loop defer the report indefinitely.

## Shape

- `ContainerNotificationRules` — pure and stateful (intent, cooldown); decides whether a death is news.
- `ContainerCrashDigest` — pure rendering of a batch into one notification, deduplicated by container.
- `ContainerCrashReporter` — owns the batch window and nothing else, so the coordinator stays thin.
- New `.container` category, registered default-on and toggleable in General settings. `AppPreferences` now registers from `Category.allCases`, so a future category cannot silently ship switched off.

## Verification

`make lint` (0 violations) and `make test` pass on the rebase: 470 passed, 0 failed. 26 cases across `ContainerNotificationRulesTests` and `ContainerCrashDigestTests`, confirmed by name in the result bundle. `make generate-xcodeproj` reproduces the committed `project.pbxproj` byte for byte. The event shapes in the tests are transcribed from the live capture above, not assumed.

Test containers created during the capture (`arcbox-evt-crash`, `arcbox-evt-stop`) were removed.

## Still open from ABXD-132

Long image operations, memory pressure, and disk usage. Deliberately not bundled here: each adds its own noise surface and deserves its own judgement, and disk needs a filesystem-usage field in `stats.proto` first, which is a daemon-side change.
