### PR TITLE
chore(release): curate the 1.35.0 highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [1.35.0](https://github.com/arcboxlabs/arcbox-desktop/compare/v1.34.5...v1.35.0) (2026-08-11)
 
+### Highlights
+
+Runners arrive: sign in, enroll this Mac as a Fleet device, and manage its runners from the new Runners section, which stays current as agent state changes instead of waiting for a refresh.
+
+The Sandboxes Ports tab now reflects the daemon's own record of exposed ports, so mappings made from the CLI or SDK show up, stale rows clear themselves, and Refresh is there when you want to re-check. Analytics also honours the Privacy toggle more faithfully: while it is on, a signed-in account is identified by email and name, and switching it back on after signing in no longer leaves the session anonymous.
+
 
 ### Features
 


### PR DESCRIPTION
## Problem

Every PR against `master` currently fails CI before it compiles.

Release PR #382 (`chore(master): release 1.35.0`, `4e034ec`) merged with its own check already red, leaving `## [1.35.0]` in `CHANGELOG.md` without a `### Highlights` section while `.release-please-manifest.json` names `1.35.0`. So [pr.yml:90](.github/workflows/pr.yml#L90) fails:

```
Error: release 1.35.0 has no non-empty ### Highlights section
```

That step sits ahead of `Lint`, `Create local Xcode config`, `Build (Debug)` and `Run Tests`, all of which are skipped when it fails.

| Time (UTC) | Branch | Result |
|---|---|---|
| 10:37 | `release-please--branches--master` | failure |
| 10:40 | `release-please--branches--master` | failure |
| 10:41 | `master` (post-merge) | failure |
| 13:44 | `fix/detail-tab-glass-animation` | failure |

Branches from earlier the same day passed — they predate the merge. Tag `v1.35.0` already exists, so this cannot be fixed by amending the release PR.

The blast radius is wider than CI: [pr.yml:84-87](.github/workflows/pr.yml#L84-L87) notes the release DMG extracts this same section to feed Sparkle's update dialog and refuses to build without it, so 1.35.0 cannot be packaged either.

## Change

Adds the missing `### Highlights` block, written from what 1.35.0 actually shipped:

- Fleet device auth, enrollment and live runner management (#320)
- Authoritative sandbox port reconciliation (#374)
- Telemetry identification and Privacy toggle ordering (#367)

Build, docs and CI-only entries are left out — this text is what users see in the update dialog.

## Verification

`cargo xtask release notes --version "$(jq -r '."."' .release-please-manifest.json)"` — the exact CI invocation — now succeeds and extracts:

> Runners arrive: sign in, enroll this Mac as a Fleet device, and manage its runners from the new Runners section, which stays current as agent state changes instead of waiting for a refresh.
>
> The Sandboxes Ports tab now reflects the daemon's own record of exposed ports, so mappings made from the CLI or SDK show up, stale rows clear themselves, and Refresh is there when you want to re-check. Analytics also honours the Privacy toggle more faithfully: while it is on, a signed-in account is identified by email and name, and switching it back on after signing in no longer leaves the session anonymous.

## Note for reviewers

**The wording is the part worth reviewing, not the mechanics** — this ships verbatim to users in Sparkle's update dialog.

One sentence is a deliberate judgment call: the telemetry line states plainly that a signed-in account is identified by email and name while analytics is on. #367 made that change and also corrected the Privacy toggle's caption, which had claimed no personal data was collected. Being upfront in the release notes seemed consistent with that, but reword or drop it if you'd rather it not appear there.

Once this merges, other open PRs only need their checks re-run — `actions/checkout@v6` builds the head-merged-into-base commit, so no rebase is required.