### PR TITLE
fix(client): regenerate the template client for the v0.6.6 pin

### DIFF
--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/Generated/arcbox/sandbox/v1/template.grpc.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/Generated/arcbox/sandbox/v1/template.grpc.swift
@@ -132,10 +132,12 @@ extension Arcbox_Sandbox_V1_TemplateService {
     /// >
     /// > TemplateService manages the template catalog. Control plane.
     /// > 
-    /// > Contract-only in CORE-58 phase 1: the daemon answers UNIMPLEMENTED
-    /// > until the catalog lands with CORE-21. Build additionally depends on the
-    /// > rootfs pipeline (CORE-5) and, for pre-warmed snapshots, FC 1.16
-    /// > network overrides (CORE-16).
+    /// > Served as of CORE-107: every RPC below is implemented, all three Build
+    /// > sources work, and `CreateSandboxRequest.template` resolves
+    /// > `name[:version]` against the catalog. Clients that also talk to older
+    /// > daemons detect it with the `templates` flag in
+    /// > `GetCapabilitiesResponse.features` rather than on this service
+    /// > existing.
     public protocol StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
         /// Handle the "Build" method.
         ///
@@ -246,10 +248,12 @@ extension Arcbox_Sandbox_V1_TemplateService {
     /// >
     /// > TemplateService manages the template catalog. Control plane.
     /// > 
-    /// > Contract-only in CORE-58 phase 1: the daemon answers UNIMPLEMENTED
-    /// > until the catalog lands with CORE-21. Build additionally depends on the
-    /// > rootfs pipeline (CORE-5) and, for pre-warmed snapshots, FC 1.16
-    /// > network overrides (CORE-16).
+    /// > Served as of CORE-107: every RPC below is implemented, all three Build
+    /// > sources work, and `CreateSandboxRequest.template` resolves
+    /// > `name[:version]` against the catalog. Clients that also talk to older
+    /// > daemons detect it with the `templates` flag in
+    /// > `GetCapabilitiesResponse.features` rather than on this service
+    /// > existing.
     public protocol ServiceProtocol: Arcbox_Sandbox_V1_TemplateService.StreamingServiceProtocol {
         /// Handle the "Build" method.
         ///
@@ -358,10 +362,12 @@ extension Arcbox_Sandbox_V1_TemplateService {
     /// >
     /// > TemplateService manages the template catalog. Control plane.
     /// > 
-    /// > Contract-only in CORE-58 phase 1: the daemon answers UNIMPLEMENTED
-    /// > until the catalog lands with CORE-21. Build additionally depends on the
-    /// > rootfs pipeline (CORE-5) and, for pre-warmed snapshots, FC 1.16
-    /// > network overrides (CORE-16).
+    /// > Served as of CORE-107: every RPC below is implemented, all three Build
+    /// > sources work, and `CreateSandboxRequest.template` resolves
+    /// > `name[:version]` against the catalog. Clients that also talk to older
+    /// > daemons detect it with the `templates` flag in
+    /// > `GetCapabilitiesResponse.features` rather than on this service
+    /// > existing.
     public protocol SimpleServiceProtocol: Arcbox_Sandbox_V1_TemplateService.ServiceProtocol {
         /// Handle the "Build" method.
         ///
@@ -664,10 +670,12 @@ extension Arcbox_Sandbox_V1_TemplateService {
     /// >
     /// > TemplateService manages the template catalog. Control plane.
     /// > 
-    /// > Contract-only in CORE-58 phase 1: the daemon answers UNIMPLEMENTED
-    /// > until the catalog lands with CORE-21. Build additionally depends on the
-    /// > rootfs pipeline (CORE-5) and, for pre-warmed snapshots, FC 1.16
-    /// > network overrides (CORE-16).
+    /// > Served as of CORE-107: every RPC below is implemented, all three Build
+    /// > sources work, and `CreateSandboxRequest.template` resolves
+    /// > `name[:version]` against the catalog. Clients that also talk to older
+    /// > daemons detect it with the `templates` flag in
+    /// > `GetCapabilitiesResponse.features` rather than on this service
+    /// > existing.
     public protocol ClientProtocol: Sendable {
         /// Call the "Build" method.
         ///
@@ -801,10 +809,12 @@ extension Arcbox_Sandbox_V1_TemplateService {
     /// >
     /// > TemplateService manages the template catalog. Control plane.
     /// > 
-    /// > Contract-only in CORE-58 phase 1: the daemon answers UNIMPLEMENTED
-    /// > until the catalog lands with CORE-21. Build additionally depends on the
-    /// > rootfs pipeline (CORE-5) and, for pre-warmed snapshots, FC 1.16
-    /// > network overrides (CORE-16).
+    /// > Served as of CORE-107: every RPC below is implemented, all three Build
+    /// > sources work, and `CreateSandboxRequest.template` resolves
+    /// > `name[:version]` against the catalog. Clients that also talk to older
+    /// > daemons detect it with the `templates` flag in
+    /// > `GetCapabilitiesResponse.features` rather than on this service
+    /// > existing.
     public struct Client<Transport>: ClientProtocol where Transport: GRPCCore.ClientTransport {
         private let client: GRPCCore.GRPCClient<Transport>
 

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/Generated/arcbox/sandbox/v1/template.pb.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/Generated/arcbox/sandbox/v1/template.pb.swift
@@ -260,8 +260,8 @@ public struct Arcbox_Sandbox_V1_BuildTemplateRequest: Sendable {
   public var labels: Dictionary<String,String> = [:]
 
   /// Also boot the built rootfs once and checkpoint it at READY, so the
-  /// template carries a warm snapshot (requires CORE-16; ignored for
-  /// `snapshot_id` sources, which are warm by construction).
+  /// template carries a warm snapshot (ignored for `snapshot_id` sources,
+  /// which are warm by construction).
   public var prewarm: Bool = false
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()


### PR DESCRIPTION
`make verify-arcbox-protobuf` currently fails on master, which means every PR's Build & Test dies at step 7 and skips Lint, Build and Run Tests.

## Why it broke

#391 (pin → v0.6.6) and #387 (template catalog) were each green on their own, and neither could see this:

- #391 was cut from a master that predated #387, so `generate.sh` had no `template.proto` in its list yet. The bump regenerated the client and produced no template output to update — its diff is one line, `arcbox.version`.
- #387 was branched and verified while the pin was still v0.6.5, so the `template.pb.swift` / `template.grpc.swift` it checked in were generated from v0.6.5's protos.

Merged together you get a v0.6.6 pin with a v0.6.5-generated client. The conflict exists only in the merge, which is why both PRs passed.

## What changed

Comments only. arcbox v0.6.5..v0.6.6 touched exactly one proto and only its doc comments (arcboxlabs/arcbox#617, which corrected `TemplateService`'s "the daemon answers UNIMPLEMENTED" claim and dropped `prewarm`'s obsolete "requires CORE-16" caveat). No API surface moves — regenerated through `cargo xtask protocol verify`'s own path.

## Verification

`make verify-arcbox-protobuf` exits 0 with a clean tree; `make build` succeeds.

## Worth fixing separately

This class of failure is silent in the checks list: a stale generated client, or a release without Highlights, fails early enough in Build & Test that nothing is ever built or tested — the job still reports as one red X, indistinguishable from a genuine test failure. The repo spent 8-11 through 8-13 in that state after 1.35.0 shipped without Highlights. Moving those guards after Build and Run Tests, or into their own job, would make a broken gate stop masking the absence of a build.