### PR TITLE
fix(ui): slide the detail tab indicator instead of morphing glass

### DIFF
--- a/ArcBox/Components/DetailTabPicker.swift
+++ b/ArcBox/Components/DetailTabPicker.swift
@@ -43,6 +43,17 @@ struct DetailTabPicker<Tab: DetailTab>: ToolbarContent {
     }
 }
 
+/// The selection indicator is one persistent glass capsule that slides between
+/// segments, positioned by `matchedGeometryEffect` against the segment it is
+/// on.
+///
+/// It deliberately does not toggle `glassEffect` per segment and morph the
+/// shapes through a `GlassEffectContainer`. That reads as a moving pill at
+/// rest, but it drives the shape through appear/disappear morphs, and
+/// `GlassEffectTransition.matchedGeometry` then "applies additional scale and
+/// offset effects to content when the identity of the shape does not change
+/// but its content does" — the selection ID is constant while the segment
+/// under it changes, so every switch picked up that extra scale and offset.
 @available(macOS 26.0, *)
 private struct LiquidGlassDetailTabPicker<Tab: DetailTab>: View {
     @Binding var selection: Tab
@@ -51,34 +62,33 @@ private struct LiquidGlassDetailTabPicker<Tab: DetailTab>: View {
     @Namespace private var glassNamespace
 
     var body: some View {
-        GlassEffectContainer(
-            spacing: CGFloat(Tab.allCases.count) * AppMetrics.detailTabSegment
-        ) {
-            HStack(spacing: 2) {
-                ForEach(Tab.allCases) { tab in
-                    Button {
-                        selection = tab
-                    } label: {
-                        Text(tab.rawValue)
-                            .font(.system(size: 12))
-                            .lineLimit(1)
-                            .frame(minWidth: 44, maxWidth: .infinity)
-                            .frame(height: 28)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .frame(maxWidth: .infinity)
-                    .foregroundStyle(selection == tab ? .primary : .secondary)
-                    .glassEffect(
-                        selection == tab ? .regular.interactive() : .identity
-                    )
-                    .glassEffectID(
-                        selection == tab ? "selected-detail-tab" : nil,
-                        in: glassNamespace
-                    )
+        HStack(spacing: DetailTabLayout.segmentGap) {
+            ForEach(Tab.allCases) { tab in
+                Button {
+                    selection = tab
+                } label: {
+                    Text(tab.rawValue)
+                        .font(.system(size: 12))
+                        .lineLimit(1)
+                        .frame(minWidth: 44, maxWidth: .infinity)
+                        .frame(height: 28)
+                        .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
+                .frame(maxWidth: .infinity)
+                .foregroundStyle(selection == tab ? .primary : .secondary)
+                .matchedGeometryEffect(id: tab, in: glassNamespace, isSource: true)
             }
-            .padding(2)
+        }
+        .padding(DetailTabLayout.segmentGap)
+        .background {
+            Color.clear
+                .glassEffect(.regular.interactive())
+                .matchedGeometryEffect(
+                    id: selection,
+                    in: glassNamespace,
+                    isSource: false
+                )
         }
         .frame(
             minWidth: DetailTabLayout.minimumWidth(for: Tab.allCases.count),
@@ -86,7 +96,7 @@ private struct LiquidGlassDetailTabPicker<Tab: DetailTab>: View {
             maxWidth: DetailTabLayout.idealWidth(for: Tab.allCases.count)
         )
         .animation(
-            reduceMotion ? nil : .smooth(duration: 0.3),
+            reduceMotion ? nil : .smooth(duration: 0.2),
             value: selection
         )
         .accessibilityRepresentation {
@@ -101,6 +111,9 @@ private struct LiquidGlassDetailTabPicker<Tab: DetailTab>: View {
 }
 
 private enum DetailTabLayout {
+    /// The gap between two segments, and the inset around the whole bar.
+    static let segmentGap: CGFloat = 2
+
     static func minimumWidth(for count: Int) -> CGFloat {
         count <= 2
             ? 3 * AppMetrics.detailTabSegment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [1.35.0](https://github.com/arcboxlabs/arcbox-desktop/compare/v1.34.5...v1.35.0) (2026-08-11)
 
+### Highlights
+
+Runners arrive: sign in, enroll this Mac as a Fleet device, and manage its runners from the new Runners section, which stays current as agent state changes instead of waiting for a refresh.
+
+The Sandboxes Ports tab now reflects the daemon's own record of exposed ports, so mappings made from the CLI or SDK show up, stale rows clear themselves, and Refresh is there when you want to re-check. Analytics also honours the Privacy toggle more faithfully: while it is on, a signed-in account is identified by email and name, and switching it back on after signing in no longer leaves the session anonymous.
+
 
 ### Features
 


### PR DESCRIPTION
## Problem

The detail tab bar in the toolbar played an exaggerated stretch on every tab switch — most visible on the four-tab **Containers** view — and the first switch after a cold launch was worse still. The Runners detail bar was unaffected because it uses a native segmented `Picker`, where AppKit owns the indicator.

Affected views: Containers, Volumes, Images (Docker), Sandboxes, Machines — everything going through `DetailTabPicker`.

## Root cause

Two independent departures from the documented Liquid Glass contract, compounding:

**1. `GlassEffectContainer(spacing:)` was being used as a layout gap.** It is a *blend threshold* — [Apple](https://developer.apple.com/documentation/swiftui/glasseffectcontainer): *"As shapes near one another, their paths start to blend into one another. The higher the spacing, the sooner blending begins."* It was set to `tabCount * AppMetrics.detailTabSegment`:

| View | Tabs | spacing | HStack spacing |
|---|---|---|---|
| Containers | 4 | 320pt | 2pt |
| Images | 3 | 240pt | 2pt |
| Sandboxes | 6 | 480pt | 2pt |

[Applying Liquid Glass to custom views](https://developer.apple.com/documentation/swiftui/applying-liquid-glass-to-custom-views): *"A spacing value on the container that's larger than the spacing of an interior HStack … causes Liquid Glass effects to blend together at rest."* Apple's own example pairs `GlassEffectContainer(spacing: 40)` with `HStack(spacing: 40)`. The blend field here covered the entire bar, so the indicator blended against segments it was nowhere near.

**2. One shared `glassEffectID` over a per-segment `.regular` ↔ `.identity` toggle.** [`GlassEffectTransition.matchedGeometry`](https://developer.apple.com/documentation/swiftui/glasseffecttransition/matchedgeometry): *"this transition applies additional scale and offset effects to content when the identity of the shape does not change but its content does."* `"selected-detail-tab"` stayed constant while the segment beneath it changed — precisely that trigger.

## Fix

Render **one persistent glass capsule** and position it with `matchedGeometryEffect` against the selected segment: each segment is a geometry source, and a single `Color.clear.glassEffect(.regular.interactive())` background follows `id: selection`.

The pill now *moves* instead of appearing and disappearing, so there is no morph to overshoot and no appearance transition to misfire on first mount. `GlassEffectContainer` is dropped — it exists to blend *multiple* effects, and there is now one.

Animation also tightened from `0.3s` to `0.2s`, closer to the native indicator's pace. `reduceMotion` handling and the `accessibilityRepresentation` segmented `Picker` are unchanged.

## Verification

- `make build`, `make lint` (0 violations), `make test` (91 tests / 10 suites) all pass on this branch.
- Manually verified in ArcBox Dev across several cold launches — cold-start first open, Containers (4 tabs), and repeated switching. Confirmed by the reporter.
- No test added: this is animation geometry with no branching logic to assert against. The behaviour is only observable in a running window.

## Note for reviewers

The pill reads as a cleaner slide than before — the liquid squish is gone. That is intentional, and tunable independently of the bug. If a glassier feel is wanted back, the lever is the animation curve, not the container spacing.

---

## Also included: curate the 1.35.0 highlights

This PR carries a second, unrelated commit because CI on `master` is currently red for every PR and this one cannot be verified without it.

Release PR #382 (`chore(master): release 1.35.0`, `4e034ec`) merged with its own check already red, leaving `## [1.35.0]` in `CHANGELOG.md` without a `### Highlights` section while `.release-please-manifest.json` names `1.35.0`. [pr.yml:90](.github/workflows/pr.yml#L90) therefore fails with `release 1.35.0 has no non-empty ### Highlights section`, and that step runs *before* `Lint`, `Build (Debug)` and `Run Tests` — so no PR reaches the compiler. The release DMG extracts the same section to feed Sparkle's update dialog and refuses to build without it, so 1.35.0 cannot be packaged either.

The added section is written from what 1.35.0 actually shipped — Fleet device auth and runner management (#320), authoritative sandbox port reconciliation (#374), and telemetry identification with the Privacy toggle ordering (#367). Build, docs and CI-only entries are left out; this text is what users see in the update dialog.

`cargo xtask release notes --version "$(jq -r '."."' .release-please-manifest.json)"` — the exact CI invocation — now succeeds. Verified green on its own branch before consolidation: `Build & Test` passed in 8m48s with `Verify curated release highlights`, `Lint`, `Build (Debug)` and `Run Tests` all ✓.

**Reviewers: the changelog wording is the part worth reviewing**, since it ships verbatim to users. One sentence is a deliberate judgment call — it states plainly that a signed-in account is identified by email and name while analytics is on. #367 made that change and also corrected the Privacy toggle's caption, which had claimed no personal data was collected. Reword or drop it if you'd rather it not appear there.

Happy to split this back out if you'd rather land the unblock on its own — it was originally #389.
