### PR TITLE
fix(client): regenerate the template client against v0.6.6

### DIFF
--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/Generated/arcbox/sandbox/v1/template.grpc.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/Generated/arcbox/sandbox/v1/template.grpc.swift
@@ -132,10 +132,12 @@ extension Arcbox_Sandbox_V1_TemplateService {
     /// >
     /// > TemplateService manages the template catalog. Control plane.
     /// > 
-    /// > Contract-only in CORE-58 phase 1: the daemon answers UNIMPLEMENTED
-    /// > until the catalog lands with CORE-21. Build additionally depends on the
-    /// > rootfs pipeline (CORE-5) and, for pre-warmed snapshots, FC 1.16
-    /// > network overrides (CORE-16).
+    /// > Served as of CORE-107: every RPC below is implemented, all three Build
+    /// > sources work, and `CreateSandboxRequest.template` resolves
+    /// > `name[:version]` against the catalog. Clients that also talk to older
+    /// > daemons detect it with the `templates` flag in
+    /// > `GetCapabilitiesResponse.features` rather than on this service
+    /// > existing.
     public protocol StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
         /// Handle the "Build" method.
         ///
@@ -246,10 +248,12 @@ extension Arcbox_Sandbox_V1_TemplateService {
     /// >
     /// > TemplateService manages the template catalog. Control plane.
     /// > 
-    /// > Contract-only in CORE-58 phase 1: the daemon answers UNIMPLEMENTED
-    /// > until the catalog lands with CORE-21. Build additionally depends on the
-    /// > rootfs pipeline (CORE-5) and, for pre-warmed snapshots, FC 1.16
-    /// > network overrides (CORE-16).
+    /// > Served as of CORE-107: every RPC below is implemented, all three Build
+    /// > sources work, and `CreateSandboxRequest.template` resolves
+    /// > `name[:version]` against the catalog. Clients that also talk to older
+    /// > daemons detect it with the `templates` flag in
+    /// > `GetCapabilitiesResponse.features` rather than on this service
+    /// > existing.
     public protocol ServiceProtocol: Arcbox_Sandbox_V1_TemplateService.StreamingServiceProtocol {
         /// Handle the "Build" method.
         ///
@@ -358,10 +362,12 @@ extension Arcbox_Sandbox_V1_TemplateService {
     /// >
     /// > TemplateService manages the template catalog. Control plane.
     /// > 
-    /// > Contract-only in CORE-58 phase 1: the daemon answers UNIMPLEMENTED
-    /// > until the catalog lands with CORE-21. Build additionally depends on the
-    /// > rootfs pipeline (CORE-5) and, for pre-warmed snapshots, FC 1.16
-    /// > network overrides (CORE-16).
+    /// > Served as of CORE-107: every RPC below is implemented, all three Build
+    /// > sources work, and `CreateSandboxRequest.template` resolves
+    /// > `name[:version]` against the catalog. Clients that also talk to older
+    /// > daemons detect it with the `templates` flag in
+    /// > `GetCapabilitiesResponse.features` rather than on this service
+    /// > existing.
     public protocol SimpleServiceProtocol: Arcbox_Sandbox_V1_TemplateService.ServiceProtocol {
         /// Handle the "Build" method.
         ///
@@ -664,10 +670,12 @@ extension Arcbox_Sandbox_V1_TemplateService {
     /// >
     /// > TemplateService manages the template catalog. Control plane.
     /// > 
-    /// > Contract-only in CORE-58 phase 1: the daemon answers UNIMPLEMENTED
-    /// > until the catalog lands with CORE-21. Build additionally depends on the
-    /// > rootfs pipeline (CORE-5) and, for pre-warmed snapshots, FC 1.16
-    /// > network overrides (CORE-16).
+    /// > Served as of CORE-107: every RPC below is implemented, all three Build
+    /// > sources work, and `CreateSandboxRequest.template` resolves
+    /// > `name[:version]` against the catalog. Clients that also talk to older
+    /// > daemons detect it with the `templates` flag in
+    /// > `GetCapabilitiesResponse.features` rather than on this service
+    /// > existing.
     public protocol ClientProtocol: Sendable {
         /// Call the "Build" method.
         ///
@@ -801,10 +809,12 @@ extension Arcbox_Sandbox_V1_TemplateService {
     /// >
     /// > TemplateService manages the template catalog. Control plane.
     /// > 
-    /// > Contract-only in CORE-58 phase 1: the daemon answers UNIMPLEMENTED
-    /// > until the catalog lands with CORE-21. Build additionally depends on the
-    /// > rootfs pipeline (CORE-5) and, for pre-warmed snapshots, FC 1.16
-    /// > network overrides (CORE-16).
+    /// > Served as of CORE-107: every RPC below is implemented, all three Build
+    /// > sources work, and `CreateSandboxRequest.template` resolves
+    /// > `name[:version]` against the catalog. Clients that also talk to older
+    /// > daemons detect it with the `templates` flag in
+    /// > `GetCapabilitiesResponse.features` rather than on this service
+    /// > existing.
     public struct Client<Transport>: ClientProtocol where Transport: GRPCCore.ClientTransport {
         private let client: GRPCCore.GRPCClient<Transport>
 

--- a/Packages/ArcBoxClient/Sources/ArcBoxClient/Generated/arcbox/sandbox/v1/template.pb.swift
+++ b/Packages/ArcBoxClient/Sources/ArcBoxClient/Generated/arcbox/sandbox/v1/template.pb.swift
@@ -260,8 +260,8 @@ public struct Arcbox_Sandbox_V1_BuildTemplateRequest: Sendable {
   public var labels: Dictionary<String,String> = [:]
 
   /// Also boot the built rootfs once and checkpoint it at READY, so the
-  /// template carries a warm snapshot (requires CORE-16; ignored for
-  /// `snapshot_id` sources, which are warm by construction).
+  /// template carries a warm snapshot (ignored for `snapshot_id` sources,
+  /// which are warm by construction).
   public var prewarm: Bool = false
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()


### PR DESCRIPTION
**`master` is red.** `Verify protobuf generated code is up-to-date` fails on `6c1341f`, so no PR can reach the compiler until this lands.

## What happened

A semantic merge conflict — both PRs were green in isolation:

1. **#391** moved `arcbox.version` to v0.6.6. That release reworded `arcbox/sandbox/v1/template.proto`. At that moment `template.proto` was **not** in `generate.sh`'s `PROTOS`, so the desktop generated no client for it and nothing could drift. Green, correctly.
2. **#387** added `template.proto` to `PROTOS` and committed the generated client — built against its own base, **v0.6.5**.

Neither PR could see the problem: #391 had no such file, and #387's tree was consistent with the version it was cut from. Merged together, the committed `template.*.swift` no longer match what regeneration at v0.6.6 produces.

## The fix

`cargo xtask protocol bump --version v0.6.6`, which touched exactly the two files:

```
 .../Generated/arcbox/sandbox/v1/template.grpc.swift | 50 +++++++++++++---------
 .../Generated/arcbox/sandbox/v1/template.pb.swift   |  4 +-
```

**The diff is entirely doc comments.** v0.6.6 rewrote `template.proto`'s documentation — the service now reads as served under CORE-107 rather than contract-only-until-CORE-21, and `prewarm` drops a stale CORE-16 caveat. Grepping the diff for removed declarations returns nothing: no message, field, enum case or RPC moved. #387's Swift is untouched and needs no change.

## Verification

- `make verify-arcbox-protobuf` passes on this branch, working tree clean.
- The regeneration diff was checked for API removals specifically, not just eyeballed — no `struct`/`var`/`func`/`case`/`enum` lines were removed.

## Worth noting

This is the second time in three days that a bot-authored bump and a feature branch each passed alone and failed together. The general shape — a PR merged against a base it was never tested on — is what a branch-up-to-date requirement catches, but that is a settings decision and you have already made it.